### PR TITLE
Persist runtime params + UI Override/Reset + tests

### DIFF
--- a/NoesisNoema.xcodeproj/project.pbxproj
+++ b/NoesisNoema.xcodeproj/project.pbxproj
@@ -7,210 +7,212 @@
     objects = {
 
 /* Begin PBXBuildFile section */
-		F4021E4F2E3DC3A2007A4236 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = F4021E4E2E3DC3A2007A4236 /* ZIPFoundation */; };
-		F409DFD52E4F88020010AB03 /* NoesisNoema/Frameworks/llama_ios.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E52E4F41C400B6B88C /* NoesisNoema/Frameworks/llama_ios.xcframework */; };
-		F409DFD62E4F88020010AB03 /* NoesisNoema/Frameworks/llama_ios.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E52E4F41C400B6B88C /* NoesisNoema/Frameworks/llama_ios.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F41611E42E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E22E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework */; };
-		F41611E92E4F4F5800B6B88C /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E82E4F4F5800B6B88C /* MetalKit.framework */; };
-		F41FAA922E4F55510077738B /* NoesisNoema/Frameworks/llama_macos.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E22E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework */; };
-		F4C5811E2E4F036E00E64194 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C5811C2E4F036E00E64194 /* Metal.framework */; };
-		F4C581212E4F037500E64194 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C581202E4F037500E64194 /* Accelerate.framework */; };
-		F4C581532E4F12D700E64194 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C581202E4F037500E64194 /* Accelerate.framework */; };
-		F4C581542E4F12E000E64194 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C5811C2E4F036E00E64194 /* Metal.framework */; };
-		F4C581552E4F12E000E64194 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C5811D2E4F036E00E64194 /* MetalKit.framework */; };
-		F4C581602E4F13EC00E64194 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C581202E4F037500E64194 /* Accelerate.framework */; };
-		F4C581612E4F13EC00E64194 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C5811C2E4F036E00E64194 /* Metal.framework */; };
-		F4D1DB542E4F18ED006B902C /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = F4D1DB532E4F18ED006B902C /* ZIPFoundation */; };
+        F4021E4F2E3DC3A2007A4236 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = F4021E4E2E3DC3A2007A4236 /* ZIPFoundation */; };
+        F409DFD52E4F88020010AB03 /* NoesisNoema/Frameworks/llama_ios.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E52E4F41C400B6B88C /* NoesisNoema/Frameworks/llama_ios.xcframework */; };
+        F409DFD62E4F88020010AB03 /* NoesisNoema/Frameworks/llama_ios.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E52E4F41C400B6B88C /* NoesisNoema/Frameworks/llama_ios.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+        F41611E42E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E22E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework */; };
+        F41611E92E4F4F5800B6B88C /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E82E4F4F5800B6B88C /* MetalKit.framework */; };
+        F41FAA922E4F55510077738B /* NoesisNoema/Frameworks/llama_macos.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E22E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework */; };
+        F4C5811E2E4F036E00E64194 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C5811C2E4F036E00E64194 /* Metal.framework */; };
+        F4C581212E4F037500E64194 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C581202E4F037500E64194 /* Accelerate.framework */; };
+        F4C581532E4F12D700E64194 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C581202E4F037500E64194 /* Accelerate.framework */; };
+        F4C581542E4F12E000E64194 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C5811C2E4F036E00E64194 /* Metal.framework */; };
+        F4C581552E4F12E000E64194 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C5811D2E4F036E00E64194 /* MetalKit.framework */; };
+        F4C581602E4F13EC00E64194 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C581202E4F037500E64194 /* Accelerate.framework */; };
+        F4C581612E4F13EC00E64194 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C5811C2E4F036E00E64194 /* Metal.framework */; };
+        F4D1DB542E4F18ED006B902C /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = F4D1DB532E4F18ED006B902C /* ZIPFoundation */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		F4C581A12E4F900000E64194 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				F409DFD62E4F88020010AB03 /* NoesisNoema/Frameworks/llama_ios.xcframework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+        F4C581A12E4F900000E64194 /* Embed Frameworks */ = {
+            isa = PBXCopyFilesBuildPhase;
+            buildActionMask = 2147483647;
+            dstPath = "";
+            dstSubfolderSpec = 10;
+            files = (
+                F409DFD62E4F88020010AB03 /* NoesisNoema/Frameworks/llama_ios.xcframework in Embed Frameworks */,
+            );
+            name = "Embed Frameworks";
+            runOnlyForDeploymentPostprocessing = 0;
+        };
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		AACE160730FAA9CB4526C2D7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = file.md; path = README.md; sourceTree = "<group>"; };
-		F41611E22E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = NoesisNoema/Frameworks/llama_macos.xcframework; sourceTree = "<group>"; };
-		F41611E52E4F41C400B6B88C /* NoesisNoema/Frameworks/llama_ios.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = NoesisNoema/Frameworks/llama_ios.xcframework; sourceTree = "<group>"; };
-		F41611E82E4F4F5800B6B88C /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.5.sdk/System/Library/Frameworks/MetalKit.framework; sourceTree = DEVELOPER_DIR; };
-		F41DFFC82E30FCD40023545E /* llama.swiftui.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = llama.swiftui.xcodeproj; sourceTree = "<group>"; };
-		F41FD01B2E2A466F00909132 /* NoesisNoema.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NoesisNoema.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		F4605E302E2CAA5E00D4C555 /* llama.swiftui.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = llama.swiftui.xcodeproj; sourceTree = "<group>"; };
-		F4607E7A2E2CCDB900D4C555 /* llama.swiftui.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = llama.swiftui.xcodeproj; sourceTree = "<group>"; };
-		F46088492E2CD45000D4C555 /* LlamaBridgeTest */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = LlamaBridgeTest; sourceTree = BUILT_PRODUCTS_DIR; };
-		F4C580FD2E4F006000E64194 /* NoesisNoemaMobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NoesisNoemaMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		F4C5811C2E4F036E00E64194 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
-		F4C5811D2E4F036E00E64194 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
-		F4C581202E4F037500E64194 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
+        AACE160730FAA9CB4526C2D7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = file.md; path = README.md; sourceTree = "<group>"; };
+        F41611E22E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = NoesisNoema/Frameworks/llama_macos.xcframework; sourceTree = "<group>"; };
+        F41611E52E4F41C400B6B88C /* NoesisNoema/Frameworks/llama_ios.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = NoesisNoema/Frameworks/llama_ios.xcframework; sourceTree = "<group>"; };
+        F41611E82E4F4F5800B6B88C /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.5.sdk/System/Library/Frameworks/MetalKit.framework; sourceTree = DEVELOPER_DIR; };
+        F41DFFC82E30FCD40023545E /* llama.swiftui.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = llama.swiftui.xcodeproj; sourceTree = "<group>"; };
+        F41FD01B2E2A466F00909132 /* NoesisNoema.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NoesisNoema.app; sourceTree = BUILT_PRODUCTS_DIR; };
+        F4605E302E2CAA5E00D4C555 /* llama.swiftui.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = llama.swiftui.xcodeproj; sourceTree = "<group>"; };
+        F4607E7A2E2CCDB900D4C555 /* llama.swiftui.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = llama.swiftui.xcodeproj; sourceTree = "<group>"; };
+        F46088492E2CD45000D4C555 /* LlamaBridgeTest */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = LlamaBridgeTest; sourceTree = BUILT_PRODUCTS_DIR; };
+        F4C580FD2E4F006000E64194 /* NoesisNoemaMobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NoesisNoemaMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
+        F4C5811C2E4F036E00E64194 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
+        F4C5811D2E4F036E00E64194 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
+        F4C581202E4F037500E64194 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		F4C581272E4F06A100E64194 /* Exceptions for "NoesisNoema" folder in "NoesisNoemaMobile" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				Assets.xcassets,
-				Frameworks/llama_macos.xcframework,
-				"Resources/Models/gpt-oss-20b-Q4_K_S.gguf",
-				Shared/ContentView.swift,
-				Shared/NoesisNoemaApp.swift,
-			);
-			target = F4C580FC2E4F006000E64194 /* NoesisNoemaMobile */;
-		};
-		F4ED32C42E37A18400CCE0DE /* Exceptions for "NoesisNoema" folder in "LlamaBridgeTest" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				ModelRegistry/GGUFReader.swift,
-				ModelRegistry/HardwareProfile.swift,
-				ModelRegistry/ModelCLI.swift,
-				ModelRegistry/ModelRegistry.swift,
-				ModelRegistry/ModelSpec.swift,
-				ModelRegistry/RegistryJSON.swift,
-				ModelRegistry/TestRunner.swift,
-				"Resources/Models/gpt-oss-20b-Q4_K_S.gguf",
-				"Resources/Models/Jan-v1-4B-Q4_K_M.gguf",
-				"Resources/Models/llama3-8b.gguf",
-				Shared/LibLlama.swift,
-				Shared/LlamaRuntimeCheck.swift,
-				Shared/LlamaState.swift,
-				Shared/SystemLog.swift,
-			);
-			target = F46088482E2CD45000D4C555 /* LlamaBridgeTest */;
-		};
-		F4EEEAAA2E50099900E64194 /* Exceptions for "NoesisNoema" folder in "NoesisNoema" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				Frameworks/llama_ios.xcframework,
-			);
-			target = F41FD01A2E2A466F00909132 /* NoesisNoema */;
-		};
+        F4C581272E4F06A100E64194 /* Exceptions for "NoesisNoema" folder in "NoesisNoemaMobile" target */ = {
+            isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+            membershipExceptions = (
+                Assets.xcassets,
+                Frameworks/llama_macos.xcframework,
+                "Resources/Models/gpt-oss-20b-Q4_K_S.gguf",
+                Shared/ContentView.swift,
+                Shared/NoesisNoemaApp.swift,
+            );
+            target = F4C580FC2E4F006000E64194 /* NoesisNoemaMobile */;
+        };
+        F4ED32C42E37A18400CCE0DE /* Exceptions for "NoesisNoema" folder in "LlamaBridgeTest" target */ = {
+            isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+            membershipExceptions = (
+                ModelRegistry/GGUFReader.swift,
+                ModelRegistry/HardwareProfile.swift,
+                ModelRegistry/ModelCLI.swift,
+                ModelRegistry/ModelRegistry.swift,
+                ModelRegistry/ModelSpec.swift,
+                ModelRegistry/RegistryJSON.swift,
+                ModelRegistry/TestRunner.swift,
+                ModelRegistry/AutotuneService.swift,
+                ModelRegistry/RegistryPersistence.swift,
+                "Resources/Models/gpt-oss-20b-Q4_K_S.gguf",
+                "Resources/Models/Jan-v1-4B-Q4_K_M.gguf",
+                "Resources/Models/llama3-8b.gguf",
+                Shared/LibLlama.swift,
+                Shared/LlamaRuntimeCheck.swift,
+                Shared/LlamaState.swift,
+                Shared/SystemLog.swift,
+            );
+            target = F46088482E2CD45000D4C555 /* LlamaBridgeTest */;
+        };
+        F4EEEAAA2E50099900E64194 /* Exceptions for "NoesisNoema" folder in "NoesisNoema" target */ = {
+            isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+            membershipExceptions = (
+                Frameworks/llama_ios.xcframework,
+            );
+            target = F41FD01A2E2A466F00909132 /* NoesisNoema */;
+        };
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		F41FD01D2E2A466F00909132 /* NoesisNoema */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				F4EEEAAA2E50099900E64194 /* Exceptions for "NoesisNoema" folder in "NoesisNoema" target */,
-				F4ED32C42E37A18400CCE0DE /* Exceptions for "NoesisNoema" folder in "LlamaBridgeTest" target */,
-				F4C581272E4F06A100E64194 /* Exceptions for "NoesisNoema" folder in "NoesisNoemaMobile" target */,
-			);
-			path = NoesisNoema;
-			sourceTree = "<group>";
-		};
-		F460884A2E2CD45000D4C555 /* LlamaBridgeTest */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = LlamaBridgeTest;
-			sourceTree = "<group>";
-		};
-		F4C580FE2E4F006000E64194 /* NoesisNoemaMobile */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = NoesisNoemaMobile;
-			sourceTree = "<group>";
-		};
+        F41FD01D2E2A466F00909132 /* NoesisNoema */ = {
+            isa = PBXFileSystemSynchronizedRootGroup;
+            exceptions = (
+                F4EEEAAA2E50099900E64194 /* Exceptions for "NoesisNoema" folder in "NoesisNoema" target */,
+                F4ED32C42E37A18400CCE0DE /* Exceptions for "NoesisNoema" folder in "LlamaBridgeTest" target */,
+                F4C581272E4F06A100E64194 /* Exceptions for "NoesisNoema" folder in "NoesisNoemaMobile" target */,
+            );
+            path = NoesisNoema;
+            sourceTree = "<group>";
+        };
+        F460884A2E2CD45000D4C555 /* LlamaBridgeTest */ = {
+            isa = PBXFileSystemSynchronizedRootGroup;
+            path = LlamaBridgeTest;
+            sourceTree = "<group>";
+        };
+        F4C580FE2E4F006000E64194 /* NoesisNoemaMobile */ = {
+            isa = PBXFileSystemSynchronizedRootGroup;
+            path = NoesisNoemaMobile;
+            sourceTree = "<group>";
+        };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		F41FD0182E2A466F00909132 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F4C581542E4F12E000E64194 /* Metal.framework in Frameworks */,
-				F41611E42E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework in Frameworks */,
-				F4C581532E4F12D700E64194 /* Accelerate.framework in Frameworks */,
-				F4C581552E4F12E000E64194 /* MetalKit.framework in Frameworks */,
-				F4021E4F2E3DC3A2007A4236 /* ZIPFoundation in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F46088462E2CD45000D4C555 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F41611E92E4F4F5800B6B88C /* MetalKit.framework in Frameworks */,
-				F4C581602E4F13EC00E64194 /* Accelerate.framework in Frameworks */,
-				F4C581612E4F13EC00E64194 /* Metal.framework in Frameworks */,
-				F41FAA922E4F55510077738B /* NoesisNoema/Frameworks/llama_macos.xcframework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F4C580FA2E4F006000E64194 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F4C581212E4F037500E64194 /* Accelerate.framework in Frameworks */,
-				F409DFD52E4F88020010AB03 /* NoesisNoema/Frameworks/llama_ios.xcframework in Frameworks */,
-				F4C5811E2E4F036E00E64194 /* Metal.framework in Frameworks */,
-				F4D1DB542E4F18ED006B902C /* ZIPFoundation in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+        F41FD0182E2A466F00909132 /* Frameworks */ = {
+            isa = PBXFrameworksBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                F4C581542E4F12E000E64194 /* Metal.framework in Frameworks */,
+                F41611E42E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework in Frameworks */,
+                F4C581532E4F12D700E64194 /* Accelerate.framework in Frameworks */,
+                F4C581552E4F12E000E64194 /* MetalKit.framework in Frameworks */,
+                F4021E4F2E3DC3A2007A4236 /* ZIPFoundation in Frameworks */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        F46088462E2CD45000D4C555 /* Frameworks */ = {
+            isa = PBXFrameworksBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                F41611E92E4F4F5800B6B88C /* MetalKit.framework in Frameworks */,
+                F4C581602E4F13EC00E64194 /* Accelerate.framework in Frameworks */,
+                F4C581612E4F13EC00E64194 /* Metal.framework in Frameworks */,
+                F41FAA922E4F55510077738B /* NoesisNoema/Frameworks/llama_macos.xcframework in Frameworks */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        F4C580FA2E4F006000E64194 /* Frameworks */ = {
+            isa = PBXFrameworksBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                F4C581212E4F037500E64194 /* Accelerate.framework in Frameworks */,
+                F409DFD52E4F88020010AB03 /* NoesisNoema/Frameworks/llama_ios.xcframework in Frameworks */,
+                F4C5811E2E4F036E00E64194 /* Metal.framework in Frameworks */,
+                F4D1DB542E4F18ED006B902C /* ZIPFoundation in Frameworks */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		F408F3402E35C1C700F621C5 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				F41611E82E4F4F5800B6B88C /* MetalKit.framework */,
-				F41611E52E4F41C400B6B88C /* NoesisNoema/Frameworks/llama_ios.xcframework */,
-				F41611E22E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework */,
-				F4C581202E4F037500E64194 /* Accelerate.framework */,
-				F4C5811C2E4F036E00E64194 /* Metal.framework */,
-				F4C5811D2E4F036E00E64194 /* MetalKit.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		F41D04C72E30FCD40023545E /* Products */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		F41FD0122E2A466F00909132 = {
-			isa = PBXGroup;
-			children = (
-				F41FD01D2E2A466F00909132 /* NoesisNoema */,
-				F460884A2E2CD45000D4C555 /* LlamaBridgeTest */,
-				F4C580FE2E4F006000E64194 /* NoesisNoemaMobile */,
-				F41FD01C2E2A466F00909132 /* Products */,
-				F408F3402E35C1C700F621C5 /* Frameworks */,
-				AACE160730FAA9CB4526C2D7 /* README.md */,
-			);
-			sourceTree = "<group>";
-		};
-		F41FD01C2E2A466F00909132 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				F41FD01B2E2A466F00909132 /* NoesisNoema.app */,
-				F46088492E2CD45000D4C555 /* LlamaBridgeTest */,
-				F4C580FD2E4F006000E64194 /* NoesisNoemaMobile.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		F46060D62E2CAA5E00D4C555 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		F46083782E2CCDB900D4C555 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
+        F408F3402E35C1C700F621C5 /* Frameworks */ = {
+            isa = PBXGroup;
+            children = (
+                F41611E82E4F4F5800B6B88C /* MetalKit.framework */,
+                F41611E52E4F41C400B6B88C /* NoesisNoema/Frameworks/llama_ios.xcframework */,
+                F41611E22E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework */,
+                F4C581202E4F037500E64194 /* Accelerate.framework */,
+                F4C5811C2E4F036E00E64194 /* Metal.framework */,
+                F4C5811D2E4F036E00E64194 /* MetalKit.framework */,
+            );
+            name = Frameworks;
+            sourceTree = "<group>";
+        };
+        F41D04C72E30FCD40023545E /* Products */ = {
+            isa = PBXGroup;
+            children = (
+            );
+            name = Products;
+            sourceTree = "<group>";
+        };
+        F41FD0122E2A466F00909132 = {
+            isa = PBXGroup;
+            children = (
+                F41FD01D2E2A466F00909132 /* NoesisNoema */,
+                F460884A2E2CD45000D4C555 /* LlamaBridgeTest */,
+                F4C580FE2E4F006000E64194 /* NoesisNoemaMobile */,
+                F41FD01C2E2A466F00909132 /* Products */,
+                F408F3402E35C1C700F621C5 /* Frameworks */,
+                AACE160730FAA9CB4526C2D7 /* README.md */,
+            );
+            sourceTree = "<group>";
+        };
+        F41FD01C2E2A466F00909132 /* Products */ = {
+            isa = PBXGroup;
+            children = (
+                F41FD01B2E2A466F00909132 /* NoesisNoema.app */,
+                F46088492E2CD45000D4C555 /* LlamaBridgeTest */,
+                F4C580FD2E4F006000E64194 /* NoesisNoemaMobile.app */,
+            );
+            name = Products;
+            sourceTree = "<group>";
+        };
+        F46060D62E2CAA5E00D4C555 /* Products */ = {
+            isa = PBXGroup;
+            children = (
+            );
+            name = Products;
+            sourceTree = "<group>";
+        };
+        F46083782E2CCDB900D4C555 /* Products */ = {
+            isa = PBXGroup;
+            children = (
+            );
+            name = Products;
+            sourceTree = "<group>";
+        };
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -392,6 +394,8 @@
                 BBBB00112E50000000000001 /* LlamaState.swift in Sources */,
                 BBBB00122E50000000000001 /* LlamaRuntimeCheck.swift in Sources */,
                 BBBB00132E50000000000001 /* SystemLog.swift in Sources */,
+                BBBB00142E50000000000001 /* AutotuneService.swift in Sources */,
+                BBBB00152E50000000000001 /* RegistryPersistence.swift in Sources */,
             );
             runOnlyForDeploymentPostprocessing = 0;
         };
@@ -405,334 +409,334 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		F41FD0242E2A467000909132 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = 7NKX7G7LV3;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
-				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-			};
-			name = Debug;
-		};
-		F41FD0252E2A467000909132 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 7NKX7G7LV3;
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
-				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				MTL_FAST_MATH = YES;
-				SDKROOT = iphoneos;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		F41FD0272E2A467000909132 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7NKX7G7LV3;
-				ENABLE_PREVIEWS = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
-				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				LD_RUNPATH_SEARCH_PATHS = "";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.tokyoyanbanjin.noesisnoema.NoesisNoema;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				REGISTER_APP_GROUPS = YES;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		F41FD0282E2A467000909132 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7NKX7G7LV3;
-				ENABLE_PREVIEWS = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
-				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				LD_RUNPATH_SEARCH_PATHS = "";
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.tokyoyanbanjin.noesisnoema.NoesisNoema;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				REGISTER_APP_GROUPS = YES;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		F460884E2E2CD45000D4C555 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7NKX7G7LV3;
-				ENABLE_HARDENED_RUNTIME = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/Frameworks",
-					"$(PROJECT_DIR)/llama_macos.xcframework/macos-arm64_x86_64",
-				);
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@loader_path",
-					"@executable_path",
-					"@rpath",
-				);
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
-				MACOSX_DEPLOYMENT_TARGET = 15.5;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				REGISTER_APP_GROUPS = YES;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG BRIDGE_TEST";
-				SWIFT_OBJC_BRIDGING_HEADER = "";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 6;
-			};
-			name = Debug;
-		};
-		F460884F2E2CD45000D4C555 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7NKX7G7LV3;
-				ENABLE_HARDENED_RUNTIME = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/Frameworks",
-					"$(PROJECT_DIR)/llama_macos.xcframework/macos-arm64_x86_64",
-				);
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@loader_path",
-					"@executable_path",
-					"@rpath",
-				);
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
-				MACOSX_DEPLOYMENT_TARGET = 15.5;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				REGISTER_APP_GROUPS = YES;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = BRIDGE_TEST;
-				SWIFT_OBJC_BRIDGING_HEADER = "";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 6;
-			};
-			name = Release;
-		};
-		F4C581062E4F006800E64194 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7NKX7G7LV3;
-				ENABLE_PREVIEWS = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
-				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.tokyoyanbanjin.noesisnoema.NoesisNoemaMobile;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
-			};
-			name = Debug;
-		};
-		F4C581072E4F006800E64194 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7NKX7G7LV3;
-				ENABLE_PREVIEWS = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
-				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.tokyoyanbanjin.noesisnoema.NoesisNoemaMobile;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
-			};
-			name = Release;
-		};
+        F41FD0242E2A467000909132 /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ALWAYS_SEARCH_USER_PATHS = NO;
+                ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+                CLANG_ANALYZER_NONNULL = YES;
+                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+                CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+                CLANG_ENABLE_MODULES = YES;
+                CLANG_ENABLE_OBJC_ARC = YES;
+                CLANG_ENABLE_OBJC_WEAK = YES;
+                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+                CLANG_WARN_BOOL_CONVERSION = YES;
+                CLANG_WARN_COMMA = YES;
+                CLANG_WARN_CONSTANT_CONVERSION = YES;
+                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+                CLANG_WARN_EMPTY_BODY = YES;
+                CLANG_WARN_ENUM_CONVERSION = YES;
+                CLANG_WARN_INFINITE_RECURSION = YES;
+                CLANG_WARN_INT_CONVERSION = YES;
+                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+                CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+                CLANG_WARN_STRICT_PROTOTYPES = YES;
+                CLANG_WARN_SUSPICIOUS_MOVE = YES;
+                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+                CLANG_WARN_UNREACHABLE_CODE = YES;
+                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+                COPY_PHASE_STRIP = NO;
+                DEBUG_INFORMATION_FORMAT = dwarf;
+                DEVELOPMENT_TEAM = 7NKX7G7LV3;
+                ENABLE_STRICT_OBJC_MSGSEND = YES;
+                ENABLE_TESTABILITY = YES;
+                ENABLE_USER_SCRIPT_SANDBOXING = YES;
+                GCC_C_LANGUAGE_STANDARD = gnu17;
+                GCC_DYNAMIC_NO_PIC = NO;
+                GCC_NO_COMMON_BLOCKS = YES;
+                GCC_OPTIMIZATION_LEVEL = 0;
+                GCC_PREPROCESSOR_DEFINITIONS = (
+                    "DEBUG=1",
+                    "$(inherited)",
+                );
+                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+                GCC_WARN_UNDECLARED_SELECTOR = YES;
+                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+                GCC_WARN_UNUSED_FUNCTION = YES;
+                GCC_WARN_UNUSED_VARIABLE = YES;
+                IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+                LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+                MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+                MTL_FAST_MATH = YES;
+                ONLY_ACTIVE_ARCH = YES;
+                SDKROOT = iphoneos;
+                SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+                SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+            };
+            name = Debug;
+        };
+        F41FD0252E2A467000909132 /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ALWAYS_SEARCH_USER_PATHS = NO;
+                ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+                CLANG_ANALYZER_NONNULL = YES;
+                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+                CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+                CLANG_ENABLE_MODULES = YES;
+                CLANG_ENABLE_OBJC_ARC = YES;
+                CLANG_ENABLE_OBJC_WEAK = YES;
+                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+                CLANG_WARN_BOOL_CONVERSION = YES;
+                CLANG_WARN_COMMA = YES;
+                CLANG_WARN_CONSTANT_CONVERSION = YES;
+                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+                CLANG_WARN_EMPTY_BODY = YES;
+                CLANG_WARN_ENUM_CONVERSION = YES;
+                CLANG_WARN_INFINITE_RECURSION = YES;
+                CLANG_WARN_INT_CONVERSION = YES;
+                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+                CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+                CLANG_WARN_STRICT_PROTOTYPES = YES;
+                CLANG_WARN_SUSPICIOUS_MOVE = YES;
+                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+                CLANG_WARN_UNREACHABLE_CODE = YES;
+                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+                COPY_PHASE_STRIP = NO;
+                DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+                DEVELOPMENT_TEAM = 7NKX7G7LV3;
+                ENABLE_NS_ASSERTIONS = NO;
+                ENABLE_STRICT_OBJC_MSGSEND = YES;
+                ENABLE_USER_SCRIPT_SANDBOXING = YES;
+                GCC_C_LANGUAGE_STANDARD = gnu17;
+                GCC_NO_COMMON_BLOCKS = YES;
+                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+                GCC_WARN_UNDECLARED_SELECTOR = YES;
+                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+                GCC_WARN_UNUSED_FUNCTION = YES;
+                GCC_WARN_UNUSED_VARIABLE = YES;
+                IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+                LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+                MTL_ENABLE_DEBUG_INFO = NO;
+                MTL_FAST_MATH = YES;
+                SDKROOT = iphoneos;
+                SWIFT_COMPILATION_MODE = wholemodule;
+                VALIDATE_PRODUCT = YES;
+            };
+            name = Release;
+        };
+        F41FD0272E2A467000909132 /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+                CODE_SIGN_STYLE = Automatic;
+                CURRENT_PROJECT_VERSION = 1;
+                DEVELOPMENT_TEAM = 7NKX7G7LV3;
+                ENABLE_PREVIEWS = YES;
+                FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
+                GENERATE_INFOPLIST_FILE = YES;
+                HEADER_SEARCH_PATHS = "";
+                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+                INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                LD_RUNPATH_SEARCH_PATHS = "";
+                LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
+                MARKETING_VERSION = 1.0;
+                PRODUCT_BUNDLE_IDENTIFIER = com.tokyoyanbanjin.noesisnoema.NoesisNoema;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                REGISTER_APP_GROUPS = YES;
+                SDKROOT = macosx;
+                SUPPORTED_PLATFORMS = macosx;
+                SUPPORTS_MACCATALYST = NO;
+                SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+                SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+                SWIFT_EMIT_LOC_STRINGS = YES;
+                SWIFT_VERSION = 5.0;
+            };
+            name = Debug;
+        };
+        F41FD0282E2A467000909132 /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+                CODE_SIGN_STYLE = Automatic;
+                CURRENT_PROJECT_VERSION = 1;
+                DEVELOPMENT_TEAM = 7NKX7G7LV3;
+                ENABLE_PREVIEWS = YES;
+                FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
+                GENERATE_INFOPLIST_FILE = YES;
+                HEADER_SEARCH_PATHS = "";
+                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+                INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                LD_RUNPATH_SEARCH_PATHS = "";
+                LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
+                MARKETING_VERSION = 1.0;
+                PRODUCT_BUNDLE_IDENTIFIER = com.tokyoyanbanjin.noesisnoema.NoesisNoema;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                REGISTER_APP_GROUPS = YES;
+                SDKROOT = macosx;
+                SUPPORTED_PLATFORMS = macosx;
+                SUPPORTS_MACCATALYST = NO;
+                SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+                SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+                SWIFT_EMIT_LOC_STRINGS = YES;
+                SWIFT_VERSION = 5.0;
+            };
+            name = Release;
+        };
+        F460884E2E2CD45000D4C555 /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+                CLANG_ENABLE_MODULES = YES;
+                CODE_SIGN_STYLE = Automatic;
+                DEVELOPMENT_TEAM = 7NKX7G7LV3;
+                ENABLE_HARDENED_RUNTIME = NO;
+                FRAMEWORK_SEARCH_PATHS = (
+                    "$(PROJECT_DIR)/Frameworks",
+                    "$(PROJECT_DIR)/llama_macos.xcframework/macos-arm64_x86_64",
+                );
+                LD_RUNPATH_SEARCH_PATHS = (
+                    "$(inherited)",
+                    "@loader_path",
+                    "@executable_path",
+                    "@rpath",
+                );
+                LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
+                MACOSX_DEPLOYMENT_TARGET = 15.5;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                REGISTER_APP_GROUPS = YES;
+                SDKROOT = macosx;
+                SUPPORTED_PLATFORMS = macosx;
+                SUPPORTS_MACCATALYST = NO;
+                SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+                SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+                SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG BRIDGE_TEST";
+                SWIFT_OBJC_BRIDGING_HEADER = "";
+                SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+                SWIFT_VERSION = 5.0;
+                TARGETED_DEVICE_FAMILY = 6;
+            };
+            name = Debug;
+        };
+        F460884F2E2CD45000D4C555 /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+                CLANG_ENABLE_MODULES = YES;
+                CODE_SIGN_STYLE = Automatic;
+                DEVELOPMENT_TEAM = 7NKX7G7LV3;
+                ENABLE_HARDENED_RUNTIME = NO;
+                FRAMEWORK_SEARCH_PATHS = (
+                    "$(PROJECT_DIR)/Frameworks",
+                    "$(PROJECT_DIR)/llama_macos.xcframework/macos-arm64_x86_64",
+                );
+                LD_RUNPATH_SEARCH_PATHS = (
+                    "$(inherited)",
+                    "@loader_path",
+                    "@executable_path",
+                    "@rpath",
+                );
+                LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
+                MACOSX_DEPLOYMENT_TARGET = 15.5;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                REGISTER_APP_GROUPS = YES;
+                SDKROOT = macosx;
+                SUPPORTED_PLATFORMS = macosx;
+                SUPPORTS_MACCATALYST = NO;
+                SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+                SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+                SWIFT_ACTIVE_COMPILATION_CONDITIONS = BRIDGE_TEST;
+                SWIFT_OBJC_BRIDGING_HEADER = "";
+                SWIFT_VERSION = 5.0;
+                TARGETED_DEVICE_FAMILY = 6;
+            };
+            name = Release;
+        };
+        F4C581062E4F006800E64194 /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+                CODE_SIGN_STYLE = Automatic;
+                CURRENT_PROJECT_VERSION = 1;
+                DEVELOPMENT_TEAM = 7NKX7G7LV3;
+                ENABLE_PREVIEWS = YES;
+                FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
+                GENERATE_INFOPLIST_FILE = YES;
+                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+                INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                LD_RUNPATH_SEARCH_PATHS = (
+                    "$(inherited)",
+                    "@executable_path/Frameworks",
+                    "@loader_path/Frameworks",
+                );
+                LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
+                MARKETING_VERSION = 1.0;
+                OTHER_LDFLAGS = "";
+                PRODUCT_BUNDLE_IDENTIFIER = com.tokyoyanbanjin.noesisnoema.NoesisNoemaMobile;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+                SUPPORTS_MACCATALYST = NO;
+                SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+                SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+                SWIFT_EMIT_LOC_STRINGS = NO;
+                SWIFT_VERSION = 5.0;
+                TARGETED_DEVICE_FAMILY = 1;
+            };
+            name = Debug;
+        };
+        F4C581072E4F006800E64194 /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+                CODE_SIGN_STYLE = Automatic;
+                CURRENT_PROJECT_VERSION = 1;
+                DEVELOPMENT_TEAM = 7NKX7G7LV3;
+                ENABLE_PREVIEWS = YES;
+                FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
+                GENERATE_INFOPLIST_FILE = YES;
+                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+                INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+                LD_RUNPATH_SEARCH_PATHS = (
+                    "$(inherited)",
+                    "@executable_path/Frameworks",
+                    "@loader_path/Frameworks",
+                );
+                LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
+                MARKETING_VERSION = 1.0;
+                OTHER_LDFLAGS = "";
+                PRODUCT_BUNDLE_IDENTIFIER = com.tokyoyanbanjin.noesisnoema.NoesisNoemaMobile;
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+                SUPPORTS_MACCATALYST = NO;
+                SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+                SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+                SWIFT_EMIT_LOC_STRINGS = NO;
+                SWIFT_VERSION = 5.0;
+                TARGETED_DEVICE_FAMILY = 1;
+            };
+            name = Release;
+        };
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */

