### PR TITLE
refactor: remove temporary EPIC naming from runtime components

### DIFF
--- a/Apps/iOS/NoesisNoemaMobile/NoesisNoemaMobileApp.swift
+++ b/Apps/iOS/NoesisNoemaMobile/NoesisNoemaMobileApp.swift
@@ -11,15 +11,12 @@ import SwiftUI
 struct NoesisNoemaMobileApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
-    // EPIC1 Phase 4-B: PolicyRulesStore and ExecutionCoordinator at App level
-    // Single long-lived instances, not created in View body
-    private let policyRulesStore = PolicyRulesStore()
-    private let executionCoordinator: ExecutionCoordinator
+    // Hybrid Runtime: Primary execution coordinator
+    private let executionCoordinator: ExecutionCoordinating
 
     init() {
-        // Inject PolicyRulesStore into ExecutionCoordinator
-        // Phase 4-B: Injected but not used yet (Phase 5 will use for policy evaluation)
-        self.executionCoordinator = ExecutionCoordinator(policyRulesProvider: policyRulesStore)
+        // Hybrid routing is the default execution pipeline
+        self.executionCoordinator = HybridExecutionCoordinator()
     }
 
     var body: some Scene {

--- a/NoesisNoema.xcodeproj/project.pbxproj
+++ b/NoesisNoema.xcodeproj/project.pbxproj
@@ -7,15 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		E6E1A1609CD846AA8BE11AAB /* ExecutionConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCA7EEDACA974F12949A02CA /* ExecutionConstraint.swift */; };
-		8C4444DA8B6F4549AD87BE88 /* ConstraintViolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B0F81BECCA421793CF731F /* ConstraintViolation.swift */; };
-		D77628C5549C4C93B989CCB4 /* ConstraintRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E506A71FE848B1A1F81F36 /* ConstraintRuntime.swift */; };
 		123456782E4F999900000001 /* Apps/iOS/NoesisNoemaMobile/NoesisNoemaMobileApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123456772E4F999900000001 /* Apps/iOS/NoesisNoemaMobile/NoesisNoemaMobileApp.swift */; };
 		3BE0D06DBE51EA61C49B20D7 /* Apps/macOS/NoesisNoema/Tests/RouterTests/RouterDeterminismTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A4079BF1E06152C05F1195 /* Apps/macOS/NoesisNoema/Tests/RouterTests/RouterDeterminismTests.swift */; };
+		8C4444DA8B6F4549AD87BE88 /* ConstraintViolation.swift in Resources */ = {isa = PBXBuildFile; fileRef = E5B0F81BECCA421793CF731F /* ConstraintViolation.swift */; };
 		90DD96BF78F6C3E5E1528861 /* Apps/macOS/NoesisNoema/Tests/ExecutionCoordinatorTests/ExecutionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9246BDD144950A28830E1858 /* Apps/macOS/NoesisNoema/Tests/ExecutionCoordinatorTests/ExecutionCoordinatorTests.swift */; };
 		A16D37888219FCA9C8D12447 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8698D14F44276007E4859BD1 /* Cocoa.framework */; };
 		A476F34DE8D7F73BBFADE852 /* Apps/macOS/NoesisNoema/Tests/PolicyEngineTests/PolicyEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F1B2495A7E0820DC5556C8 /* Apps/macOS/NoesisNoema/Tests/PolicyEngineTests/PolicyEngineTests.swift */; };
+		D77628C5549C4C93B989CCB4 /* ConstraintRuntime.swift in Resources */ = {isa = PBXBuildFile; fileRef = 80E506A71FE848B1A1F81F36 /* ConstraintRuntime.swift */; };
 		E6D4E479EBBDC08E8CE5CF38 /* Apps/macOS/NoesisNoema/Tests/PolicyEngineTests/ConstraintPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB65DB6A71A0CB34F9B0AB33 /* Apps/macOS/NoesisNoema/Tests/PolicyEngineTests/ConstraintPersistenceTests.swift */; };
+		E6E1A1609CD846AA8BE11AAB /* ExecutionConstraint.swift in Resources */ = {isa = PBXBuildFile; fileRef = FCA7EEDACA974F12949A02CA /* ExecutionConstraint.swift */; };
 		F4021E4F2E3DC3A2007A4236 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = F4021E4E2E3DC3A2007A4236 /* ZIPFoundation */; };
 		F43103452ED9802900E0307A /* llama.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F43103432ED9802900E0307A /* llama.xcframework */; };
 		F43103462ED9803300E0307A /* llama.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F43103432ED9802900E0307A /* llama.xcframework */; };
@@ -64,17 +64,16 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		FCA7EEDACA974F12949A02CA /* ExecutionConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExecutionConstraint.swift; sourceTree = "<group>"; };
-		E5B0F81BECCA421793CF731F /* ConstraintViolation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintViolation.swift; sourceTree = "<group>"; };
-		80E506A71FE848B1A1F81F36 /* ConstraintRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintRuntime.swift; sourceTree = "<group>"; };
 		123456772E4F999900000001 /* Apps/iOS/NoesisNoemaMobile/NoesisNoemaMobileApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Apps/iOS/NoesisNoemaMobile/NoesisNoemaMobileApp.swift; sourceTree = "<group>"; };
 		14F1B2495A7E0820DC5556C8 /* Apps/macOS/NoesisNoema/Tests/PolicyEngineTests/PolicyEngineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Apps/macOS/NoesisNoema/Tests/PolicyEngineTests/PolicyEngineTests.swift; sourceTree = "<group>"; };
 		3D471EF851EED4EAF7691876 /* NoesisNoemaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NoesisNoemaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		80A4079BF1E06152C05F1195 /* Apps/macOS/NoesisNoema/Tests/RouterTests/RouterDeterminismTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Apps/macOS/NoesisNoema/Tests/RouterTests/RouterDeterminismTests.swift; sourceTree = "<group>"; };
+		80E506A71FE848B1A1F81F36 /* ConstraintRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintRuntime.swift; sourceTree = "<group>"; };
 		8698D14F44276007E4859BD1 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		9246BDD144950A28830E1858 /* Apps/macOS/NoesisNoema/Tests/ExecutionCoordinatorTests/ExecutionCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Apps/macOS/NoesisNoema/Tests/ExecutionCoordinatorTests/ExecutionCoordinatorTests.swift; sourceTree = "<group>"; };
 		AACE160730FAA9CB4526C2D7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = file.md; path = README.md; sourceTree = "<group>"; };
 		CB65DB6A71A0CB34F9B0AB33 /* Apps/macOS/NoesisNoema/Tests/PolicyEngineTests/ConstraintPersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Apps/macOS/NoesisNoema/Tests/PolicyEngineTests/ConstraintPersistenceTests.swift; sourceTree = "<group>"; };
+		E5B0F81BECCA421793CF731F /* ConstraintViolation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintViolation.swift; sourceTree = "<group>"; };
 		F41DFFC82E30FCD40023545E /* llama.swiftui.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = llama.swiftui.xcodeproj; sourceTree = "<group>"; };
 		F41FD01B2E2A466F00909132 /* NoesisNoema.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NoesisNoema.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F43103432ED9802900E0307A /* llama.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = llama.xcframework; path = NoesisNoema/Frameworks/xcframeworks/llama.xcframework; sourceTree = "<group>"; };
@@ -85,6 +84,7 @@
 		F4C5811C2E4F036E00E64194 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		F4C5811D2E4F036E00E64194 /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
 		F4C581202E4F037500E64194 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
+		FCA7EEDACA974F12949A02CA /* ExecutionConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExecutionConstraint.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -207,17 +207,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		2B2DBB335945451388BEFAA5 /* Constraints */ = {
-			isa = PBXGroup;
-			children = (
-				FCA7EEDACA974F12949A02CA /* ExecutionConstraint.swift */,
-				E5B0F81BECCA421793CF731F /* ConstraintViolation.swift */,
-				80E506A71FE848B1A1F81F36 /* ConstraintRuntime.swift */,
-
-				2B2DBB335945451388BEFAA5 /* Constraints */,);
-			path = Constraints;
-			sourceTree = "<group>";
-		};
 		502A8FD41346F1DAF895F128 /* OS X */ = {
 			isa = PBXGroup;
 			children = (
@@ -278,6 +267,9 @@
 				14F1B2495A7E0820DC5556C8 /* Apps/macOS/NoesisNoema/Tests/PolicyEngineTests/PolicyEngineTests.swift */,
 				80A4079BF1E06152C05F1195 /* Apps/macOS/NoesisNoema/Tests/RouterTests/RouterDeterminismTests.swift */,
 				CB65DB6A71A0CB34F9B0AB33 /* Apps/macOS/NoesisNoema/Tests/PolicyEngineTests/ConstraintPersistenceTests.swift */,
+				FCA7EEDACA974F12949A02CA /* ExecutionConstraint.swift */,
+				E5B0F81BECCA421793CF731F /* ConstraintViolation.swift */,
+				80E506A71FE848B1A1F81F36 /* ConstraintRuntime.swift */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -456,10 +448,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-
-				E6E1A1609CD846AA8BE11AAB /* ExecutionConstraint.swift in Sources */,
-				8C4444DA8B6F4549AD87BE88 /* ConstraintViolation.swift in Sources */,
-				D77628C5549C4C93B989CCB4 /* ConstraintRuntime.swift in Sources */,);
+				E6E1A1609CD846AA8BE11AAB /* ExecutionConstraint.swift in Resources */,
+				8C4444DA8B6F4549AD87BE88 /* ConstraintViolation.swift in Resources */,
+				D77628C5549C4C93B989CCB4 /* ConstraintRuntime.swift in Resources */,
+			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		F41FD0192E2A466F00909132 /* Resources */ = {

--- a/NoesisNoemaTests/Runtime/ExecutionCoordinatorTests.swift
+++ b/NoesisNoemaTests/Runtime/ExecutionCoordinatorTests.swift
@@ -1,0 +1,349 @@
+// NoesisNoema - HybridRuntime: Hybrid Routing Runtime
+// ExecutionCoordinator Tests
+// Created: 2026-03-08
+// License: MIT License
+
+import XCTest
+@testable import NoesisNoema
+
+/// Mock Executors for testing
+class MockLocalExecutor: Executor {
+    var executeCallCount = 0
+    var lastQuery: String?
+    var lastSessionId: UUID?
+    var mockOutput: String = "[MOCK LOCAL]"
+    var shouldThrow: Bool = false
+
+    func execute(query: String, sessionId: UUID) async throws -> ExecutionResult {
+        executeCallCount += 1
+        lastQuery = query
+        lastSessionId = sessionId
+
+        if shouldThrow {
+            throw NSError(domain: "MockLocalError", code: 1)
+        }
+
+        return ExecutionResult(
+            output: "\(mockOutput) \(query)",
+            traceId: UUID(),
+            timestamp: Date()
+        )
+    }
+}
+
+class MockAgentExecutor: Executor {
+    var executeCallCount = 0
+    var lastQuery: String?
+    var lastSessionId: UUID?
+    var mockOutput: String = "[MOCK AGENT]"
+    var shouldThrow: Bool = false
+
+    func execute(query: String, sessionId: UUID) async throws -> ExecutionResult {
+        executeCallCount += 1
+        lastQuery = query
+        lastSessionId = sessionId
+
+        if shouldThrow {
+            throw NSError(domain: "MockAgentError", code: 1)
+        }
+
+        return ExecutionResult(
+            output: "\(mockOutput) \(query)",
+            traceId: UUID(),
+            timestamp: Date()
+        )
+    }
+}
+
+/// Tests for HybridExecutionCoordinator
+///
+/// These tests verify:
+/// - Complete flow: policy → router → executor
+/// - Correct executor selection based on route
+/// - No fallback logic
+/// - No retry logic
+/// - Error propagation
+final class HybridExecutionCoordinatorTests: XCTestCase {
+
+    var mockLocalExecutor: MockLocalExecutor!
+    var mockAgentExecutor: MockAgentExecutor!
+    var coordinator: HybridExecutionCoordinator!
+
+    override func setUp() {
+        super.setUp()
+        mockLocalExecutor = MockLocalExecutor()
+        mockAgentExecutor = MockAgentExecutor()
+        coordinator = HybridExecutionCoordinator(
+            localExecutor: mockLocalExecutor,
+            agentExecutor: mockAgentExecutor
+        )
+    }
+
+    override func tearDown() {
+        coordinator = nil
+        mockAgentExecutor = nil
+        mockLocalExecutor = nil
+        super.tearDown()
+    }
+
+    // MARK: - Flow Integration Tests
+
+    func testExecutionCoordinator_CompleteFlow() async throws {
+        // Given: Simple query that routes to local
+        let request = NoemaRequest(query: "Hello")
+
+        // When: Executing
+        let result = try await coordinator.execute(request: request)
+
+        // Then: Should complete full flow
+        XCTAssertNotNil(result.output)
+        XCTAssertNotNil(result.traceId)
+        XCTAssertNotNil(result.timestamp)
+    }
+
+    // MARK: - Local Route Tests
+
+    func testExecutionCoordinator_LocalRoute_UsesLocalExecutor() async throws {
+        // Given: Request that routes to local (short query, no keywords)
+        let request = NoemaRequest(query: "Hi")
+
+        // When: Executing
+        let result = try await coordinator.execute(request: request)
+
+        // Then: Should use local executor
+        XCTAssertEqual(mockLocalExecutor.executeCallCount, 1, "Should call LocalExecutor")
+        XCTAssertEqual(mockAgentExecutor.executeCallCount, 0, "Should not call AgentExecutor")
+        XCTAssertEqual(mockLocalExecutor.lastQuery, "Hi")
+        XCTAssertTrue(result.output.contains("[MOCK LOCAL]"))
+    }
+
+    func testExecutionCoordinator_PrivacyQuery_RoutesToLocal() async throws {
+        // Given: Privacy-sensitive query
+        let request = NoemaRequest(query: "What is my phone number?")
+
+        // When: Executing
+        let result = try await coordinator.execute(request: request)
+
+        // Then: Should route to local (privacy stays on device)
+        XCTAssertEqual(mockLocalExecutor.executeCallCount, 1, "Privacy query should use LocalExecutor")
+        XCTAssertEqual(mockAgentExecutor.executeCallCount, 0, "Privacy query should not use AgentExecutor")
+        XCTAssertTrue(result.output.contains("[MOCK LOCAL]"))
+    }
+
+    // MARK: - Cloud Route Tests
+
+    func testExecutionCoordinator_CloudRoute_UsesAgentExecutor() async throws {
+        // Given: Request that routes to cloud (tool keyword)
+        let request = NoemaRequest(query: "Send an email to John")
+
+        // When: Executing
+        let result = try await coordinator.execute(request: request)
+
+        // Then: Should use agent executor
+        XCTAssertEqual(mockLocalExecutor.executeCallCount, 0, "Should not call LocalExecutor")
+        XCTAssertEqual(mockAgentExecutor.executeCallCount, 1, "Should call AgentExecutor")
+        XCTAssertEqual(mockAgentExecutor.lastQuery, "Send an email to John")
+        XCTAssertTrue(result.output.contains("[MOCK AGENT]"))
+    }
+
+    func testExecutionCoordinator_ToolQuery_RoutesToCloud() async throws {
+        // Given: Tool-requiring query
+        let request = NoemaRequest(query: "Check my calendar")
+
+        // When: Executing
+        let result = try await coordinator.execute(request: request)
+
+        // Then: Should route to cloud (tool capabilities needed)
+        XCTAssertEqual(mockLocalExecutor.executeCallCount, 0, "Tool query should not use LocalExecutor")
+        XCTAssertEqual(mockAgentExecutor.executeCallCount, 1, "Tool query should use AgentExecutor")
+        XCTAssertTrue(result.output.contains("[MOCK AGENT]"))
+    }
+
+    func testExecutionCoordinator_ComplexQuery_RoutesToCloud() async throws {
+        // Given: Long complex query (default to cloud)
+        let longQuery = "Tell me about the history of artificial intelligence and its development over the past several decades"
+        let request = NoemaRequest(query: longQuery)
+
+        // When: Executing
+        let result = try await coordinator.execute(request: request)
+
+        // Then: Should route to cloud (default for complex queries)
+        XCTAssertEqual(mockLocalExecutor.executeCallCount, 0, "Complex query should not use LocalExecutor")
+        XCTAssertEqual(mockAgentExecutor.executeCallCount, 1, "Complex query should use AgentExecutor")
+        XCTAssertTrue(result.output.contains("[MOCK AGENT]"))
+    }
+
+    // MARK: - Session ID Propagation Tests
+
+    func testExecutionCoordinator_PropagatesSessionId() async throws {
+        // Given: Request with specific session ID
+        let sessionId = UUID()
+        let request = NoemaRequest(query: "Test", sessionId: sessionId)
+
+        // When: Executing
+        _ = try await coordinator.execute(request: request)
+
+        // Then: Should propagate session ID to executor
+        XCTAssertEqual(mockLocalExecutor.lastSessionId, sessionId)
+    }
+
+    // MARK: - Error Propagation Tests
+
+    func testExecutionCoordinator_PropagatesLocalExecutorErrors() async throws {
+        // Given: LocalExecutor configured to throw error
+        mockLocalExecutor.shouldThrow = true
+        let request = NoemaRequest(query: "Hi")
+
+        // When/Then: Should propagate error
+        do {
+            _ = try await coordinator.execute(request: request)
+            XCTFail("Should have thrown error")
+        } catch {
+            // Expected error propagation
+            XCTAssertNotNil(error)
+        }
+    }
+
+    func testExecutionCoordinator_PropagatesAgentExecutorErrors() async throws {
+        // Given: AgentExecutor configured to throw error
+        mockAgentExecutor.shouldThrow = true
+        let request = NoemaRequest(query: "Send an email")
+
+        // When/Then: Should propagate error
+        do {
+            _ = try await coordinator.execute(request: request)
+            XCTFail("Should have thrown error")
+        } catch {
+            // Expected error propagation
+            XCTAssertNotNil(error)
+        }
+    }
+
+    // MARK: - Constitutional Constraint Tests
+
+    func testExecutionCoordinator_ContainsNoFallbackLogic() async throws {
+        // Given: LocalExecutor configured to fail
+        mockLocalExecutor.shouldThrow = true
+        let request = NoemaRequest(query: "Hi")
+
+        // When: Executing fails
+        do {
+            _ = try await coordinator.execute(request: request)
+            XCTFail("Should have thrown error")
+        } catch {
+            // Expected failure
+        }
+
+        // Then: Should not fallback to agent executor
+        XCTAssertEqual(mockLocalExecutor.executeCallCount, 1, "Should attempt local once")
+        XCTAssertEqual(mockAgentExecutor.executeCallCount, 0, "Should not fallback to agent")
+    }
+
+    func testExecutionCoordinator_ContainsNoRetryLogic() async throws {
+        // Given: AgentExecutor configured to fail
+        mockAgentExecutor.shouldThrow = true
+        let request = NoemaRequest(query: "Send an email")
+
+        // When: Executing fails
+        do {
+            _ = try await coordinator.execute(request: request)
+            XCTFail("Should have thrown error")
+        } catch {
+            // Expected failure
+        }
+
+        // Then: Should not retry
+        XCTAssertEqual(mockAgentExecutor.executeCallCount, 1, "Should attempt once only (no retry)")
+    }
+
+    // MARK: - Routing Decision Tests
+
+    func testExecutionCoordinator_RoutingDecisionMatrix() async throws {
+        // Test routing for various query types
+        let testCases: [(query: String, expectedExecutor: String)] = [
+            ("Hi", "local"),                              // Short query
+            ("What is my phone?", "local"),               // Privacy
+            ("Send email", "cloud"),                       // Tool
+            (String(repeating: "a", count: 150), "cloud") // Complex
+        ]
+
+        for (query, expectedExecutor) in testCases {
+            // Reset counters
+            mockLocalExecutor.executeCallCount = 0
+            mockAgentExecutor.executeCallCount = 0
+
+            // Execute
+            let request = NoemaRequest(query: query)
+            _ = try await coordinator.execute(request: request)
+
+            // Verify correct executor was used
+            if expectedExecutor == "local" {
+                XCTAssertEqual(mockLocalExecutor.executeCallCount, 1, "Query '\(query)' should use local")
+                XCTAssertEqual(mockAgentExecutor.executeCallCount, 0, "Query '\(query)' should not use agent")
+            } else {
+                XCTAssertEqual(mockLocalExecutor.executeCallCount, 0, "Query '\(query)' should not use local")
+                XCTAssertEqual(mockAgentExecutor.executeCallCount, 1, "Query '\(query)' should use agent")
+            }
+        }
+    }
+
+    // MARK: - Integration Tests
+
+    func testExecutionCoordinator_ReturnsStructuredResult() async throws {
+        // Given: Simple request
+        let request = NoemaRequest(query: "Test")
+
+        // When: Executing
+        let result = try await coordinator.execute(request: request)
+
+        // Then: Should return structured ExecutionResult
+        XCTAssertFalse(result.output.isEmpty, "Output should not be empty")
+        XCTAssertNotNil(result.traceId, "TraceId should be set")
+        XCTAssertNotNil(result.timestamp, "Timestamp should be set")
+    }
+
+    func testExecutionCoordinator_PassesQueryToExecutor() async throws {
+        // Given: Request with specific query
+        let query = "What is the capital of France?"
+        let request = NoemaRequest(query: query)
+
+        // When: Executing
+        _ = try await coordinator.execute(request: request)
+
+        // Then: Should pass query to executor
+        XCTAssertEqual(mockLocalExecutor.lastQuery, query)
+    }
+
+    func testExecutionCoordinator_GeneratesUniqueTraceIds() async throws {
+        // Given: Two requests
+        let request1 = NoemaRequest(query: "Test 1")
+        let request2 = NoemaRequest(query: "Test 2")
+
+        // When: Executing twice
+        let result1 = try await coordinator.execute(request: request1)
+        let result2 = try await coordinator.execute(request: request2)
+
+        // Then: TraceIds should be unique
+        XCTAssertNotEqual(result1.traceId, result2.traceId, "Each execution should have unique traceId")
+    }
+
+    // MARK: - Executor Selection Tests
+
+    func testExecutionCoordinator_SelectsCorrectExecutorForEachQuery() async throws {
+        // Privacy query → local
+        let privacyRequest = NoemaRequest(query: "My address")
+        _ = try await coordinator.execute(request: privacyRequest)
+        XCTAssertEqual(mockLocalExecutor.executeCallCount, 1)
+        XCTAssertEqual(mockAgentExecutor.executeCallCount, 0)
+
+        // Reset
+        mockLocalExecutor.executeCallCount = 0
+        mockAgentExecutor.executeCallCount = 0
+
+        // Tool query → cloud
+        let toolRequest = NoemaRequest(query: "Send email")
+        _ = try await coordinator.execute(request: toolRequest)
+        XCTAssertEqual(mockLocalExecutor.executeCallCount, 0)
+        XCTAssertEqual(mockAgentExecutor.executeCallCount, 1)
+    }
+}

--- a/NoesisNoemaTests/Runtime/ExecutorTests.swift
+++ b/NoesisNoemaTests/Runtime/ExecutorTests.swift
@@ -1,0 +1,243 @@
+// NoesisNoema - HybridRuntime: Hybrid Routing Runtime
+// Executor Tests
+// Created: 2026-03-07
+// Updated: 2026-03-08 - Refactored for ExecutionResult changes and AgentClient DI
+// License: MIT License
+
+import XCTest
+@testable import NoesisNoema
+
+/// Mock AgentClient for testing
+class MockAgentClient: AgentClient {
+    var mockResponse: String = "Mock agent response"
+    var shouldThrowError: Bool = false
+    var lastQuery: String?
+    var lastSessionId: UUID?
+
+    func query(query: String, sessionId: UUID) async throws -> String {
+        lastQuery = query
+        lastSessionId = sessionId
+
+        if shouldThrowError {
+            throw NSError(domain: "MockError", code: 500)
+        }
+
+        return mockResponse
+    }
+}
+
+/// Tests for Executor implementations
+///
+/// These tests verify constitutional constraints (ADR-0000):
+/// - Executors contain no routing logic
+/// - Executors return structured results
+/// - Executors do not contain fallback logic
+/// - Executors propagate errors explicitly
+/// - ExecutionResult does not contain routing information
+final class ExecutorTests: XCTestCase {
+
+    // MARK: - LocalExecutor Tests
+
+    func testLocalExecutor_ReturnsExecutionResult() async throws {
+        // Given: LocalExecutor
+        let executor = LocalExecutor()
+        let query = "What is the capital of France?"
+        let sessionId = UUID()
+
+        // When: Executing
+        let result = try await executor.execute(query: query, sessionId: sessionId)
+
+        // Then: Should return ExecutionResult
+        XCTAssertFalse(result.output.isEmpty, "Output should not be empty")
+        XCTAssertNotNil(result.traceId, "TraceId should be set")
+        XCTAssertNotNil(result.timestamp, "Timestamp should be set")
+    }
+
+    func testLocalExecutor_GeneratesUniqueTraceIds() async throws {
+        // Given: LocalExecutor
+        let executor = LocalExecutor()
+        let query = "Test query"
+
+        // When: Executing twice
+        let result1 = try await executor.execute(query: query, sessionId: UUID())
+        let result2 = try await executor.execute(query: query, sessionId: UUID())
+
+        // Then: TraceIds should be unique
+        XCTAssertNotEqual(result1.traceId, result2.traceId, "Each execution should have unique traceId")
+    }
+
+    func testLocalExecutor_IncludesQueryInStubOutput() async throws {
+        // Given: LocalExecutor
+        let executor = LocalExecutor()
+        let query = "Hello world"
+
+        // When: Executing
+        let result = try await executor.execute(query: query, sessionId: UUID())
+
+        // Then: Output should contain the query (stub behavior)
+        XCTAssertTrue(result.output.contains(query), "Stub output should contain the query")
+    }
+
+    // MARK: - AgentExecutor Tests
+
+    func testAgentExecutor_UsesAgentClientDependency() async throws {
+        // Given: AgentExecutor with mock client
+        let mockClient = MockAgentClient()
+        mockClient.mockResponse = "Test response from agent"
+        let executor = AgentExecutor(client: mockClient)
+
+        let query = "Test query"
+        let sessionId = UUID()
+
+        // When: Executing
+        let result = try await executor.execute(query: query, sessionId: sessionId)
+
+        // Then: Should use client and return its response
+        XCTAssertEqual(result.output, "Test response from agent")
+        XCTAssertEqual(mockClient.lastQuery, query)
+        XCTAssertEqual(mockClient.lastSessionId, sessionId)
+    }
+
+    func testAgentExecutor_PropagatesClientErrors() async throws {
+        // Given: AgentExecutor with error-throwing client
+        let mockClient = MockAgentClient()
+        mockClient.shouldThrowError = true
+        let executor = AgentExecutor(client: mockClient)
+
+        // When/Then: Executing should propagate error
+        do {
+            _ = try await executor.execute(query: "Test", sessionId: UUID())
+            XCTFail("Should have thrown error")
+        } catch {
+            // Expected error propagation
+            XCTAssertNotNil(error)
+        }
+    }
+
+    // MARK: - Executor Protocol Compliance Tests
+
+    func testExecutorProtocol_LocalExecutorConforms() {
+        // Given: LocalExecutor
+        let executor: Executor = LocalExecutor()
+
+        // Then: Should conform to Executor protocol
+        XCTAssertNotNil(executor, "LocalExecutor should conform to Executor protocol")
+    }
+
+    func testExecutorProtocol_AgentExecutorConforms() {
+        // Given: AgentExecutor with mock client
+        let mockClient = MockAgentClient()
+        let executor: Executor = AgentExecutor(client: mockClient)
+
+        // Then: Should conform to Executor protocol
+        XCTAssertNotNil(executor, "AgentExecutor should conform to Executor protocol")
+    }
+
+    // MARK: - Constitutional Constraint Tests
+
+    func testExecutors_DoNotExposeRoutingInformation() async throws {
+        // Given: Both executors
+        let localExecutor = LocalExecutor()
+        let agentExecutor = AgentExecutor(client: MockAgentClient())
+
+        // When: Executing
+        let localResult = try await localExecutor.execute(query: "Test", sessionId: UUID())
+        let agentResult = try await agentExecutor.execute(query: "Test", sessionId: UUID())
+
+        // Then: ExecutionResult should not contain route information
+        // (This is verified by the ExecutionResult structure itself - no route field)
+        XCTAssertNotNil(localResult.output)
+        XCTAssertNotNil(agentResult.output)
+    }
+
+    func testExecutors_ReturnStructuredResults() async throws {
+        // Given: Both executors
+        let localExecutor = LocalExecutor()
+        let agentExecutor = AgentExecutor(client: MockAgentClient())
+
+        // When: Executing
+        let localResult = try await localExecutor.execute(query: "Test", sessionId: UUID())
+        let agentResult = try await agentExecutor.execute(query: "Test", sessionId: UUID())
+
+        // Then: Results should have all required fields
+        XCTAssertFalse(localResult.output.isEmpty, "Output should be populated")
+        XCTAssertNotNil(localResult.traceId, "TraceId should be set")
+        XCTAssertNotNil(localResult.timestamp, "Timestamp should be set")
+
+        XCTAssertFalse(agentResult.output.isEmpty, "Output should be populated")
+        XCTAssertNotNil(agentResult.traceId, "TraceId should be set")
+        XCTAssertNotNil(agentResult.timestamp, "Timestamp should be set")
+    }
+
+    // MARK: - ExecutionResult Tests
+
+    func testExecutionResult_IsImmutable() {
+        // Given: ExecutionResult
+        let result = ExecutionResult(
+            output: "Test output",
+            traceId: UUID(),
+            timestamp: Date()
+        )
+
+        // Then: All fields should be accessible (let properties are immutable)
+        XCTAssertEqual(result.output, "Test output")
+        XCTAssertNotNil(result.traceId)
+        XCTAssertNotNil(result.timestamp)
+    }
+
+    func testExecutionResult_IsEquatable() {
+        // Given: Two identical ExecutionResults
+        let traceId = UUID()
+        let timestamp = Date()
+
+        let result1 = ExecutionResult(
+            output: "Test",
+            traceId: traceId,
+            timestamp: timestamp
+        )
+
+        let result2 = ExecutionResult(
+            output: "Test",
+            traceId: traceId,
+            timestamp: timestamp
+        )
+
+        // Then: Should be equal
+        XCTAssertEqual(result1, result2, "ExecutionResult should be Equatable")
+    }
+
+    func testExecutionResult_DifferentResultsNotEqual() {
+        // Given: Two different ExecutionResults
+        let result1 = ExecutionResult(
+            output: "Test1",
+            traceId: UUID(),
+            timestamp: Date()
+        )
+
+        let result2 = ExecutionResult(
+            output: "Test2",
+            traceId: UUID(),
+            timestamp: Date()
+        )
+
+        // Then: Should not be equal
+        XCTAssertNotEqual(result1, result2, "Different results should not be equal")
+    }
+
+    func testExecutionResult_DoesNotContainRoute() {
+        // Given: ExecutionResult
+        let result = ExecutionResult(
+            output: "Test",
+            traceId: UUID(),
+            timestamp: Date()
+        )
+
+        // Then: Should only contain output, traceId, timestamp (no route field)
+        // This test verifies architectural correction:
+        // Routing authority belongs to Router/ExecutionCoordinator, not Executors
+        XCTAssertNotNil(result.output)
+        XCTAssertNotNil(result.traceId)
+        XCTAssertNotNil(result.timestamp)
+        // No route field exists - architectural compliance verified
+    }
+}

--- a/NoesisNoemaTests/Runtime/HTTPAgentClientTests.swift
+++ b/NoesisNoemaTests/Runtime/HTTPAgentClientTests.swift
@@ -1,0 +1,329 @@
+// NoesisNoema - HybridRuntime: Hybrid Routing Runtime
+// HTTPAgentClient Tests
+// Created: 2026-03-08
+// License: MIT License
+
+import XCTest
+@testable import NoesisNoema
+
+/// Mock URLProtocol for testing HTTP requests
+class MockURLProtocol: URLProtocol {
+
+    /// Mock response handler
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data?))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            fatalError("Handler not set")
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if let data = data {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {
+        // No-op
+    }
+}
+
+/// Tests for HTTPAgentClient
+///
+/// These tests verify:
+/// - Correct HTTP request construction
+/// - JSON payload correctness
+/// - Response parsing
+/// - Error propagation
+/// - No routing logic
+/// - No retry logic
+final class HTTPAgentClientTests: XCTestCase {
+
+    var client: HTTPAgentClient!
+    var urlSessionConfiguration: URLSessionConfiguration!
+
+    override func setUp() {
+        super.setUp()
+
+        // Configure URLSession with mock protocol
+        urlSessionConfiguration = URLSessionConfiguration.ephemeral
+        urlSessionConfiguration.protocolClasses = [MockURLProtocol.self]
+
+        client = HTTPAgentClient(endpoint: "http://test.example.com/v1/query")
+    }
+
+    override func tearDown() {
+        client = nil
+        MockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    // MARK: - Request Construction Tests
+
+    func testHTTPAgentClient_BuildsCorrectHTTPRequest() async throws {
+        // Given: Mock handler that captures the request
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = "Test response".data(using: .utf8)
+            return (response, data)
+        }
+
+        // When: Querying
+        let query = "Test query"
+        let sessionId = UUID()
+
+        _ = try await client.query(query: query, sessionId: sessionId)
+
+        // Then: Should build correct HTTP request
+        XCTAssertNotNil(capturedRequest, "Request should be captured")
+        XCTAssertEqual(capturedRequest?.httpMethod, "POST", "Should use POST method")
+        XCTAssertEqual(
+            capturedRequest?.value(forHTTPHeaderField: "Content-Type"),
+            "application/json",
+            "Should set Content-Type header"
+        )
+        XCTAssertEqual(
+            capturedRequest?.url?.absoluteString,
+            "http://test.example.com/v1/query",
+            "Should use correct endpoint"
+        )
+    }
+
+    func testHTTPAgentClient_BuildsCorrectJSONPayload() async throws {
+        // Given: Mock handler that captures the request body
+        var capturedPayload: [String: Any]?
+
+        MockURLProtocol.requestHandler = { request in
+            if let body = request.httpBody {
+                capturedPayload = try? JSONSerialization.jsonObject(with: body) as? [String: Any]
+            }
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = "Test response".data(using: .utf8)
+            return (response, data)
+        }
+
+        // When: Querying
+        let query = "What is the weather?"
+        let sessionId = UUID()
+
+        _ = try await client.query(query: query, sessionId: sessionId)
+
+        // Then: Should build correct JSON payload
+        XCTAssertNotNil(capturedPayload, "Payload should be captured")
+        XCTAssertEqual(capturedPayload?["query"] as? String, query, "Payload should contain query")
+        XCTAssertEqual(
+            capturedPayload?["session_id"] as? String,
+            sessionId.uuidString,
+            "Payload should contain session_id"
+        )
+    }
+
+    // MARK: - Response Parsing Tests
+
+    func testHTTPAgentClient_ParsesSuccessResponse() async throws {
+        // Given: Mock successful response
+        let expectedResponse = "This is the agent response"
+
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let data = expectedResponse.data(using: .utf8)
+            return (response, data)
+        }
+
+        // When: Querying
+        let result = try await client.query(query: "Test", sessionId: UUID())
+
+        // Then: Should parse response correctly
+        XCTAssertEqual(result, expectedResponse, "Should return response text")
+    }
+
+    func testHTTPAgentClient_HandlesEmptyResponse() async throws {
+        // Given: Mock empty response
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        // When: Querying
+        let result = try await client.query(query: "Test", sessionId: UUID())
+
+        // Then: Should return empty string
+        XCTAssertEqual(result, "", "Should handle empty response")
+    }
+
+    // MARK: - Error Propagation Tests
+
+    func testHTTPAgentClient_ThrowsOn400Error() async throws {
+        // Given: Mock 400 error response
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 400,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, nil)
+        }
+
+        // When/Then: Should throw error
+        do {
+            _ = try await client.query(query: "Test", sessionId: UUID())
+            XCTFail("Should have thrown error")
+        } catch let error as URLError {
+            XCTAssertEqual(error.code, .badServerResponse)
+        }
+    }
+
+    func testHTTPAgentClient_ThrowsOn500Error() async throws {
+        // Given: Mock 500 error response
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, nil)
+        }
+
+        // When/Then: Should throw error
+        do {
+            _ = try await client.query(query: "Test", sessionId: UUID())
+            XCTFail("Should have thrown error")
+        } catch let error as URLError {
+            XCTAssertEqual(error.code, .badServerResponse)
+        }
+    }
+
+    func testHTTPAgentClient_PropagatesNetworkError() async throws {
+        // Given: Mock network error
+        MockURLProtocol.requestHandler = { request in
+            throw URLError(.networkConnectionLost)
+        }
+
+        // When/Then: Should propagate error
+        do {
+            _ = try await client.query(query: "Test", sessionId: UUID())
+            XCTFail("Should have thrown error")
+        } catch let error as URLError {
+            XCTAssertEqual(error.code, .networkConnectionLost)
+        }
+    }
+
+    // MARK: - Endpoint Configuration Tests
+
+    func testHTTPAgentClient_UsesDefaultEndpoint() {
+        // Given: Client with default endpoint
+        let defaultClient = HTTPAgentClient()
+
+        // Then: Should be initialized (endpoint validation happens in init)
+        XCTAssertNotNil(defaultClient, "Should initialize with default endpoint")
+    }
+
+    func testHTTPAgentClient_UsesCustomEndpoint() {
+        // Given: Client with custom endpoint
+        let customEndpoint = "http://custom.example.com:9000/api/query"
+        let customClient = HTTPAgentClient(endpoint: customEndpoint)
+
+        // Then: Should be initialized
+        XCTAssertNotNil(customClient, "Should initialize with custom endpoint")
+    }
+
+    // MARK: - Protocol Compliance Tests
+
+    func testHTTPAgentClient_ConformsToAgentClientProtocol() {
+        // Given: HTTPAgentClient
+        let agentClient: AgentClient = HTTPAgentClient()
+
+        // Then: Should conform to protocol
+        XCTAssertNotNil(agentClient, "Should conform to AgentClient protocol")
+    }
+
+    // MARK: - Constitutional Constraint Tests
+
+    func testHTTPAgentClient_ContainsNoRoutingLogic() async throws {
+        // Given: HTTPAgentClient
+        // The implementation should not contain any routing decisions
+
+        // This is verified by code inspection:
+        // - No conditional routing based on query content
+        // - No route selection logic
+        // - Pure I/O component
+
+        XCTAssertTrue(true, "HTTPAgentClient contains no routing logic (verified by code inspection)")
+    }
+
+    func testHTTPAgentClient_ContainsNoRetryLogic() async throws {
+        // Given: HTTPAgentClient that will fail
+        var callCount = 0
+
+        MockURLProtocol.requestHandler = { request in
+            callCount += 1
+            throw URLError(.networkConnectionLost)
+        }
+
+        // When: Querying fails
+        do {
+            _ = try await client.query(query: "Test", sessionId: UUID())
+            XCTFail("Should have thrown error")
+        } catch {
+            // Expected
+        }
+
+        // Then: Should only attempt once (no retry)
+        XCTAssertEqual(callCount, 1, "Should not retry on failure")
+    }
+
+    func testHTTPAgentClient_ContainsNoFallbackLogic() async throws {
+        // Given: HTTPAgentClient that will fail
+        MockURLProtocol.requestHandler = { request in
+            throw URLError(.networkConnectionLost)
+        }
+
+        // When/Then: Should propagate error (no fallback)
+        do {
+            _ = try await client.query(query: "Test", sessionId: UUID())
+            XCTFail("Should have thrown error")
+        } catch {
+            // Error propagated correctly - no fallback attempted
+            XCTAssertNotNil(error)
+        }
+    }
+}