--- a/NoesisNoema.xcodeproj/project.pbxproj
+++ b/NoesisNoema.xcodeproj/project.pbxproj
@@ -1,806 +1,793 @@
 // !$*UTF8*$!
 {
-    archiveVersion = 1;
-    classes = {
-    };
-    objectVersion = 77;
-    objects = {
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
 
 /* Begin PBXBuildFile section */
-        F4021E4F2E3DC3A2007A4236 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = F4021E4E2E3DC3A2007A4236 /* ZIPFoundation */; };
-        F409DFD52E4F88020010AB03 /* NoesisNoema/Frameworks/llama_ios.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E52E4F41C400B6B88C /* NoesisNoema/Frameworks/llama_ios.xcframework */; };
-        F409DFD62E4F88020010AB03 /* NoesisNoema/Frameworks/llama_ios.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E52E4F41C400B6B88C /* NoesisNoema/Frameworks/llama_ios.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-        F41611E42E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E22E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework */; };
-        F41611E92E4F4F5800B6B88C /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E82E4F4F5800B6B88C /* MetalKit.framework */; };
-        F41FAA922E4F55510077738B /* NoesisNoema/Frameworks/llama_macos.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E22E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework */; };
-        F4C5811E2E4F036E00E64194 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C5811C2E4F036E00E64194 /* Metal.framework */; };
-        F4C581212E4F037500E64194 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C581202E4F037500E64194 /* Accelerate.framework */; };
-        F4C581532E4F12D700E64194 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C581202E4F037500E64194 /* Accelerate.framework */; };
-        F4C581542E4F12E000E64194 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C5811C2E4F036E00E64194 /* Metal.framework */; };
-        F4C581552E4F12E000E64194 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C5811D2E4F036E00E64194 /* MetalKit.framework */; };
-        F4C581602E4F13EC00E64194 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C581202E4F037500E64194 /* Accelerate.framework */; };
-        F4C581612E4F13EC00E64194 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C5811C2E4F036E00E64194 /* Metal.framework */; };
-        F4D1DB542E4F18ED006B902C /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = F4D1DB532E4F18ED006B902C /* ZIPFoundation */; };
+		F4021E4F2E3DC3A2007A4236 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = F4021E4E2E3DC3A2007A4236 /* ZIPFoundation */; };
+		F409DFD52E4F88020010AB03 /* NoesisNoema/Frameworks/llama_ios.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E52E4F41C400B6B88C /* NoesisNoema/Frameworks/llama_ios.xcframework */; };
+		F409DFD62E4F88020010AB03 /* NoesisNoema/Frameworks/llama_ios.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E52E4F41C400B6B88C /* NoesisNoema/Frameworks/llama_ios.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F41611E42E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E22E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework */; };
+		F41611E92E4F4F5800B6B88C /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E82E4F4F5800B6B88C /* MetalKit.framework */; };
+		F41FAA922E4F55510077738B /* NoesisNoema/Frameworks/llama_macos.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41611E22E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework */; };
+		F4C5811E2E4F036E00E64194 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C5811C2E4F036E00E64194 /* Metal.framework */; };
+		F4C581212E4F037500E64194 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C581202E4F037500E64194 /* Accelerate.framework */; };
+		F4C581532E4F12D700E64194 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C581202E4F037500E64194 /* Accelerate.framework */; };
+		F4C581542E4F12E000E64194 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C5811C2E4F036E00E64194 /* Metal.framework */; };
+		F4C581552E4F12E000E64194 /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C5811D2E4F036E00E64194 /* MetalKit.framework */; };
+		F4C581602E4F13EC00E64194 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C581202E4F037500E64194 /* Accelerate.framework */; };
+		F4C581612E4F13EC00E64194 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4C5811C2E4F036E00E64194 /* Metal.framework */; };
+		F4D1DB542E4F18ED006B902C /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = F4D1DB532E4F18ED006B902C /* ZIPFoundation */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-        F4C581A12E4F900000E64194 /* Embed Frameworks */ = {
-            isa = PBXCopyFilesBuildPhase;
-            buildActionMask = 2147483647;
-            dstPath = "";
-            dstSubfolderSpec = 10;
-            files = (
-                F409DFD62E4F88020010AB03 /* NoesisNoema/Frameworks/llama_ios.xcframework in Embed Frameworks */,
-            );
-            name = "Embed Frameworks";
-            runOnlyForDeploymentPostprocessing = 0;
-        };
+		F4C581A12E4F900000E64194 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				F409DFD62E4F88020010AB03 /* NoesisNoema/Frameworks/llama_ios.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-        AACE160730FAA9CB4526C2D7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = file.md; path = README.md; sourceTree = "<group>"; };
-        F41611E22E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = NoesisNoema/Frameworks/llama_macos.xcframework; sourceTree = "<group>"; };
-        F41611E52E4F41C400B6B88C /* NoesisNoema/Frameworks/llama_ios.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = NoesisNoema/Frameworks/llama_ios.xcframework; sourceTree = "<group>"; };
-        F41611E82E4F4F5800B6B88C /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.5.sdk/System/Library/Frameworks/MetalKit.framework; sourceTree = DEVELOPER_DIR; };
-        F41DFFC82E30FCD40023545E /* llama.swiftui.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = llama.swiftui.xcodeproj; sourceTree = "<group>"; };
-        F41FD01B2E2A466F00909132 /* NoesisNoema.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NoesisNoema.app; sourceTree = BUILT_PRODUCTS_DIR; };
-        F4605E302E2CAA5E00D4C555 /* llama.swiftui.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = llama.swiftui.xcodeproj; sourceTree = "<group>"; };
-        F4607E7A2E2CCDB900D4C555 /* llama.swiftui.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = llama.swiftui.xcodeproj; sourceTree = "<group>"; };
-        F46088492E2CD45000D4C555 /* LlamaBridgeTest */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = LlamaBridgeTest; sourceTree = BUILT_PRODUCTS_DIR; };
-        F4C580FD2E4F006000E64194 /* NoesisNoemaMobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NoesisNoemaMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
-        F4C5811C2E4F036E00E64194 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
-        F4C5811D2E4F036E00E64194 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
-        F4C581202E4F037500E64194 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
+		AACE160730FAA9CB4526C2D7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = file.md; path = README.md; sourceTree = "<group>"; };
+		F41611E22E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = NoesisNoema/Frameworks/llama_macos.xcframework; sourceTree = "<group>"; };
+		F41611E52E4F41C400B6B88C /* NoesisNoema/Frameworks/llama_ios.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = NoesisNoema/Frameworks/llama_ios.xcframework; sourceTree = "<group>"; };
+		F41611E82E4F4F5800B6B88C /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.5.sdk/System/Library/Frameworks/MetalKit.framework; sourceTree = DEVELOPER_DIR; };
+		F41DFFC82E30FCD40023545E /* llama.swiftui.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = llama.swiftui.xcodeproj; sourceTree = "<group>"; };
+		F41FD01B2E2A466F00909132 /* NoesisNoema.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NoesisNoema.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4605E302E2CAA5E00D4C555 /* llama.swiftui.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = llama.swiftui.xcodeproj; sourceTree = "<group>"; };
+		F4607E7A2E2CCDB900D4C555 /* llama.swiftui.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = llama.swiftui.xcodeproj; sourceTree = "<group>"; };
+		F46088492E2CD45000D4C555 /* LlamaBridgeTest */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = LlamaBridgeTest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4C580FD2E4F006000E64194 /* NoesisNoemaMobile.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NoesisNoemaMobile.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4C5811C2E4F036E00E64194 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
+		F4C5811D2E4F036E00E64194 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
+		F4C581202E4F037500E64194 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-        F4C581272E4F06A100E64194 /* Exceptions for "NoesisNoema" folder in "NoesisNoemaMobile" target */ = {
-            isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-            membershipExceptions = (
-                Assets.xcassets,
-                Frameworks/llama_macos.xcframework,
-                "Resources/Models/gpt-oss-20b-Q4_K_S.gguf",
-                Shared/ContentView.swift,
-                Shared/NoesisNoemaApp.swift,
-            );
-            target = F4C580FC2E4F006000E64194 /* NoesisNoemaMobile */;
-        };
-        F4ED32C42E37A18400CCE0DE /* Exceptions for "NoesisNoema" folder in "LlamaBridgeTest" target */ = {
-            isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-            membershipExceptions = (
-                ModelRegistry/GGUFReader.swift,
-                ModelRegistry/HardwareProfile.swift,
-                ModelRegistry/ModelCLI.swift,
-                ModelRegistry/ModelRegistry.swift,
-                ModelRegistry/ModelSpec.swift,
-                ModelRegistry/RegistryJSON.swift,
-                ModelRegistry/TestRunner.swift,
-                ModelRegistry/AutotuneService.swift,
-                ModelRegistry/RegistryPersistence.swift,
-                "Resources/Models/gpt-oss-20b-Q4_K_S.gguf",
-                "Resources/Models/Jan-v1-4B-Q4_K_M.gguf",
-                "Resources/Models/llama3-8b.gguf",
-                Shared/LibLlama.swift,
-                Shared/LlamaRuntimeCheck.swift,
-                Shared/LlamaState.swift,
-                Shared/SystemLog.swift,
-            );
-            target = F46088482E2CD45000D4C555 /* LlamaBridgeTest */;
-        };
-        F4EEEAAA2E50099900E64194 /* Exceptions for "NoesisNoema" folder in "NoesisNoema" target */ = {
-            isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-            membershipExceptions = (
-                Frameworks/llama_ios.xcframework,
-            );
-            target = F41FD01A2E2A466F00909132 /* NoesisNoema */;
-        };
+		F4C581272E4F06A100E64194 /* Exceptions for "NoesisNoema" folder in "NoesisNoemaMobile" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Assets.xcassets,
+				Frameworks/llama_macos.xcframework,
+				"Resources/Models/gpt-oss-20b-Q4_K_S.gguf",
+				"Resources/Models/llama3-8b.gguf",
+				Shared/ContentView.swift,
+				Shared/NoesisNoemaApp.swift,
+			);
+			target = F4C580FC2E4F006000E64194 /* NoesisNoemaMobile */;
+		};
+		F4ED32C42E37A18400CCE0DE /* Exceptions for "NoesisNoema" folder in "LlamaBridgeTest" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				ModelRegistry/AutotuneService.swift,
+				ModelRegistry/GGUFReader.swift,
+				ModelRegistry/HardwareProfile.swift,
+				ModelRegistry/ModelCLI.swift,
+				ModelRegistry/ModelRegistry.swift,
+				ModelRegistry/ModelSpec.swift,
+				ModelRegistry/RegistryJSON.swift,
+				ModelRegistry/RegistryPersistence.swift,
+				ModelRegistry/TestRunner.swift,
+				"Resources/Models/gpt-oss-20b-Q4_K_S.gguf",
+				"Resources/Models/Jan-v1-4B-Q4_K_M.gguf",
+				"Resources/Models/llama3-8b.gguf",
+				Shared/LibLlama.swift,
+				Shared/LlamaRuntimeCheck.swift,
+				Shared/LlamaState.swift,
+				Shared/SystemLog.swift,
+			);
+			target = F46088482E2CD45000D4C555 /* LlamaBridgeTest */;
+		};
+		F4EEEAAA2E50099900E64194 /* Exceptions for "NoesisNoema" folder in "NoesisNoema" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Frameworks/llama_ios.xcframework,
+			);
+			target = F41FD01A2E2A466F00909132 /* NoesisNoema */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-        F41FD01D2E2A466F00909132 /* NoesisNoema */ = {
-            isa = PBXFileSystemSynchronizedRootGroup;
-            exceptions = (
-                F4EEEAAA2E50099900E64194 /* Exceptions for "NoesisNoema" folder in "NoesisNoema" target */,
-                F4ED32C42E37A18400CCE0DE /* Exceptions for "NoesisNoema" folder in "LlamaBridgeTest" target */,
-                F4C581272E4F06A100E64194 /* Exceptions for "NoesisNoema" folder in "NoesisNoemaMobile" target */,
-            );
-            path = NoesisNoema;
-            sourceTree = "<group>";
-        };
-        F460884A2E2CD45000D4C555 /* LlamaBridgeTest */ = {
-            isa = PBXFileSystemSynchronizedRootGroup;
-            path = LlamaBridgeTest;
-            sourceTree = "<group>";
-        };
-        F4C580FE2E4F006000E64194 /* NoesisNoemaMobile */ = {
-            isa = PBXFileSystemSynchronizedRootGroup;
-            path = NoesisNoemaMobile;
-            sourceTree = "<group>";
-        };
+		F41FD01D2E2A466F00909132 /* NoesisNoema */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				F4EEEAAA2E50099900E64194 /* Exceptions for "NoesisNoema" folder in "NoesisNoema" target */,
+				F4ED32C42E37A18400CCE0DE /* Exceptions for "NoesisNoema" folder in "LlamaBridgeTest" target */,
+				F4C581272E4F06A100E64194 /* Exceptions for "NoesisNoema" folder in "NoesisNoemaMobile" target */,
+			);
+			path = NoesisNoema;
+			sourceTree = "<group>";
+		};
+		F460884A2E2CD45000D4C555 /* LlamaBridgeTest */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = LlamaBridgeTest;
+			sourceTree = "<group>";
+		};
+		F4C580FE2E4F006000E64194 /* NoesisNoemaMobile */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = NoesisNoemaMobile;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-        F41FD0182E2A466F00909132 /* Frameworks */ = {
-            isa = PBXFrameworksBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-                F4C581542E4F12E000E64194 /* Metal.framework in Frameworks */,
-                F41611E42E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework in Frameworks */,
-                F4C581532E4F12D700E64194 /* Accelerate.framework in Frameworks */,
-                F4C581552E4F12E000E64194 /* MetalKit.framework in Frameworks */,
-                F4021E4F2E3DC3A2007A4236 /* ZIPFoundation in Frameworks */,
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
-        F46088462E2CD45000D4C555 /* Frameworks */ = {
-            isa = PBXFrameworksBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-                F41611E92E4F4F5800B6B88C /* MetalKit.framework in Frameworks */,
-                F4C581602E4F13EC00E64194 /* Accelerate.framework in Frameworks */,
-                F4C581612E4F13EC00E64194 /* Metal.framework in Frameworks */,
-                F41FAA922E4F55510077738B /* NoesisNoema/Frameworks/llama_macos.xcframework in Frameworks */,
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
-        F4C580FA2E4F006000E64194 /* Frameworks */ = {
-            isa = PBXFrameworksBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-                F4C581212E4F037500E64194 /* Accelerate.framework in Frameworks */,
-                F409DFD52E4F88020010AB03 /* NoesisNoema/Frameworks/llama_ios.xcframework in Frameworks */,
-                F4C5811E2E4F036E00E64194 /* Metal.framework in Frameworks */,
-                F4D1DB542E4F18ED006B902C /* ZIPFoundation in Frameworks */,
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
+		F41FD0182E2A466F00909132 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F4C581542E4F12E000E64194 /* Metal.framework in Frameworks */,
+				F41611E42E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework in Frameworks */,
+				F4C581532E4F12D700E64194 /* Accelerate.framework in Frameworks */,
+				F4C581552E4F12E000E64194 /* MetalKit.framework in Frameworks */,
+				F4021E4F2E3DC3A2007A4236 /* ZIPFoundation in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F46088462E2CD45000D4C555 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F41611E92E4F4F5800B6B88C /* MetalKit.framework in Frameworks */,
+				F4C581602E4F13EC00E64194 /* Accelerate.framework in Frameworks */,
+				F4C581612E4F13EC00E64194 /* Metal.framework in Frameworks */,
+				F41FAA922E4F55510077738B /* NoesisNoema/Frameworks/llama_macos.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F4C580FA2E4F006000E64194 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F4C581212E4F037500E64194 /* Accelerate.framework in Frameworks */,
+				F409DFD52E4F88020010AB03 /* NoesisNoema/Frameworks/llama_ios.xcframework in Frameworks */,
+				F4C5811E2E4F036E00E64194 /* Metal.framework in Frameworks */,
+				F4D1DB542E4F18ED006B902C /* ZIPFoundation in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-        F408F3402E35C1C700F621C5 /* Frameworks */ = {
-            isa = PBXGroup;
-            children = (
-                F41611E82E4F4F5800B6B88C /* MetalKit.framework */,
-                F41611E52E4F41C400B6B88C /* NoesisNoema/Frameworks/llama_ios.xcframework */,
-                F41611E22E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework */,
-                F4C581202E4F037500E64194 /* Accelerate.framework */,
-                F4C5811C2E4F036E00E64194 /* Metal.framework */,
-                F4C5811D2E4F036E00E64194 /* MetalKit.framework */,
-            );
-            name = Frameworks;
-            sourceTree = "<group>";
-        };
-        F41D04C72E30FCD40023545E /* Products */ = {
-            isa = PBXGroup;
-            children = (
-            );
-            name = Products;
-            sourceTree = "<group>";
-        };
-        F41FD0122E2A466F00909132 = {
-            isa = PBXGroup;
-            children = (
-                F41FD01D2E2A466F00909132 /* NoesisNoema */,
-                F460884A2E2CD45000D4C555 /* LlamaBridgeTest */,
-                F4C580FE2E4F006000E64194 /* NoesisNoemaMobile */,
-                F41FD01C2E2A466F00909132 /* Products */,
-                F408F3402E35C1C700F621C5 /* Frameworks */,
-                AACE160730FAA9CB4526C2D7 /* README.md */,
-            );
-            sourceTree = "<group>";
-        };
-        F41FD01C2E2A466F00909132 /* Products */ = {
-            isa = PBXGroup;
-            children = (
-                F41FD01B2E2A466F00909132 /* NoesisNoema.app */,
-                F46088492E2CD45000D4C555 /* LlamaBridgeTest */,
-                F4C580FD2E4F006000E64194 /* NoesisNoemaMobile.app */,
-            );
-            name = Products;
-            sourceTree = "<group>";
-        };
-        F46060D62E2CAA5E00D4C555 /* Products */ = {
-            isa = PBXGroup;
-            children = (
-            );
-            name = Products;
-            sourceTree = "<group>";
-        };
-        F46083782E2CCDB900D4C555 /* Products */ = {
-            isa = PBXGroup;
-            children = (
-            );
-            name = Products;
-            sourceTree = "<group>";
-        };
+		F408F3402E35C1C700F621C5 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				F41611E82E4F4F5800B6B88C /* MetalKit.framework */,
+				F41611E52E4F41C400B6B88C /* NoesisNoema/Frameworks/llama_ios.xcframework */,
+				F41611E22E4F41B800B6B88C /* NoesisNoema/Frameworks/llama_macos.xcframework */,
+				F4C581202E4F037500E64194 /* Accelerate.framework */,
+				F4C5811C2E4F036E00E64194 /* Metal.framework */,
+				F4C5811D2E4F036E00E64194 /* MetalKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F41D04C72E30FCD40023545E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F41FD0122E2A466F00909132 = {
+			isa = PBXGroup;
+			children = (
+				F41FD01D2E2A466F00909132 /* NoesisNoema */,
+				F460884A2E2CD45000D4C555 /* LlamaBridgeTest */,
+				F4C580FE2E4F006000E64194 /* NoesisNoemaMobile */,
+				F41FD01C2E2A466F00909132 /* Products */,
+				F408F3402E35C1C700F621C5 /* Frameworks */,
+				AACE160730FAA9CB4526C2D7 /* README.md */,
+			);
+			sourceTree = "<group>";
+		};
+		F41FD01C2E2A466F00909132 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F41FD01B2E2A466F00909132 /* NoesisNoema.app */,
+				F46088492E2CD45000D4C555 /* LlamaBridgeTest */,
+				F4C580FD2E4F006000E64194 /* NoesisNoemaMobile.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F46060D62E2CAA5E00D4C555 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F46083782E2CCDB900D4C555 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-        F41FD01A2E2A466F00909132 /* NoesisNoema */ = {
-            isa = PBXNativeTarget;
-            buildConfigurationList = F41FD0262E2A467000909132 /* Build configuration list for PBXNativeTarget "NoesisNoema" */;
-            buildPhases = (
-                F41FD0172E2A466F00909132 /* Sources */,
-                F41FD0182E2A466F00909132 /* Frameworks */,
-                F41FD0192E2A466F00909132 /* Resources */,
-            );
-            buildRules = (
-            );
-            dependencies = (
-            );
-            fileSystemSynchronizedGroups = (
-                F41FD01D2E2A466F00909132 /* NoesisNoema */,
-            );
-            name = NoesisNoema;
-            packageProductDependencies = (
-                F4021E4E2E3DC3A2007A4236 /* ZIPFoundation */,
-            );
-            productName = NoesisNoema;
-            productReference = F41FD01B2E2A466F00909132 /* NoesisNoema.app */;
-            productType = "com.apple.product-type.application";
-        };
-        F46088482E2CD45000D4C555 /* LlamaBridgeTest */ = {
-            isa = PBXNativeTarget;
-            buildConfigurationList = F460884D2E2CD45000D4C555 /* Build configuration list for PBXNativeTarget "LlamaBridgeTest" */;
-            buildPhases = (
-                F46088452E2CD45000D4C555 /* Sources */,
-                F46088462E2CD45000D4C555 /* Frameworks */,
-                F4F7BAB72E37A7A40018DE75 /* Resources */,
-            );
-            buildRules = (
-            );
-            dependencies = (
-            );
-            fileSystemSynchronizedGroups = (
-                F460884A2E2CD45000D4C555 /* LlamaBridgeTest */,
-                // Removed NoesisNoema root sync to avoid pulling UI/ZIPFoundation sources
-            );
-            name = LlamaBridgeTest;
-            packageProductDependencies = (
-            );
-            productName = LlamaBridgeTest;
-            productReference = F46088492E2CD45000D4C555 /* LlamaBridgeTest */;
-            productType = "com.apple.product-type.tool";
-        };
-        F4C580FC2E4F006000E64194 /* NoesisNoemaMobile */ = {
-            isa = PBXNativeTarget;
-            buildConfigurationList = F4C581052E4F006800E64194 /* Build configuration list for PBXNativeTarget "NoesisNoemaMobile" */;
-            buildPhases = (
-                F4C580F92E4F006000E64194 /* Sources */,
-                F4C580FA2E4F006000E64194 /* Frameworks */,
-                F4C580FB2E4F006000E64194 /* Resources */,
-                F4C581A12E4F900000E64194 /* Embed Frameworks */,
-            );
-            buildRules = (
-            );
-            dependencies = (
-            );
-            fileSystemSynchronizedGroups = (
-                F41FD01D2E2A466F00909132 /* NoesisNoema */,
-                F4C580FE2E4F006000E64194 /* NoesisNoemaMobile */,
-            );
-            name = NoesisNoemaMobile;
-            packageProductDependencies = (
-                F4D1DB532E4F18ED006B902C /* ZIPFoundation */,
-            );
-            productName = NoesisNoemaMobile;
-            productReference = F4C580FD2E4F006000E64194 /* NoesisNoemaMobile.app */;
-            productType = "com.apple.product-type.application";
-        };
+		F41FD01A2E2A466F00909132 /* NoesisNoema */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F41FD0262E2A467000909132 /* Build configuration list for PBXNativeTarget "NoesisNoema" */;
+			buildPhases = (
+				F41FD0172E2A466F00909132 /* Sources */,
+				F41FD0182E2A466F00909132 /* Frameworks */,
+				F41FD0192E2A466F00909132 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				F41FD01D2E2A466F00909132 /* NoesisNoema */,
+			);
+			name = NoesisNoema;
+			packageProductDependencies = (
+				F4021E4E2E3DC3A2007A4236 /* ZIPFoundation */,
+			);
+			productName = NoesisNoema;
+			productReference = F41FD01B2E2A466F00909132 /* NoesisNoema.app */;
+			productType = "com.apple.product-type.application";
+		};
+		F46088482E2CD45000D4C555 /* LlamaBridgeTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F460884D2E2CD45000D4C555 /* Build configuration list for PBXNativeTarget "LlamaBridgeTest" */;
+			buildPhases = (
+				F46088452E2CD45000D4C555 /* Sources */,
+				F46088462E2CD45000D4C555 /* Frameworks */,
+				F4F7BAB72E37A7A40018DE75 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				F460884A2E2CD45000D4C555 /* LlamaBridgeTest */,
+			);
+			name = LlamaBridgeTest;
+			packageProductDependencies = (
+			);
+			productName = LlamaBridgeTest;
+			productReference = F46088492E2CD45000D4C555 /* LlamaBridgeTest */;
+			productType = "com.apple.product-type.tool";
+		};
+		F4C580FC2E4F006000E64194 /* NoesisNoemaMobile */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F4C581052E4F006800E64194 /* Build configuration list for PBXNativeTarget "NoesisNoemaMobile" */;
+			buildPhases = (
+				F4C580F92E4F006000E64194 /* Sources */,
+				F4C580FA2E4F006000E64194 /* Frameworks */,
+				F4C580FB2E4F006000E64194 /* Resources */,
+				F4C581A12E4F900000E64194 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				F41FD01D2E2A466F00909132 /* NoesisNoema */,
+				F4C580FE2E4F006000E64194 /* NoesisNoemaMobile */,
+			);
+			name = NoesisNoemaMobile;
+			packageProductDependencies = (
+				F4D1DB532E4F18ED006B902C /* ZIPFoundation */,
+			);
+			productName = NoesisNoemaMobile;
+			productReference = F4C580FD2E4F006000E64194 /* NoesisNoemaMobile.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-        F41FD0132E2A466F00909132 /* Project object */ = {
-            isa = PBXProject;
-            attributes = {
-                BuildIndependentTargetsInParallel = 1;
-                LastSwiftUpdateCheck = 1640;
-                LastUpgradeCheck = 1640;
-                TargetAttributes = {
-                    F41FD01A2E2A466F00909132 = {
-                        CreatedOnToolsVersion = 16.4;
-                    };
-                    F46088482E2CD45000D4C555 = {
-                        CreatedOnToolsVersion = 16.4;
-                        LastSwiftMigration = 1640;
-                    };
-                    F4C580FC2E4F006000E64194 = {
-                        CreatedOnToolsVersion = 16.4;
-                    };
-                };
-            };
-            buildConfigurationList = F41FD0162E2A466F00909132 /* Build configuration list for PBXProject "NoesisNoema" */;
-            developmentRegion = en;
-            hasScannedForEncodings = 0;
-            knownRegions = (
-                en,
-                Base,
-            );
-            mainGroup = F41FD0122E2A466F00909132;
-            minimizedProjectReferenceProxies = 1;
-            packageReferences = (
-                F4021E4D2E3DC3A2007A4236 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
-            );
-            preferredProjectObjectVersion = 77;
-            productRefGroup = F41FD01C2E2A466F00909132 /* Products */;
-            projectDirPath = "";
-            projectReferences = (
-                {
-                    ProductGroup = F46083782E2CCDB900D4C555 /* Products */;
-                    ProjectRef = F4607E7A2E2CCDB900D4C555 /* llama.swiftui.xcodeproj */;
-                },
-                {
-                    ProductGroup = F46060D62E2CAA5E00D4C555 /* Products */;
-                    ProjectRef = F4605E302E2CAA5E00D4C555 /* llama.swiftui.xcodeproj */;
-                },
-                {
-                    ProductGroup = F41D04C72E30FCD40023545E /* Products */;
-                    ProjectRef = F41DFFC82E30FCD40023545E /* llama.swiftui.xcodeproj */;
-                },
-            );
-            projectRoot = "";
-            targets = (
-                F41FD01A2E2A466F00909132 /* NoesisNoema */,
-                F46088482E2CD45000D4C555 /* LlamaBridgeTest */,
-                F4C580FC2E4F006000E64194 /* NoesisNoemaMobile */,
-            );
-        };
+		F41FD0132E2A466F00909132 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1640;
+				LastUpgradeCheck = 1640;
+				TargetAttributes = {
+					F41FD01A2E2A466F00909132 = {
+						CreatedOnToolsVersion = 16.4;
+					};
+					F46088482E2CD45000D4C555 = {
+						CreatedOnToolsVersion = 16.4;
+						LastSwiftMigration = 1640;
+					};
+					F4C580FC2E4F006000E64194 = {
+						CreatedOnToolsVersion = 16.4;
+					};
+				};
+			};
+			buildConfigurationList = F41FD0162E2A466F00909132 /* Build configuration list for PBXProject "NoesisNoema" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = F41FD0122E2A466F00909132;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				F4021E4D2E3DC3A2007A4236 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = F41FD01C2E2A466F00909132 /* Products */;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = F46083782E2CCDB900D4C555 /* Products */;
+					ProjectRef = F4607E7A2E2CCDB900D4C555 /* llama.swiftui.xcodeproj */;
+				},
+				{
+					ProductGroup = F46060D62E2CAA5E00D4C555 /* Products */;
+					ProjectRef = F4605E302E2CAA5E00D4C555 /* llama.swiftui.xcodeproj */;
+				},
+				{
+					ProductGroup = F41D04C72E30FCD40023545E /* Products */;
+					ProjectRef = F41DFFC82E30FCD40023545E /* llama.swiftui.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				F41FD01A2E2A466F00909132 /* NoesisNoema */,
+				F46088482E2CD45000D4C555 /* LlamaBridgeTest */,
+				F4C580FC2E4F006000E64194 /* NoesisNoemaMobile */,
+			);
+		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-        F41FD0192E2A466F00909132 /* Resources */ = {
-            isa = PBXResourcesBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
-        F4C580FB2E4F006000E64194 /* Resources */ = {
-            isa = PBXResourcesBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
-        F4F7BAB72E37A7A40018DE75 /* Resources */ = {
-            isa = PBXResourcesBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
+		F41FD0192E2A466F00909132 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F4C580FB2E4F006000E64194 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F4F7BAB72E37A7A40018DE75 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-        F41FD0172E2A466F00909132 /* Sources */ = {
-            isa = PBXSourcesBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
-        F46088452E2CD45000D4C555 /* Sources */ = {
-            isa = PBXSourcesBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-                BBBB00012E50000000000001 /* ModelCLI.swift in Sources */,
-                BBBB00022E50000000000001 /* TestRunner.swift in Sources */,
-                BBBB00032E50000000000001 /* ModelRegistry.swift in Sources */,
-                BBBB00042E50000000000001 /* ModelSpec.swift in Sources */,
-                BBBB00052E50000000000001 /* GGUFReader.swift in Sources */,
-                BBBB00062E50000000000001 /* RegistryJSON.swift in Sources */,
-                BBBB00072E50000000000001 /* HardwareProfile.swift in Sources */,
-                BBBB00102E50000000000001 /* LibLlama.swift in Sources */,
-                BBBB00112E50000000000001 /* LlamaState.swift in Sources */,
-                BBBB00122E50000000000001 /* LlamaRuntimeCheck.swift in Sources */,
-                BBBB00132E50000000000001 /* SystemLog.swift in Sources */,
-                BBBB00142E50000000000001 /* AutotuneService.swift in Sources */,
-                BBBB00152E50000000000001 /* RegistryPersistence.swift in Sources */,
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
-        F4C580F92E4F006000E64194 /* Sources */ = {
-            isa = PBXSourcesBuildPhase;
-            buildActionMask = 2147483647;
-            files = (
-            );
-            runOnlyForDeploymentPostprocessing = 0;
-        };
+		F41FD0172E2A466F00909132 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F46088452E2CD45000D4C555 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F4C580F92E4F006000E64194 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-        F41FD0242E2A467000909132 /* Debug */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ALWAYS_SEARCH_USER_PATHS = NO;
-                ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
-                CLANG_ANALYZER_NONNULL = YES;
-                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-                CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-                CLANG_ENABLE_MODULES = YES;
-                CLANG_ENABLE_OBJC_ARC = YES;
-                CLANG_ENABLE_OBJC_WEAK = YES;
-                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-                CLANG_WARN_BOOL_CONVERSION = YES;
-                CLANG_WARN_COMMA = YES;
-                CLANG_WARN_CONSTANT_CONVERSION = YES;
-                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-                CLANG_WARN_EMPTY_BODY = YES;
-                CLANG_WARN_ENUM_CONVERSION = YES;
-                CLANG_WARN_INFINITE_RECURSION = YES;
-                CLANG_WARN_INT_CONVERSION = YES;
-                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-                CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-                CLANG_WARN_STRICT_PROTOTYPES = YES;
-                CLANG_WARN_SUSPICIOUS_MOVE = YES;
-                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-                CLANG_WARN_UNREACHABLE_CODE = YES;
-                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-                COPY_PHASE_STRIP = NO;
-                DEBUG_INFORMATION_FORMAT = dwarf;
-                DEVELOPMENT_TEAM = 7NKX7G7LV3;
-                ENABLE_STRICT_OBJC_MSGSEND = YES;
-                ENABLE_TESTABILITY = YES;
-                ENABLE_USER_SCRIPT_SANDBOXING = YES;
-                GCC_C_LANGUAGE_STANDARD = gnu17;
-                GCC_DYNAMIC_NO_PIC = NO;
-                GCC_NO_COMMON_BLOCKS = YES;
-                GCC_OPTIMIZATION_LEVEL = 0;
-                GCC_PREPROCESSOR_DEFINITIONS = (
-                    "DEBUG=1",
-                    "$(inherited)",
-                );
-                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-                GCC_WARN_UNDECLARED_SELECTOR = YES;
-                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-                GCC_WARN_UNUSED_FUNCTION = YES;
-                GCC_WARN_UNUSED_VARIABLE = YES;
-                IPHONEOS_DEPLOYMENT_TARGET = 18.5;
-                LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-                MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-                MTL_FAST_MATH = YES;
-                ONLY_ACTIVE_ARCH = YES;
-                SDKROOT = iphoneos;
-                SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
-                SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-            };
-            name = Debug;
-        };
-        F41FD0252E2A467000909132 /* Release */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ALWAYS_SEARCH_USER_PATHS = NO;
-                ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
-                CLANG_ANALYZER_NONNULL = YES;
-                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-                CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-                CLANG_ENABLE_MODULES = YES;
-                CLANG_ENABLE_OBJC_ARC = YES;
-                CLANG_ENABLE_OBJC_WEAK = YES;
-                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-                CLANG_WARN_BOOL_CONVERSION = YES;
-                CLANG_WARN_COMMA = YES;
-                CLANG_WARN_CONSTANT_CONVERSION = YES;
-                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-                CLANG_WARN_EMPTY_BODY = YES;
-                CLANG_WARN_ENUM_CONVERSION = YES;
-                CLANG_WARN_INFINITE_RECURSION = YES;
-                CLANG_WARN_INT_CONVERSION = YES;
-                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-                CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-                CLANG_WARN_STRICT_PROTOTYPES = YES;
-                CLANG_WARN_SUSPICIOUS_MOVE = YES;
-                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-                CLANG_WARN_UNREACHABLE_CODE = YES;
-                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-                COPY_PHASE_STRIP = NO;
-                DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-                DEVELOPMENT_TEAM = 7NKX7G7LV3;
-                ENABLE_NS_ASSERTIONS = NO;
-                ENABLE_STRICT_OBJC_MSGSEND = YES;
-                ENABLE_USER_SCRIPT_SANDBOXING = YES;
-                GCC_C_LANGUAGE_STANDARD = gnu17;
-                GCC_NO_COMMON_BLOCKS = YES;
-                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-                GCC_WARN_UNDECLARED_SELECTOR = YES;
-                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-                GCC_WARN_UNUSED_FUNCTION = YES;
-                GCC_WARN_UNUSED_VARIABLE = YES;
-                IPHONEOS_DEPLOYMENT_TARGET = 18.5;
-                LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-                MTL_ENABLE_DEBUG_INFO = NO;
-                MTL_FAST_MATH = YES;
-                SDKROOT = iphoneos;
-                SWIFT_COMPILATION_MODE = wholemodule;
-                VALIDATE_PRODUCT = YES;
-            };
-            name = Release;
-        };
-        F41FD0272E2A467000909132 /* Debug */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-                CODE_SIGN_STYLE = Automatic;
-                CURRENT_PROJECT_VERSION = 1;
-                DEVELOPMENT_TEAM = 7NKX7G7LV3;
-                ENABLE_PREVIEWS = YES;
-                FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
-                GENERATE_INFOPLIST_FILE = YES;
-                HEADER_SEARCH_PATHS = "";
-                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-                INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-                LD_RUNPATH_SEARCH_PATHS = "";
-                LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
-                MARKETING_VERSION = 1.0;
-                PRODUCT_BUNDLE_IDENTIFIER = com.tokyoyanbanjin.noesisnoema.NoesisNoema;
-                PRODUCT_NAME = "$(TARGET_NAME)";
-                REGISTER_APP_GROUPS = YES;
-                SDKROOT = macosx;
-                SUPPORTED_PLATFORMS = macosx;
-                SUPPORTS_MACCATALYST = NO;
-                SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-                SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-                SWIFT_EMIT_LOC_STRINGS = YES;
-                SWIFT_VERSION = 5.0;
-            };
-            name = Debug;
-        };
-        F41FD0282E2A467000909132 /* Release */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-                CODE_SIGN_STYLE = Automatic;
-                CURRENT_PROJECT_VERSION = 1;
-                DEVELOPMENT_TEAM = 7NKX7G7LV3;
-                ENABLE_PREVIEWS = YES;
-                FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
-                GENERATE_INFOPLIST_FILE = YES;
-                HEADER_SEARCH_PATHS = "";
-                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-                INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-                LD_RUNPATH_SEARCH_PATHS = "";
-                LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
-                MARKETING_VERSION = 1.0;
-                PRODUCT_BUNDLE_IDENTIFIER = com.tokyoyanbanjin.noesisnoema.NoesisNoema;
-                PRODUCT_NAME = "$(TARGET_NAME)";
-                REGISTER_APP_GROUPS = YES;
-                SDKROOT = macosx;
-                SUPPORTED_PLATFORMS = macosx;
-                SUPPORTS_MACCATALYST = NO;
-                SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-                SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-                SWIFT_EMIT_LOC_STRINGS = YES;
-                SWIFT_VERSION = 5.0;
-            };
-            name = Release;
-        };
-        F460884E2E2CD45000D4C555 /* Debug */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-                CLANG_ENABLE_MODULES = YES;
-                CODE_SIGN_STYLE = Automatic;
-                DEVELOPMENT_TEAM = 7NKX7G7LV3;
-                ENABLE_HARDENED_RUNTIME = NO;
-                FRAMEWORK_SEARCH_PATHS = (
-                    "$(PROJECT_DIR)/Frameworks",
-                    "$(PROJECT_DIR)/llama_macos.xcframework/macos-arm64_x86_64",
-                );
-                LD_RUNPATH_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "@loader_path",
-                    "@executable_path",
-                    "@rpath",
-                );
-                LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
-                MACOSX_DEPLOYMENT_TARGET = 15.5;
-                PRODUCT_NAME = "$(TARGET_NAME)";
-                REGISTER_APP_GROUPS = YES;
-                SDKROOT = macosx;
-                SUPPORTED_PLATFORMS = macosx;
-                SUPPORTS_MACCATALYST = NO;
-                SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-                SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-                SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG BRIDGE_TEST";
-                SWIFT_OBJC_BRIDGING_HEADER = "";
-                SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-                SWIFT_VERSION = 5.0;
-                TARGETED_DEVICE_FAMILY = 6;
-            };
-            name = Debug;
-        };
-        F460884F2E2CD45000D4C555 /* Release */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-                CLANG_ENABLE_MODULES = YES;
-                CODE_SIGN_STYLE = Automatic;
-                DEVELOPMENT_TEAM = 7NKX7G7LV3;
-                ENABLE_HARDENED_RUNTIME = NO;
-                FRAMEWORK_SEARCH_PATHS = (
-                    "$(PROJECT_DIR)/Frameworks",
-                    "$(PROJECT_DIR)/llama_macos.xcframework/macos-arm64_x86_64",
-                );
-                LD_RUNPATH_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "@loader_path",
-                    "@executable_path",
-                    "@rpath",
-                );
-                LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
-                MACOSX_DEPLOYMENT_TARGET = 15.5;
-                PRODUCT_NAME = "$(TARGET_NAME)";
-                REGISTER_APP_GROUPS = YES;
-                SDKROOT = macosx;
-                SUPPORTED_PLATFORMS = macosx;
-                SUPPORTS_MACCATALYST = NO;
-                SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-                SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-                SWIFT_ACTIVE_COMPILATION_CONDITIONS = BRIDGE_TEST;
-                SWIFT_OBJC_BRIDGING_HEADER = "";
-                SWIFT_VERSION = 5.0;
-                TARGETED_DEVICE_FAMILY = 6;
-            };
-            name = Release;
-        };
-        F4C581062E4F006800E64194 /* Debug */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-                CODE_SIGN_STYLE = Automatic;
-                CURRENT_PROJECT_VERSION = 1;
-                DEVELOPMENT_TEAM = 7NKX7G7LV3;
-                ENABLE_PREVIEWS = YES;
-                FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
-                GENERATE_INFOPLIST_FILE = YES;
-                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-                INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-                LD_RUNPATH_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "@executable_path/Frameworks",
-                    "@loader_path/Frameworks",
-                );
-                LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
-                MARKETING_VERSION = 1.0;
-                OTHER_LDFLAGS = "";
-                PRODUCT_BUNDLE_IDENTIFIER = com.tokyoyanbanjin.noesisnoema.NoesisNoemaMobile;
-                PRODUCT_NAME = "$(TARGET_NAME)";
-                SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-                SUPPORTS_MACCATALYST = NO;
-                SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-                SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-                SWIFT_EMIT_LOC_STRINGS = NO;
-                SWIFT_VERSION = 5.0;
-                TARGETED_DEVICE_FAMILY = 1;
-            };
-            name = Debug;
-        };
-        F4C581072E4F006800E64194 /* Release */ = {
-            isa = XCBuildConfiguration;
-            buildSettings = {
-                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-                CODE_SIGN_STYLE = Automatic;
-                CURRENT_PROJECT_VERSION = 1;
-                DEVELOPMENT_TEAM = 7NKX7G7LV3;
-                ENABLE_PREVIEWS = YES;
-                FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
-                GENERATE_INFOPLIST_FILE = YES;
-                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-                INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-                INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-                LD_RUNPATH_SEARCH_PATHS = (
-                    "$(inherited)",
-                    "@executable_path/Frameworks",
-                    "@loader_path/Frameworks",
-                );
-                LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
-                MARKETING_VERSION = 1.0;
-                OTHER_LDFLAGS = "";
-                PRODUCT_BUNDLE_IDENTIFIER = com.tokyoyanbanjin.noesisnoema.NoesisNoemaMobile;
-                PRODUCT_NAME = "$(TARGET_NAME)";
-                SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-                SUPPORTS_MACCATALYST = NO;
-                SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-                SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
-                SWIFT_EMIT_LOC_STRINGS = NO;
-                SWIFT_VERSION = 5.0;
-                TARGETED_DEVICE_FAMILY = 1;
-            };
-            name = Release;
-        };
+		F41FD0242E2A467000909132 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 7NKX7G7LV3;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		F41FD0252E2A467000909132 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 7NKX7G7LV3;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		F41FD0272E2A467000909132 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7NKX7G7LV3;
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = "";
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tokyoyanbanjin.noesisnoema.NoesisNoema;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		F41FD0282E2A467000909132 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7NKX7G7LV3;
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = "";
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tokyoyanbanjin.noesisnoema.NoesisNoema;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		F460884E2E2CD45000D4C555 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 7NKX7G7LV3;
+				ENABLE_HARDENED_RUNTIME = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Frameworks",
+					"$(PROJECT_DIR)/llama_macos.xcframework/macos-arm64_x86_64",
+				);
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@loader_path",
+					"@executable_path",
+					"@rpath",
+				);
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
+				MACOSX_DEPLOYMENT_TARGET = 15.5;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG BRIDGE_TEST";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 6;
+			};
+			name = Debug;
+		};
+		F460884F2E2CD45000D4C555 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 7NKX7G7LV3;
+				ENABLE_HARDENED_RUNTIME = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Frameworks",
+					"$(PROJECT_DIR)/llama_macos.xcframework/macos-arm64_x86_64",
+				);
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@loader_path",
+					"@executable_path",
+					"@rpath",
+				);
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
+				MACOSX_DEPLOYMENT_TARGET = 15.5;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				REGISTER_APP_GROUPS = YES;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = BRIDGE_TEST;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 6;
+			};
+			name = Release;
+		};
+		F4C581062E4F006800E64194 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7NKX7G7LV3;
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.tokyoyanbanjin.noesisnoema.NoesisNoemaMobile;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		F4C581072E4F006800E64194 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7NKX7G7LV3;
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks/**";
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.tokyoyanbanjin.noesisnoema.NoesisNoemaMobile;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-        F41FD0162E2A466F00909132 /* Build configuration list for PBXProject "NoesisNoema" */ = {
-            isa = XCConfigurationList;
-            buildConfigurations = (
-                F41FD0242E2A467000909132 /* Debug */,
-                F41FD0252E2A467000909132 /* Release */,
-            );
-            defaultConfigurationIsVisible = 0;
-            defaultConfigurationName = Release;
-        };
-        F41FD0262E2A467000909132 /* Build configuration list for PBXNativeTarget "NoesisNoema" */ = {
-            isa = XCConfigurationList;
-            buildConfigurations = (
-                F41FD0272E2A467000909132 /* Debug */,
-                F41FD0282E2A467000909132 /* Release */,
-            );
-            defaultConfigurationIsVisible = 0;
-            defaultConfigurationName = Release;
-        };
-        F460884D2E2CD45000D4C555 /* Build configuration list for PBXNativeTarget "LlamaBridgeTest" */ = {
-            isa = XCConfigurationList;
-            buildConfigurations = (
-                F460884E2E2CD45000D4C555 /* Debug */,
-                F460884F2E2CD45000D4C555 /* Release */,
-            );
-            defaultConfigurationIsVisible = 0;
-            defaultConfigurationName = Release;
-        };
-        F4C581052E4F006800E64194 /* Build configuration list for PBXNativeTarget "NoesisNoemaMobile" */ = {
-            isa = XCConfigurationList;
-            buildConfigurations = (
-                F4C581062E4F006800E64194 /* Debug */,
-                F4C581072E4F006800E64194 /* Release */,
-            );
-            defaultConfigurationIsVisible = 0;
-            defaultConfigurationName = Release;
-        };
+		F41FD0162E2A466F00909132 /* Build configuration list for PBXProject "NoesisNoema" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F41FD0242E2A467000909132 /* Debug */,
+				F41FD0252E2A467000909132 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F41FD0262E2A467000909132 /* Build configuration list for PBXNativeTarget "NoesisNoema" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F41FD0272E2A467000909132 /* Debug */,
+				F41FD0282E2A467000909132 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F460884D2E2CD45000D4C555 /* Build configuration list for PBXNativeTarget "LlamaBridgeTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F460884E2E2CD45000D4C555 /* Debug */,
+				F460884F2E2CD45000D4C555 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F4C581052E4F006800E64194 /* Build configuration list for PBXNativeTarget "NoesisNoemaMobile" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F4C581062E4F006800E64194 /* Debug */,
+				F4C581072E4F006800E64194 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-        F4021E4D2E3DC3A2007A4236 /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {
-            isa = XCRemoteSwiftPackageReference;
-            repositoryURL = "https://github.com/weichsel/ZIPFoundation";
-            requirement = {
-                kind = upToNextMajorVersion;
-                minimumVersion = 0.9.19;
-            };
-        };
+		F4021E4D2E3DC3A2007A4236 /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/weichsel/ZIPFoundation";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.19;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-        F4021E4E2E3DC3A2007A4236 /* ZIPFoundation */ = {
-            isa = XCSwiftPackageProductDependency;
-            package = F4021E4D2E3DC3A2007A4236 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
-            productName = ZIPFoundation;
-        };
-        F4D1DB532E4F18ED006B902C /* ZIPFoundation */ = {
-            isa = XCSwiftPackageProductDependency;
-            package = F4021E4D2E3DC3A2007A4236 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
-            productName = ZIPFoundation;
-        };
+		F4021E4E2E3DC3A2007A4236 /* ZIPFoundation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F4021E4D2E3DC3A2007A4236 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
+			productName = ZIPFoundation;
+		};
+		F4D1DB532E4F18ED006B902C /* ZIPFoundation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F4021E4D2E3DC3A2007A4236 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
+			productName = ZIPFoundation;
+		};
 /* End XCSwiftPackageProductDependency section */