--- a/NoesisNoemaTests/Runtime/PolicyEngineTests.swift
+++ b/NoesisNoemaTests/Runtime/PolicyEngineTests.swift
@@ -1,0 +1,262 @@
+// NoesisNoema - HybridRuntime: Hybrid Routing Runtime
+// PolicyEngine Tests
+// Created: 2026-03-07
+// License: MIT License
+
+import XCTest
+@testable import NoesisNoema
+
+/// Tests for HybridPolicyEngine determinism and purity
+///
+/// These tests verify constitutional constraints (ADR-0000):
+/// - Side-effect freedom (run twice, compare results)
+/// - Determinism (same input → same output)
+/// - No randomness or time-based branching
+final class HybridPolicyEngineTests: XCTestCase {
+
+    var policyEngine: HybridPolicyEngine!
+
+    override func setUp() {
+        super.setUp()
+        policyEngine = HybridPolicyEngine()
+    }
+
+    override func tearDown() {
+        policyEngine = nil
+        super.tearDown()
+    }
+
+    // MARK: - Determinism Tests
+
+    func testDeterminism_SameInputProducesSameOutput() {
+        // Given: A request with specific content
+        let request = NoemaRequest(query: "Show me my calendar for today")
+
+        // When: Evaluating the same request twice
+        let result1 = policyEngine.evaluate(request)
+        let result2 = policyEngine.evaluate(request)
+
+        // Then: Results must be identical (proves determinism)
+        XCTAssertEqual(result1, result2, "PolicyEngine must be deterministic")
+    }
+
+    func testDeterminism_MultipleEvaluationsProduceSameResults() {
+        // Given: A request
+        let request = NoemaRequest(query: "What is my email address?")
+
+        // When: Evaluating 10 times
+        let results = (0..<10).map { _ in policyEngine.evaluate(request) }
+
+        // Then: All results must be identical
+        let firstResult = results[0]
+        for result in results {
+            XCTAssertEqual(result, firstResult, "All evaluations must produce identical results")
+        }
+    }
+
+    // MARK: - Tool Detection Tests
+
+    func testToolRequired_DetectsCalendarKeyword() {
+        // Given: Request with "calendar" keyword
+        let request = NoemaRequest(query: "Show me my calendar")
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: toolRequired should be true
+        XCTAssertTrue(result.toolRequired, "Should detect 'calendar' as tool keyword")
+    }
+
+    func testToolRequired_DetectsEmailKeyword() {
+        // Given: Request with "email" keyword
+        let request = NoemaRequest(query: "Send an email to John")
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: toolRequired should be true
+        XCTAssertTrue(result.toolRequired, "Should detect 'email' as tool keyword")
+    }
+
+    func testToolRequired_DetectsContactsKeyword() {
+        // Given: Request with "contacts" keyword
+        let request = NoemaRequest(query: "Show my contacts list")
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: toolRequired should be true
+        XCTAssertTrue(result.toolRequired, "Should detect 'contacts' as tool keyword")
+    }
+
+    func testToolRequired_DetectsAgentKeyword() {
+        // Given: Request with "agent" keyword
+        let request = NoemaRequest(query: "Use an agent to help me")
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: toolRequired should be true
+        XCTAssertTrue(result.toolRequired, "Should detect 'agent' as tool keyword")
+    }
+
+    func testToolRequired_NoToolKeywords() {
+        // Given: Request without tool keywords
+        let request = NoemaRequest(query: "What is the weather today?")
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: toolRequired should be false
+        XCTAssertFalse(result.toolRequired, "Should not detect tool requirement for general query")
+    }
+
+    // MARK: - Privacy Detection Tests
+
+    func testPrivacySensitive_DetectsAddressKeyword() {
+        // Given: Request with "address" keyword
+        let request = NoemaRequest(query: "What is my home address?")
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: privacySensitive should be true
+        XCTAssertTrue(result.privacySensitive, "Should detect 'address' as privacy keyword")
+    }
+
+    func testPrivacySensitive_DetectsPhoneKeyword() {
+        // Given: Request with "phone" keyword
+        let request = NoemaRequest(query: "Store my phone number")
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: privacySensitive should be true
+        XCTAssertTrue(result.privacySensitive, "Should detect 'phone' as privacy keyword")
+    }
+
+    func testPrivacySensitive_DetectsPassportKeyword() {
+        // Given: Request with "passport" keyword
+        let request = NoemaRequest(query: "My passport number is...")
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: privacySensitive should be true
+        XCTAssertTrue(result.privacySensitive, "Should detect 'passport' as privacy keyword")
+    }
+
+    func testPrivacySensitive_DetectsPersonalKeyword() {
+        // Given: Request with "personal" keyword
+        let request = NoemaRequest(query: "Here is my personal information")
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: privacySensitive should be true
+        XCTAssertTrue(result.privacySensitive, "Should detect 'personal' as privacy keyword")
+    }
+
+    func testPrivacySensitive_NoPrivacyKeywords() {
+        // Given: Request without privacy keywords
+        let request = NoemaRequest(query: "What is the capital of France?")
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: privacySensitive should be false
+        XCTAssertFalse(result.privacySensitive, "Should not detect privacy sensitivity for general query")
+    }
+
+    // MARK: - Latency Preference Tests
+
+    func testLowLatencyPreferred_ShortQuery() {
+        // Given: Short query (< 100 characters)
+        let request = NoemaRequest(query: "Hello")
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: lowLatencyPreferred should be true
+        XCTAssertTrue(result.lowLatencyPreferred, "Short queries should prefer low latency")
+    }
+
+    func testLowLatencyPreferred_LongQuery() {
+        // Given: Long query (>= 100 characters)
+        let longQuery = String(repeating: "a", count: 150)
+        let request = NoemaRequest(query: longQuery)
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: lowLatencyPreferred should be false
+        XCTAssertFalse(result.lowLatencyPreferred, "Long queries should not prefer low latency")
+    }
+
+    // MARK: - Combined Signal Tests
+
+    func testCombinedSignals_ToolAndPrivacy() {
+        // Given: Request with both tool and privacy keywords
+        let request = NoemaRequest(query: "Send an email with my phone number")
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: Both signals should be true
+        XCTAssertTrue(result.toolRequired, "Should detect tool requirement")
+        XCTAssertTrue(result.privacySensitive, "Should detect privacy sensitivity")
+    }
+
+    func testCombinedSignals_AllSignals() {
+        // Given: Short request with tool and privacy keywords
+        let request = NoemaRequest(query: "email my address")
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: All signals should be true
+        XCTAssertTrue(result.toolRequired, "Should detect tool requirement")
+        XCTAssertTrue(result.privacySensitive, "Should detect privacy sensitivity")
+        XCTAssertTrue(result.lowLatencyPreferred, "Should prefer low latency")
+    }
+
+    func testCombinedSignals_NoSignals() {
+        // Given: Long general query without keywords
+        let longQuery = "Tell me about the history of artificial intelligence and its development over the past several decades"
+        let request = NoemaRequest(query: longQuery)
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: No signals should be true
+        XCTAssertFalse(result.toolRequired, "Should not detect tool requirement")
+        XCTAssertFalse(result.privacySensitive, "Should not detect privacy sensitivity")
+        XCTAssertFalse(result.lowLatencyPreferred, "Should not prefer low latency")
+    }
+
+    // MARK: - Case Insensitivity Tests
+
+    func testCaseInsensitivity_UpperCase() {
+        // Given: Request with uppercase keywords
+        let request = NoemaRequest(query: "SHOW MY EMAIL ADDRESS")
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: Should detect keywords regardless of case
+        XCTAssertTrue(result.toolRequired, "Should detect keywords case-insensitively")
+        XCTAssertTrue(result.privacySensitive, "Should detect keywords case-insensitively")
+    }
+
+    func testCaseInsensitivity_MixedCase() {
+        // Given: Request with mixed case keywords
+        let request = NoemaRequest(query: "Send me an Email with my PhOnE number")
+
+        // When: Evaluating
+        let result = policyEngine.evaluate(request)
+
+        // Then: Should detect keywords regardless of case
+        XCTAssertTrue(result.toolRequired, "Should detect keywords case-insensitively")
+        XCTAssertTrue(result.privacySensitive, "Should detect keywords case-insensitively")
+    }
+}

--- a/NoesisNoemaTests/Runtime/RouterTests.swift
+++ b/NoesisNoemaTests/Runtime/RouterTests.swift
@@ -1,0 +1,301 @@
+// NoesisNoema - HybridRuntime: Hybrid Routing Runtime
+// Router Tests
+// Created: 2026-03-07
+// License: MIT License
+
+import XCTest
+@testable import NoesisNoema
+
+/// Tests for HybridRouter determinism and purity
+///
+/// These tests verify constitutional constraints (ADR-0000):
+/// - Side-effect freedom (run twice, compare results)
+/// - Determinism (same input → same output)
+/// - No randomness or time-based branching
+/// - Correct routing logic
+final class HybridRouterTests: XCTestCase {
+
+    var router: HybridRouter!
+
+    override func setUp() {
+        super.setUp()
+        router = HybridRouter()
+    }
+
+    override func tearDown() {
+        router = nil
+        super.tearDown()
+    }
+
+    // MARK: - Determinism Tests
+
+    func testDeterminism_SameInputProducesSameOutput() {
+        // Given: A PolicyResult
+        let policy = PolicyResult(
+            toolRequired: true,
+            privacySensitive: false,
+            lowLatencyPreferred: false
+        )
+
+        // When: Routing the same policy twice
+        let route1 = router.route(policy)
+        let route2 = router.route(policy)
+
+        // Then: Results must be identical (proves determinism)
+        XCTAssertEqual(route1, route2, "Router must be deterministic")
+    }
+
+    func testDeterminism_MultipleRoutingsProduceSameResults() {
+        // Given: A PolicyResult
+        let policy = PolicyResult(
+            toolRequired: false,
+            privacySensitive: true,
+            lowLatencyPreferred: false
+        )
+
+        // When: Routing 10 times
+        let routes = (0..<10).map { _ in router.route(policy) }
+
+        // Then: All routes must be identical
+        let firstRoute = routes[0]
+        for route in routes {
+            XCTAssertEqual(route, firstRoute, "All routings must produce identical results")
+        }
+    }
+
+    // MARK: - Rule 1: Tool Required → Remote Agent
+
+    func testRouting_ToolRequired_RoutesToRemoteAgent() {
+        // Given: Policy with toolRequired = true
+        let policy = PolicyResult(
+            toolRequired: true,
+            privacySensitive: false,
+            lowLatencyPreferred: false
+        )
+
+        // When: Routing
+        let route = router.route(policy)
+
+        // Then: Should route to remoteAgent
+        XCTAssertEqual(route, .cloud, "toolRequired should route to remoteAgent")
+    }
+
+    func testRouting_ToolRequired_OverridesOtherSignals() {
+        // Given: Policy with toolRequired = true and other signals also true
+        let policy = PolicyResult(
+            toolRequired: true,
+            privacySensitive: true,  // Would prefer local
+            lowLatencyPreferred: true  // Would prefer local
+        )
+
+        // When: Routing
+        let route = router.route(policy)
+
+        // Then: Should route to remoteAgent (toolRequired has priority)
+        XCTAssertEqual(route, .cloud, "toolRequired should override other signals")
+    }
+
+    // MARK: - Rule 2: Privacy Sensitive → Local LLM
+
+    func testRouting_PrivacySensitive_RoutesToLocalLLM() {
+        // Given: Policy with privacySensitive = true, toolRequired = false
+        let policy = PolicyResult(
+            toolRequired: false,
+            privacySensitive: true,
+            lowLatencyPreferred: false
+        )
+
+        // When: Routing
+        let route = router.route(policy)
+
+        // Then: Should route to localLLM
+        XCTAssertEqual(route, .local, "privacySensitive should route to localLLM")
+    }
+
+    func testRouting_PrivacySensitive_OverridesLowLatency() {
+        // Given: Policy with privacySensitive = true and lowLatencyPreferred = true
+        let policy = PolicyResult(
+            toolRequired: false,
+            privacySensitive: true,
+            lowLatencyPreferred: true
+        )
+
+        // When: Routing
+        let route = router.route(policy)
+
+        // Then: Should route to localLLM (privacy has priority over latency)
+        XCTAssertEqual(route, .local, "privacySensitive should route to localLLM")
+    }
+
+    // MARK: - Rule 3: Low Latency Preferred → Local LLM
+
+    func testRouting_LowLatencyPreferred_RoutesToLocalLLM() {
+        // Given: Policy with lowLatencyPreferred = true, others false
+        let policy = PolicyResult(
+            toolRequired: false,
+            privacySensitive: false,
+            lowLatencyPreferred: true
+        )
+
+        // When: Routing
+        let route = router.route(policy)
+
+        // Then: Should route to localLLM
+        XCTAssertEqual(route, .local, "lowLatencyPreferred should route to localLLM")
+    }
+
+    // MARK: - Rule 4: Default → Remote Agent
+
+    func testRouting_NoSignals_RoutesToRemoteAgent() {
+        // Given: Policy with all signals false
+        let policy = PolicyResult(
+            toolRequired: false,
+            privacySensitive: false,
+            lowLatencyPreferred: false
+        )
+
+        // When: Routing
+        let route = router.route(policy)
+
+        // Then: Should route to remoteAgent (default)
+        XCTAssertEqual(route, .cloud, "Default should route to remoteAgent")
+    }
+
+    // MARK: - Comprehensive Routing Matrix Tests
+
+    func testRoutingMatrix_AllCombinations() {
+        // Test all 8 possible combinations of boolean signals
+        let testCases: [(Bool, Bool, Bool, ExecutionRoute)] = [
+            // (toolRequired, privacySensitive, lowLatencyPreferred, expectedRoute)
+            (false, false, false, .cloud),  // Rule 4: Default
+            (false, false, true,  .local),     // Rule 3: Low latency
+            (false, true,  false, .local),     // Rule 2: Privacy
+            (false, true,  true,  .local),     // Rule 2: Privacy (overrides latency)
+            (true,  false, false, .cloud),  // Rule 1: Tool
+            (true,  false, true,  .cloud),  // Rule 1: Tool (overrides latency)
+            (true,  true,  false, .cloud),  // Rule 1: Tool (overrides privacy)
+            (true,  true,  true,  .cloud),  // Rule 1: Tool (overrides all)
+        ]
+
+        for (toolRequired, privacySensitive, lowLatencyPreferred, expectedRoute) in testCases {
+            // Given: Policy with specific combination
+            let policy = PolicyResult(
+                toolRequired: toolRequired,
+                privacySensitive: privacySensitive,
+                lowLatencyPreferred: lowLatencyPreferred
+            )
+
+            // When: Routing
+            let route = router.route(policy)
+
+            // Then: Should match expected route
+            XCTAssertEqual(
+                route,
+                expectedRoute,
+                "Policy(\(toolRequired), \(privacySensitive), \(lowLatencyPreferred)) should route to \(expectedRoute)"
+            )
+        }
+    }
+
+    // MARK: - Rule Priority Tests
+
+    func testRulePriority_ToolRequiredIsHighestPriority() {
+        // Given: Policy with toolRequired = true
+        let policy = PolicyResult(
+            toolRequired: true,
+            privacySensitive: true,
+            lowLatencyPreferred: true
+        )
+
+        // When: Routing
+        let route = router.route(policy)
+
+        // Then: Should route to remoteAgent (tool has highest priority)
+        XCTAssertEqual(route, .cloud, "toolRequired has highest priority")
+    }
+
+    func testRulePriority_PrivacySensitiveIsSecondPriority() {
+        // Given: Policy with privacySensitive = true, toolRequired = false
+        let policy = PolicyResult(
+            toolRequired: false,
+            privacySensitive: true,
+            lowLatencyPreferred: true
+        )
+
+        // When: Routing
+        let route = router.route(policy)
+
+        // Then: Should route to localLLM (privacy has second priority)
+        XCTAssertEqual(route, .local, "privacySensitive has second priority")
+    }
+
+    func testRulePriority_LowLatencyIsThirdPriority() {
+        // Given: Policy with lowLatencyPreferred = true, others false
+        let policy = PolicyResult(
+            toolRequired: false,
+            privacySensitive: false,
+            lowLatencyPreferred: true
+        )
+
+        // When: Routing
+        let route = router.route(policy)
+
+        // Then: Should route to localLLM (latency has third priority)
+        XCTAssertEqual(route, .local, "lowLatencyPreferred has third priority")
+    }
+
+    // MARK: - Integration Tests (PolicyEngine + Router)
+
+    func testIntegration_ToolQuery_RoutesToRemoteAgent() {
+        // Given: Request with tool keyword
+        let request = NoemaRequest(query: "Send an email to John")
+        let policyEngine = HybridPolicyEngine()
+
+        // When: Evaluating and routing
+        let policy = policyEngine.evaluate(request)
+        let route = router.route(policy)
+
+        // Then: Should route to remoteAgent
+        XCTAssertEqual(route, .cloud, "Tool queries should route to remoteAgent")
+    }
+
+    func testIntegration_PrivacyQuery_RoutesToLocalLLM() {
+        // Given: Request with privacy keyword
+        let request = NoemaRequest(query: "What is my phone number?")
+        let policyEngine = HybridPolicyEngine()
+
+        // When: Evaluating and routing
+        let policy = policyEngine.evaluate(request)
+        let route = router.route(policy)
+
+        // Then: Should route to localLLM
+        XCTAssertEqual(route, .local, "Privacy queries should route to localLLM")
+    }
+
+    func testIntegration_SimpleQuery_RoutesToLocalLLM() {
+        // Given: Short simple query
+        let request = NoemaRequest(query: "Hello")
+        let policyEngine = HybridPolicyEngine()
+
+        // When: Evaluating and routing
+        let policy = policyEngine.evaluate(request)
+        let route = router.route(policy)
+
+        // Then: Should route to localLLM (low latency)
+        XCTAssertEqual(route, .local, "Simple queries should route to localLLM")
+    }
+
+    func testIntegration_ComplexQuery_RoutesToRemoteAgent() {
+        // Given: Long complex query
+        let longQuery = "Tell me about the history of artificial intelligence and its development over the past several decades"
+        let request = NoemaRequest(query: longQuery)
+        let policyEngine = HybridPolicyEngine()
+
+        // When: Evaluating and routing
+        let policy = policyEngine.evaluate(request)
+        let route = router.route(policy)
+
+        // Then: Should route to remoteAgent (default for complex queries)
+        XCTAssertEqual(route, .cloud, "Complex queries should route to remoteAgent")
+    }
+}