-    };
-    rootObject = F41FD0132E2A466F00909132 /* Project object */;
+	};
+	rootObject = F41FD0132E2A466F00909132 /* Project object */;
 }

--- a/NoesisNoema/ModelRegistry/RegistryPersistence.swift
+++ b/NoesisNoema/ModelRegistry/RegistryPersistence.swift
@@ -1,0 +1,121 @@
+// filepath: /Users/raskolnikoff/Documents/Xcode Projects/NoesisNoema/NoesisNoema/ModelRegistry/RegistryPersistence.swift
+// Project: NoesisNoema
+// File: RegistryPersistence.swift
+// Description: Persist and load per-model runtime params (recommended/override) and last selection
+
+import Foundation
+import UniformTypeIdentifiers
+
+enum RuntimeMode: String, Codable {
+    case recommended
+    case override
+}
+
+struct ModelRuntimeRecord: Codable {
+    var recommended: RuntimeParams
+    var overrideParams: RuntimeParams?
+    var mode: RuntimeMode
+}
+
+struct PersistentRegistry: Codable {
+    var lastSelectedModelId: String?
+    var models: [String: ModelRuntimeRecord]
+
+    init(lastSelectedModelId: String? = nil, models: [String: ModelRuntimeRecord] = [:]) {
+        self.lastSelectedModelId = lastSelectedModelId
+        self.models = models
+    }
+}
+
+actor RegistryPersistence {
+    static let shared = RegistryPersistence()
+
+    // For tests: override base directory (e.g., /tmp/testdir)
+    static var baseDirectoryOverride: URL?
+
+    private var cached: PersistentRegistry?
+
+    private func baseDirectoryURL() -> URL {
+        if let o = RegistryPersistence.baseDirectoryOverride { return o }
+        #if os(iOS)
+        let home = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+        #else
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        #endif
+        return home
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("NoesisNoema", isDirectory: true)
+    }
+
+    private func fileURL() -> URL {
+        return baseDirectoryURL().appendingPathComponent("registry.json", conformingTo: .json)
+    }
+
+    func load() async -> PersistentRegistry {
+        if let cached { return cached }
+        let url = fileURL()
+        do {
+            let data = try Data(contentsOf: url)
+            let reg = try JSONDecoder().decode(PersistentRegistry.self, from: data)
+            self.cached = reg
+            return reg
+        } catch {
+            // Ensure directory exists
+            do { try FileManager.default.createDirectory(at: baseDirectoryURL(), withIntermediateDirectories: true) } catch { /* ignore */ }
+            let empty = PersistentRegistry()
+            self.cached = empty
+            return empty
+        }
+    }
+
+    func save(_ reg: PersistentRegistry) async {
+        let url = fileURL()
+        do {
+            try FileManager.default.createDirectory(at: baseDirectoryURL(), withIntermediateDirectories: true)
+            let enc = JSONEncoder()
+            enc.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try enc.encode(reg)
+            try data.write(to: url, options: [.atomic])
+            self.cached = reg
+        } catch {
+            print("[RegistryPersistence] Save failed: \(error)")
+        }
+    }
+
+    // Convenience helpers
+    func updateRecord(modelId: String, mutate: (inout ModelRuntimeRecord?) -> Void) async {
+        var reg = await load()
+        var rec = reg.models[modelId]
+        mutate(&rec)
+        if let rec { reg.models[modelId] = rec } else { reg.models.removeValue(forKey: modelId) }
+        await save(reg)
+    }
+
+    func setLastSelectedModel(id: String?) async {
+        var reg = await load()
+        reg.lastSelectedModelId = id
+        await save(reg)
+    }
+
+    func getRecord(for modelId: String) async -> ModelRuntimeRecord? {
+        let reg = await load()
+        return reg.models[modelId]
+    }
+
+    func getLastSelectedModelId() async -> String? {
+        let reg = await load()
+        return reg.lastSelectedModelId
+    }
+
+    // Testing helpers
+    func clearCache() {
+        self.cached = nil
+    }
+
+    func wipe() async {
+        let url = fileURL()
+        do { try FileManager.default.removeItem(at: url) } catch { /* ignore */ }
+        self.cached = nil
+    }
+}