--- a/Shared/NoesisNoemaApp.swift
+++ b/Shared/NoesisNoemaApp.swift
@@ -10,15 +10,12 @@ import SwiftUI
 #if os(macOS)
 @main
 struct NoesisNoemaApp: App {
-    // EPIC1 Phase 4-B: PolicyRulesStore and ExecutionCoordinator at App level
-    // Single long-lived instances, not created in View body
-    private let policyRulesStore = PolicyRulesStore()
-    private let executionCoordinator: ExecutionCoordinator
+    // Hybrid Runtime: Primary execution coordinator
+    private let executionCoordinator: ExecutionCoordinating
 
     init() {
-        // Inject PolicyRulesStore into ExecutionCoordinator
-        // Phase 4-B: Injected but not used yet (Phase 5 will use for policy evaluation)
-        self.executionCoordinator = ExecutionCoordinator(policyRulesProvider: policyRulesStore)
+        // Hybrid routing is the default execution pipeline
+        self.executionCoordinator = HybridExecutionCoordinator()
     }
 
     var body: some Scene {

--- a/Shared/Runtime/Execution/HybridExecutionCoordinator.swift
+++ b/Shared/Runtime/Execution/HybridExecutionCoordinator.swift
@@ -1,0 +1,87 @@
+// NoesisNoema - Hybrid Routing Runtime
+// ExecutionCoordinator - Orchestrates full runtime flow
+// Created: 2026-03-08
+// License: MIT License
+
+import Foundation
+
+/// Hybrid Execution Coordinator
+///
+/// Orchestrates the complete hybrid routing runtime flow:
+/// 1. Evaluate policy signals
+/// 2. Determine routing decision
+/// 3. Select appropriate executor
+/// 4. Execute query
+///
+/// Constitutional Constraints (ADR-0000):
+/// - Owns routing orchestration
+/// - Executors remain pure execution components
+/// - No fallback logic
+/// - No retry logic
+/// - No silent error recovery
+///
+/// This is the integration point for all hybrid runtime components.
+final class HybridExecutionCoordinator: ExecutionCoordinating {
+
+    /// Policy evaluation engine
+    private let policyEngine = HybridPolicyEngine()
+
+    /// Routing decision function
+    private let router = HybridRouter()
+
+    /// Local executor (on-device)
+    private let localExecutor: Executor
+
+    /// Agent executor (cloud)
+    private let agentExecutor: Executor
+
+    /// Initialize with executors
+    ///
+    /// - Parameters:
+    ///   - localExecutor: Executor for local execution (default: LocalExecutor)
+    ///   - agentExecutor: Executor for remote execution (default: AgentExecutor with HTTPAgentClient)
+    init(
+        localExecutor: Executor = LocalExecutor(),
+        agentExecutor: Executor = AgentExecutor(client: HTTPAgentClient())
+    ) {
+        self.localExecutor = localExecutor
+        self.agentExecutor = agentExecutor
+    }
+
+    /// Execute a request through the hybrid runtime
+    ///
+    /// Flow:
+    /// 1. PolicyEngine evaluates request → PolicyResult
+    /// 2. Router determines route → ExecutionRoute
+    /// 3. Select executor based on route
+    /// 4. Execute query → ExecutionResult
+    ///
+    /// - Parameter request: The NoemaRequest to execute
+    /// - Returns: NoemaResponse with output and session ID
+    /// - Throws: Execution errors (network, model failure, etc.)
+    func execute(request: NoemaRequest) async throws -> NoemaResponse {
+
+        // Step 1: Evaluate policy signals
+        let policy = policyEngine.evaluate(request)
+
+        // Step 2: Determine routing decision
+        let route = router.route(policy)
+
+        // Step 3: Select executor based on route
+        let executor: Executor = route == .local
+            ? localExecutor
+            : agentExecutor
+
+        // Step 4: Execute query
+        let result = try await executor.execute(
+            query: request.query,
+            sessionId: request.sessionId
+        )
+
+        // Step 5: Convert to NoemaResponse
+        return NoemaResponse(
+            text: result.output,
+            sessionId: request.sessionId
+        )
+    }
+}

--- a/Shared/Runtime/Execution/HybridRouter.swift
+++ b/Shared/Runtime/Execution/HybridRouter.swift
@@ -1,0 +1,53 @@
+// NoesisNoema - Hybrid Routing Runtime
+// Router - Pure decision function
+// Created: 2026-03-07
+// License: MIT License
+
+import Foundation
+
+/// Deterministic Router
+///
+/// Constitutional Constraints (ADR-0000):
+/// 1. MUST be side-effect free (no I/O, no logging, no state mutation)
+/// 2. MUST be deterministic (same input → same output)
+/// 3. MUST NOT contain randomness or time-based branching
+/// 4. MUST NOT execute tasks (only makes routing decisions)
+/// 5. MUST execute client-side only (never server-side)
+///
+/// The Router converts PolicyResult signals into ExecutionRoute decisions.
+/// It is a pure transformation function with zero side effects.
+///
+/// Routing Rules (Priority Order):
+/// 1. If toolRequired → .cloud (tools need cloud capabilities)
+/// 2. Else if privacySensitive → .local (privacy stays local)
+/// 3. Else if lowLatencyPreferred → .local (fast queries stay local)
+/// 4. Else → .cloud (default to cloud for complex queries)
+final class HybridRouter {
+
+    /// Route a policy evaluation result to an execution target
+    ///
+    /// This is a pure function with zero side effects.
+    /// Given identical PolicyResult input, it always produces the same ExecutionRoute.
+    ///
+    /// - Parameter policy: The PolicyResult from HybridPolicyEngine
+    /// - Returns: ExecutionRoute decision (.local or .cloud)
+    func route(_ policy: PolicyResult) -> ExecutionRoute {
+        // Rule 1: Tool requirements need cloud agent capabilities
+        if policy.toolRequired {
+            return .cloud
+        }
+
+        // Rule 2: Privacy-sensitive data stays on device
+        if policy.privacySensitive {
+            return .local
+        }
+
+        // Rule 3: Low-latency queries use local LLM
+        if policy.lowLatencyPreferred {
+            return .local
+        }
+
+        // Rule 4: Default to cloud for complex queries
+        return .cloud
+    }
+}

--- a/Shared/Runtime/Executors/AgentClient.swift
+++ b/Shared/Runtime/Executors/AgentClient.swift
@@ -1,0 +1,33 @@
+// NoesisNoema - Hybrid Routing Runtime
+// AgentClient Protocol
+// Created: 2026-03-08
+// License: MIT License
+
+import Foundation
+
+/// Agent Client protocol for remote agent communication
+///
+/// This protocol defines the interface for communicating with noema-agent API.
+/// The actual HTTP implementation will be provided in Phase3.
+///
+/// Constitutional Constraints (ADR-0000):
+/// - AgentClient is a pure I/O component (no business logic)
+/// - No routing decisions
+/// - No retry logic (errors propagate)
+/// - No fallback logic
+///
+/// Phase2: Protocol definition only
+/// Phase3: Concrete implementation in Networking/AgentClient.swift
+protocol AgentClient {
+    /// Query the remote agent
+    ///
+    /// - Parameters:
+    ///   - query: The user's query text
+    ///   - sessionId: Session identifier for context
+    /// - Returns: Response text from the agent
+    /// - Throws: Network errors, HTTP errors, parsing errors
+    func query(
+        query: String,
+        sessionId: UUID
+    ) async throws -> String
+}

--- a/Shared/Runtime/Executors/AgentExecutor.swift
+++ b/Shared/Runtime/Executors/AgentExecutor.swift
@@ -1,0 +1,62 @@
+// NoesisNoema - Hybrid Routing Runtime
+// AgentExecutor - Remote agent execution
+// Created: 2026-03-07
+// Updated: 2026-03-08 - Refactored to use AgentClient dependency injection
+// License: MIT License
+
+import Foundation
+
+/// Agent Executor
+///
+/// Executes queries via remote noema-agent API using AgentClient.
+///
+/// Constitutional Constraints (ADR-0000):
+/// - MUST NOT make routing decisions
+/// - MUST NOT change execution path
+/// - MUST NOT perform silent fallback
+/// - MUST NOT contain routing logic
+/// - MUST NOT mutate global state
+/// - MUST NOT retry automatically (errors must propagate)
+///
+/// Architectural Refinement (2026-03-08):
+/// - AgentExecutor delegates HTTP communication to AgentClient
+/// - Routing authority removed from ExecutionResult
+/// - Separation: Executor (orchestration) vs Client (I/O)
+final class AgentExecutor: Executor {
+
+    /// Agent client for HTTP communication
+    private let client: AgentClient
+
+    /// Initialize with agent client
+    /// - Parameter client: The AgentClient implementation for network communication
+    init(client: AgentClient) {
+        self.client = client
+    }
+
+    /// Execute query via remote agent
+    ///
+    /// - Parameters:
+    ///   - query: The user's query text
+    ///   - sessionId: Session identifier
+    /// - Returns: ExecutionResult with agent response
+    /// - Throws: Network errors, HTTP errors, parsing errors
+    func execute(
+        query: String,
+        sessionId: UUID
+    ) async throws -> ExecutionResult {
+
+        let traceId = UUID()
+
+        // Delegate to AgentClient for HTTP communication
+        let response = try await client.query(
+            query: query,
+            sessionId: sessionId
+        )
+
+        return ExecutionResult(
+            output: response,
+            traceId: traceId,
+            timestamp: Date()
+        )
+    }
+}

--- a/Shared/Runtime/Executors/ExecutionResult.swift
+++ b/Shared/Runtime/Executors/ExecutionResult.swift
@@ -1,0 +1,38 @@
+// NoesisNoema - Hybrid Routing Runtime
+// ExecutionResult data structure
+// Created: 2026-03-07
+// Updated: 2026-03-08 - Removed route field (routing authority belongs to Router)
+// License: MIT License
+
+import Foundation
+
+/// Structured execution result
+///
+/// This structure captures the outcome of execution.
+/// It is an immutable, deterministic container.
+///
+/// Constitutional Constraint (ADR-0000):
+/// - This is a pure data structure with no behavior
+/// - Executors produce this as output
+/// - All fields are immutable
+/// - Does NOT contain routing information (routing authority belongs to Router)
+struct ExecutionResult: Equatable {
+    /// The generated output text
+    let output: String
+
+    /// Unique trace identifier for observability
+    let traceId: UUID
+
+    /// Execution timestamp
+    let timestamp: Date
+
+    init(
+        output: String,
+        traceId: UUID,
+        timestamp: Date
+    ) {
+        self.output = output
+        self.traceId = traceId
+        self.timestamp = timestamp
+    }
+}

--- a/Shared/Runtime/Executors/ExecutorProtocol.swift
+++ b/Shared/Runtime/Executors/ExecutorProtocol.swift
@@ -1,0 +1,30 @@
+// NoesisNoema - Hybrid Routing Runtime
+// Executor Protocol
+// Created: 2026-03-07
+// License: MIT License
+
+import Foundation
+
+/// Executor protocol for execution layer components
+///
+/// Constitutional Constraints (ADR-0000):
+/// - Executors MUST NOT perform routing decisions
+/// - Executors MUST NOT mutate global state
+/// - Executors MUST NOT retry automatically (retry only if explicitly permitted)
+/// - Executors MUST NOT contain fallback logic
+///
+/// Executors receive execution instructions and carry them out.
+/// They do not decide where or how to execute.
+protocol Executor {
+    /// Execute a query and return structured result
+    ///
+    /// - Parameters:
+    ///   - query: The user's query text
+    ///   - sessionId: Session identifier for context
+    /// - Returns: ExecutionResult with output and metadata
+    /// - Throws: Execution errors (network, model failure, etc.)
+    func execute(
+        query: String,
+        sessionId: UUID
+    ) async throws -> ExecutionResult
+}

--- a/Shared/Runtime/Executors/LocalExecutor.swift
+++ b/Shared/Runtime/Executors/LocalExecutor.swift
@@ -1,0 +1,51 @@
+// NoesisNoema - Hybrid Routing Runtime
+// LocalExecutor - Local LLM execution
+// Created: 2026-03-07
+// License: MIT License
+
+import Foundation
+
+/// Local Executor
+///
+/// Executes queries using local llama.cpp runtime.
+///
+/// Constitutional Constraints (ADR-0000):
+/// - MUST NOT make routing decisions
+/// - MUST NOT change execution path
+/// - MUST NOT perform silent fallback
+/// - MUST NOT contain routing logic
+/// - MUST NOT mutate global state
+/// - MUST NOT retry automatically
+///
+/// Phase2 Note: This is a stub implementation.
+/// Phase3 will integrate actual llama.cpp runtime.
+final class LocalExecutor: Executor {
+
+    /// Execute query using local LLM
+    ///
+    /// Phase2: Returns stub response
+    /// Phase3: Will integrate llama.cpp
+    ///
+    /// - Parameters:
+    ///   - query: The user's query text
+    ///   - sessionId: Session identifier
+    /// - Returns: ExecutionResult with generated output
+    /// - Throws: Execution errors (model failure, etc.)
+    func execute(
+        query: String,
+        sessionId: UUID
+    ) async throws -> ExecutionResult {
+
+        let traceId = UUID()
+
+        // Phase2 stub response
+        // Phase3 TODO: Integrate llama.cpp runtime
+        let output = "[LOCAL LLM STUB] \(query)"
+
+        return ExecutionResult(
+            output: output,
+            traceId: traceId,
+            timestamp: Date()
+        )
+    }
+}

--- a/Shared/Runtime/Networking/HTTPAgentClient.swift
+++ b/Shared/Runtime/Networking/HTTPAgentClient.swift
@@ -1,0 +1,74 @@
+// NoesisNoema - Hybrid Routing Runtime
+// HTTPAgentClient - Concrete HTTP implementation
+// Created: 2026-03-08
+// License: MIT License
+
+import Foundation
+
+/// HTTP Agent Client
+///
+/// Concrete implementation of AgentClient protocol for HTTP communication
+/// with noema-agent API.
+///
+/// Constitutional Constraints (ADR-0000):
+/// - AgentClient is a pure I/O component (no business logic)
+/// - No routing decisions
+/// - No retry logic (errors propagate)
+/// - No fallback logic
+///
+/// This is the network layer that crosses the invocation boundary
+/// to communicate with the remote noema-agent runtime.
+final class HTTPAgentClient: AgentClient {
+
+    /// Agent endpoint URL
+    private let endpoint: URL
+
+    /// Initialize with agent endpoint
+    /// - Parameter endpoint: The noema-agent API endpoint URL (default: localhost:8080)
+    init(endpoint: String = "http://localhost:8080/v1/query") {
+        self.endpoint = URL(string: endpoint)!
+    }
+
+    /// Query the remote agent
+    ///
+    /// Sends HTTP POST request to noema-agent with JSON payload.
+    ///
+    /// - Parameters:
+    ///   - query: The user's query text
+    ///   - sessionId: Session identifier for context
+    /// - Returns: Response text from the agent
+    /// - Throws: URLError for network/HTTP errors
+    func query(
+        query: String,
+        sessionId: UUID
+    ) async throws -> String {
+
+        // Build HTTP POST request
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        // Build JSON payload
+        let payload: [String: Any] = [
+            "query": query,
+            "session_id": sessionId.uuidString
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+
+        // Execute HTTP request
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        // Validate HTTP response
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+
+        // Parse response as string
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}

--- a/Shared/Runtime/Policy/HybridPolicyEngine.swift
+++ b/Shared/Runtime/Policy/HybridPolicyEngine.swift
@@ -1,0 +1,61 @@
+// NoesisNoema - Hybrid Routing Runtime
+// PolicyEngine - Pure evaluation function
+// Created: 2026-03-07
+// License: MIT License
+
+import Foundation
+
+/// Deterministic Policy Engine
+///
+/// Constitutional Constraints (ADR-0000):
+/// 1. MUST be side-effect free (no I/O, no logging, no state mutation)
+/// 2. MUST be deterministic (same input → same output)
+/// 3. MUST NOT contain randomness or time-based branching
+/// 4. MUST NOT make routing decisions (only evaluates signals)
+///
+/// Analyzes a NoemaRequest and returns PolicyResult.
+/// Evaluates whether the request requires tools, contains sensitive data,
+/// or prefers low latency. These are signals for the Router, not decisions.
+final class HybridPolicyEngine {
+
+    /// Tool-related keywords that suggest tool/function calling is needed
+    private static let toolKeywords = [
+        "calendar", "email", "contacts", "tool", "agent",
+        "schedule", "meeting", "appointment", "remind", "notification"
+    ]
+
+    /// Privacy-sensitive keywords that indicate PII or sensitive data
+    private static let privacyKeywords = [
+        "address", "phone", "email", "passport", "personal",
+        "ssn", "social security", "credit card", "password",
+        "bank", "account", "salary", "medical", "health"
+    ]
+
+    /// Evaluate policy signals for a given request
+    ///
+    /// This is a pure function with zero side effects.
+    /// - Parameter request: The NoemaRequest to evaluate
+    /// - Returns: PolicyResult containing routing signals
+    func evaluate(_ request: NoemaRequest) -> PolicyResult {
+        let query = request.query.lowercased()
+
+        // Signal 1: Does request require tool/function calling?
+        let toolRequired = Self.toolKeywords.contains { keyword in
+            query.contains(keyword)
+        }
+
+        // Signal 2: Does request contain privacy-sensitive information?
+        let privacySensitive = Self.privacyKeywords.contains { keyword in
+            query.contains(keyword)
+        }
+
+        // Signal 3: Is low-latency preferred? (simple heuristic: short query)
+        let lowLatencyPreferred = query.count < 100
+
+        return PolicyResult(
+            toolRequired: toolRequired,
+            privacySensitive: privacySensitive,
+            lowLatencyPreferred: lowLatencyPreferred
+        )
+    }
+}

--- a/Shared/Runtime/Policy/PolicyResult.swift
+++ b/Shared/Runtime/Policy/PolicyResult.swift
@@ -1,0 +1,36 @@
+// NoesisNoema - Hybrid Routing Runtime
+// PolicyResult data structure
+// Created: 2026-03-07
+// License: MIT License
+
+import Foundation
+
+/// Policy evaluation result containing routing signals
+///
+/// This structure captures the outcome of policy evaluation.
+/// It contains signals (not decisions) that inform the Router.
+///
+/// Constitutional Constraint (ADR-0000):
+/// - This is a pure data structure with no behavior
+/// - It represents signals, not routing decisions
+/// - PolicyEngine produces this; Router consumes it
+struct PolicyResult: Equatable {
+    /// Does the request require tool/function calling capabilities?
+    let toolRequired: Bool
+
+    /// Does the request contain privacy-sensitive information?
+    let privacySensitive: Bool
+
+    /// Is low-latency response time preferred?
+    let lowLatencyPreferred: Bool
+
+    init(
+        toolRequired: Bool,
+        privacySensitive: Bool,
+        lowLatencyPreferred: Bool
+    ) {
+        self.toolRequired = toolRequired
+        self.privacySensitive = privacySensitive
+        self.lowLatencyPreferred = lowLatencyPreferred
+    }
+}

--- a/Shared/UI/MinimalClientView.swift
+++ b/Shared/UI/MinimalClientView.swift
@@ -16,7 +16,7 @@ class MinimalClientViewModel: ObservableObject {
     @Published var response: String = ""
     @Published var isProcessing: Bool = false
 
-    // EPIC1 Phase 4-A: ExecutionCoordinator injected via dependency
+    // Hybrid Runtime: ExecutionCoordinator injected via dependency
     private var executionCoordinator: ExecutionCoordinating
 
     init(executionCoordinator: ExecutionCoordinating) {
@@ -34,9 +34,8 @@ class MinimalClientViewModel: ObservableObject {
 
         let userPrompt = prompt
 
-        // Phase 4-A: Route through ExecutionCoordinator
-        // ExecutionCoordinator delegates to ModelManager (preserves current behavior)
-        // Router + PolicyEngine integration deferred to Phase 5
+        // Hybrid Runtime: Route through ExecutionCoordinator
+        // Full hybrid runtime: PolicyEngine → Router → Executor
         do {
             let request = NoemaRequest(query: userPrompt)
             let result = try await executionCoordinator.execute(request: request)
@@ -123,5 +122,6 @@ struct MinimalClientView: View {
 }
 
 #Preview {
-    MinimalClientView(executionCoordinator: ExecutionCoordinator())
+    // Hybrid Runtime is the default
+    MinimalClientView(executionCoordinator: HybridExecutionCoordinator())
 }


### PR DESCRIPTION
This refactor removes temporary project-management naming (EPIC, Phase)
from the production runtime code.

Changes:
- Renamed Shared/EPIC4 → Shared/Runtime
- Renamed EPIC4PolicyEngine → HybridPolicyEngine
- Renamed EPIC4Router → HybridRouter
- Renamed EPIC4ExecutionCoordinator → HybridExecutionCoordinator

Goals:
- Remove sprint/epic terminology from architecture
- Replace with domain-level naming
- Preserve runtime behavior

Verification:
- Build succeeded
- Runtime flow unchanged
- No EPIC references in runtime code