### PR DESCRIPTION
## What
Persist recommended runtime params per model and user overrides to disk and apply them on startup. Add UI controls to switch between recommended and override, plus reset to recommended. Show badges (Recommended/Custom) and support accessibility.

## Why
Ensure stability and continuity across sessions: users keep their settings and recommended values automatically. Non-blocking UX with clear state.

## How
- New persistence layer (RegistryPersistence) storing JSON at `~/Library/Application Support/NoesisNoema/registry.json`.
- Save per-model record: `{ recommended, overrideParams?, mode }` and `lastSelectedModelId`.
- On app startup, load last selected model and apply persisted mode/params.
- UI (macOS/iOS): radio "Use recommended / Override", Reset button, badges: "Recommended" or "Custom". VoiceOver labels and keyboard shortcut (Cmd+R) on macOS.
- ModelManager APIs to set mode, update overrides, reset, and to persist autotune recommendations (non-blocking, cached, timeout-backed).
- CLI wiring (LlamaBridgeTest) updated to compile new sources.
- Tests: add persistence and reset tests to the existing test runner.

## DoD
- Settings persist after restart (simulated): PASS (Test 12)
- Reset restores recommended values: PASS (Test 13)
- Accessibility supported (labels, shortcut)

## Tests
Run:
```
# Build
xcodebuild -scheme LlamaBridgeTest -configuration Debug build

# Test suite (includes cache/timeout/unknown-quant + persistence/reset)
./build/Build/Products/Debug/LlamaBridgeTest model test
```

All tests passing locally (13/13).

## Notes
- Also integrates prior background autotune and cache/timeout logic.
- Closes #10.
