### PR TITLE
feat(policy): EPIC4 #68 Phase 1 — ConditionEvaluator protocol + parity tests

### DIFF
--- a/Apps/macOS/NoesisNoema/Tests/PolicyEngineTests/ConditionEvaluatorParityTests.swift
+++ b/Apps/macOS/NoesisNoema/Tests/PolicyEngineTests/ConditionEvaluatorParityTests.swift
@@ -1,0 +1,332 @@
+// NoesisNoema is a knowledge graph framework for building AI applications.
+// Phase 1 of EPIC4 #68 PolicyEngine extensibility.
+//
+// This test asserts that PolicyRule.evaluate(question:runtimeState:)
+// (the new protocol-based path landed in Phase 1) produces the same
+// per-rule match/no-match decision as the legacy PolicyEngine path
+// (the switch chain that still lives in PolicyEngine.swift) for every
+// fixture below.
+//
+// Phase 1's success criterion is exactly this: the new path is
+// behaviourally indistinguishable from the legacy path on the existing
+// surface. Phase 2 deletes the legacy path; if any divergence existed
+// at that point, this test would already be red and the deletion would
+// be unsafe. Hence the test is the gate, not the convenience.
+//
+// License: MIT License
+
+import XCTest
+@testable import NoesisNoema
+
+/// Parity test between the legacy PolicyEngine evaluation path and the
+/// new PolicyRule.evaluate(...) path introduced in Phase 1.
+///
+/// We do not call PolicyEngine.evaluate(...) here because that function
+/// also exercises sort + conflict resolution; we want a focused test on
+/// the per-rule match decision. Each fixture is a single rule plus a
+/// question; we assert the legacy and new evaluators agree on whether
+/// the rule matches.
+final class ConditionEvaluatorParityTests: XCTestCase {
+
+    // MARK: - Fixture helpers (style-aligned with PolicyEngineTests.swift)
+
+    private func makeQuestion(
+        content: String = "Test question",
+        privacyLevel: PrivacyLevel = .auto,
+        intent: Intent? = nil
+    ) -> NoemaQuestion {
+        NoemaQuestion(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+            content: content,
+            privacyLevel: privacyLevel,
+            intent: intent,
+            sessionId: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+        )
+    }
+
+    private func makeRuntimeState() -> RuntimeState {
+        let localCapability = LocalModelCapability(
+            modelName: "llama-3.2-8b",
+            maxTokens: 4096,
+            supportedIntents: [.informational, .retrieval],
+            available: true
+        )
+        return RuntimeState(
+            localModelCapability: localCapability,
+            networkState: .online,
+            tokenThreshold: 4096,
+            cloudModelName: "gpt-4"
+        )
+    }
+
+    private func makeRule(
+        conditions: [ConditionRule],
+        action: ConstraintAction = .warn(message: "parity")
+    ) -> PolicyRule {
+        PolicyRule(
+            id: UUID(uuidString: "00000000-0000-0000-0000-0000000000aa")!,
+            name: "parity-rule",
+            type: .privacy,
+            enabled: true,
+            priority: 1,
+            conditions: conditions,
+            action: action
+        )
+    }
+
+    /// Run the rule through both the legacy PolicyEngine path and the
+    /// new PolicyRule.evaluate path, and assert they agree on whether
+    /// the rule matched.
+    ///
+    /// We use the legacy path indirectly: PolicyEngine.evaluate with a
+    /// `.warn` action returns a result whose appliedConstraints is
+    /// non-empty iff the rule matched. The new path is queried directly.
+    private func assertParity(
+        rule: PolicyRule,
+        question: NoemaQuestion,
+        state: RuntimeState,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let legacyMatched: Bool
+        do {
+            let result = try PolicyEngine.evaluate(
+                question: question,
+                runtimeState: state,
+                rules: [rule]
+            )
+            legacyMatched = !result.appliedConstraints.isEmpty
+        } catch {
+            // A throw here would only happen for .block actions, which
+            // we do not use as the action for parity-test rules above.
+            XCTFail("Unexpected throw from legacy path: \(error)", file: file, line: line)
+            return
+        }
+
+        let newMatched = rule.evaluate(question: question, runtimeState: state)
+
+        XCTAssertEqual(
+            legacyMatched,
+            newMatched,
+            "Parity violation: legacy=\(legacyMatched) new=\(newMatched)",
+            file: file,
+            line: line
+        )
+    }
+
+    // MARK: - Content field
+
+    func testParity_Content_Contains_Match() {
+        let q = makeQuestion(content: "This contains SENSITIVE data")
+        let r = makeRule(conditions: [
+            ConditionRule(field: "content", operator: .contains, value: "sensitive")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    func testParity_Content_Contains_CaseInsensitive() {
+        let q = makeQuestion(content: "lowercase only")
+        let r = makeRule(conditions: [
+            ConditionRule(field: "content", operator: .contains, value: "LOWERCASE")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    func testParity_Content_Contains_NoMatch() {
+        let q = makeQuestion(content: "hello")
+        let r = makeRule(conditions: [
+            ConditionRule(field: "content", operator: .contains, value: "goodbye")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    func testParity_Content_Contains_PipeSeparatedOR_Match() {
+        let q = makeQuestion(content: "My password is secret")
+        let r = makeRule(conditions: [
+            ConditionRule(field: "content", operator: .contains, value: "SSN|password|credit card")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    func testParity_Content_Contains_PipeSeparatedOR_NoneMatch() {
+        let q = makeQuestion(content: "ordinary message")
+        let r = makeRule(conditions: [
+            ConditionRule(field: "content", operator: .contains, value: "SSN|password|credit card")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    func testParity_Content_NotContains() {
+        let q = makeQuestion(content: "hello world")
+        let r = makeRule(conditions: [
+            ConditionRule(field: "content", operator: .notContains, value: "goodbye")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    func testParity_Content_Equals_CaseInsensitive() {
+        let q = makeQuestion(content: "Hello")
+        let r = makeRule(conditions: [
+            ConditionRule(field: "content", operator: .equals, value: "hello")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    func testParity_Content_NotEquals() {
+        let q = makeQuestion(content: "Hello")
+        let r = makeRule(conditions: [
+            ConditionRule(field: "content", operator: .notEquals, value: "world")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    // MARK: - token_count field
+
+    func testParity_TokenCount_Exceeds_Match() {
+        let big = String(repeating: "word ", count: 6000) // ~7500 chars / 4 ≈ 1875 tokens
+        let q = makeQuestion(content: big)
+        let r = makeRule(conditions: [
+            ConditionRule(field: "token_count", operator: .exceeds, value: "1000")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    func testParity_TokenCount_Exceeds_NoMatch() {
+        let q = makeQuestion(content: "short")
+        let r = makeRule(conditions: [
+            ConditionRule(field: "token_count", operator: .exceeds, value: "1000")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    func testParity_TokenCount_LessThan() {
+        let q = makeQuestion(content: "short")
+        let r = makeRule(conditions: [
+            ConditionRule(field: "token_count", operator: .lessThan, value: "1000")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    func testParity_TokenCount_NonIntegerValue_DoesNotMatch() {
+        // PolicyEngine.evaluateNumericCondition: Int(condition.value) returns
+        // nil, falls through to `return false`. We want parity: new path also
+        // returns false (toEvaluator returns nil -> rule.evaluate returns false).
+        let q = makeQuestion(content: "short")
+        let r = makeRule(conditions: [
+            ConditionRule(field: "token_count", operator: .exceeds, value: "not a number")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    func testParity_TokenCount_StringOperator_DoesNotMatch() {
+        // .contains on token_count is a malformed rule. Legacy hits the
+        // `default: return false` in evaluateNumericCondition. New path
+        // returns false via toEvaluator -> nil.
+        let q = makeQuestion(content: "anything")
+        let r = makeRule(conditions: [
+            ConditionRule(field: "token_count", operator: .contains, value: "100")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    // MARK: - intent field
+
+    func testParity_Intent_Equals_Match() {
+        let q = makeQuestion(intent: .analytical)
+        let r = makeRule(conditions: [
+            ConditionRule(field: "intent", operator: .equals, value: "analytical")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    func testParity_Intent_Nil_DoesNotMatch() {
+        // question.intent is nil. Legacy: `guard let intent = ... else { return false }`.
+        // New: IntentCondition.evaluate same guard.
+        let q = makeQuestion(intent: nil)
+        let r = makeRule(conditions: [
+            ConditionRule(field: "intent", operator: .equals, value: "analytical")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    func testParity_Intent_NumericOperator_DoesNotMatch() {
+        // .exceeds on intent is malformed. Legacy hits default in
+        // evaluateStringCondition. New path returns false via toEvaluator.
+        let q = makeQuestion(intent: .analytical)
+        let r = makeRule(conditions: [
+            ConditionRule(field: "intent", operator: .exceeds, value: "1")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    // MARK: - privacy_level field
+
+    func testParity_PrivacyLevel_Equals_Match() {
+        let q = makeQuestion(privacyLevel: .auto)
+        let r = makeRule(conditions: [
+            ConditionRule(field: "privacy_level", operator: .equals, value: "auto")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    func testParity_PrivacyLevel_Equals_NoMatch() {
+        let q = makeQuestion(privacyLevel: .local)
+        let r = makeRule(conditions: [
+            ConditionRule(field: "privacy_level", operator: .equals, value: "auto")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    // MARK: - Unknown field
+
+    func testParity_UnknownField_DoesNotMatch() {
+        // Legacy: `default: return false`. New: toEvaluator returns nil ->
+        // rule.evaluate returns false.
+        let q = makeQuestion(content: "anything")
+        let r = makeRule(conditions: [
+            ConditionRule(field: "future_unimplemented_field", operator: .contains, value: "x")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    // MARK: - Multiple conditions (AND logic)
+
+    func testParity_MultipleConditions_AllMatch() {
+        let q = makeQuestion(content: "test query", privacyLevel: .auto)
+        let r = makeRule(conditions: [
+            ConditionRule(field: "content",       operator: .contains, value: "test"),
+            ConditionRule(field: "privacy_level", operator: .equals,   value: "auto")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    func testParity_MultipleConditions_OneFails() {
+        let q = makeQuestion(content: "test query", privacyLevel: .local)
+        let r = makeRule(conditions: [
+            ConditionRule(field: "content",       operator: .contains, value: "test"),
+            ConditionRule(field: "privacy_level", operator: .equals,   value: "auto")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    func testParity_MultipleConditions_OneIsUnknownField() {
+        // Even if other conditions match, an unknown field should drop
+        // the whole rule (AND logic + per-condition false).
+        let q = makeQuestion(content: "test query")
+        let r = makeRule(conditions: [
+            ConditionRule(field: "content", operator: .contains, value: "test"),
+            ConditionRule(field: "future",  operator: .contains, value: "x")
+        ])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+
+    // MARK: - Empty conditions
+
+    func testParity_EmptyConditions_Matches() {
+        // PolicyEngine.evaluateConditions: allSatisfy on empty list is true.
+        // PolicyRule.evaluate: same (loop body never executes; returns true).
+        let q = makeQuestion(content: "anything")
+        let r = makeRule(conditions: [])
+        assertParity(rule: r, question: q, state: makeRuntimeState())
+    }
+}

--- a/Shared/Policy/Conditions/ConditionEvaluator.swift
+++ b/Shared/Policy/Conditions/ConditionEvaluator.swift
@@ -1,0 +1,35 @@
+//
+//  ConditionEvaluator.swift
+//  NoesisNoema
+//
+//  Phase 1 of EPIC4 #68 PolicyEngine extensibility.
+//  See docs/EPIC4_Policy_Engine_Extensibility_Design.md (section 4.1).
+//
+//  Pure, deterministic predicate. No Sendable annotation, no actor
+//  isolation, no async. Concrete conformers are value-type structs.
+//
+//  License: MIT License
+//
+
+import Foundation
+
+/// A pure predicate that decides whether a single policy condition holds
+/// for a given question and runtime state.
+///
+/// Adding a new condition kind (for example, a future `TimeOfDayCondition`)
+/// is achieved by introducing a new struct that conforms to this protocol.
+/// `PolicyEngine` does not need to be modified.
+///
+/// Conformers MUST be deterministic, side-effect free, and synchronous.
+/// They MUST NOT throw, depend on `@MainActor` state, or perform any
+/// async or external call.
+protocol ConditionEvaluator {
+
+    /// Evaluate the condition.
+    ///
+    /// - Returns: `true` if the condition is satisfied, `false` otherwise.
+    func evaluate(
+        question: NoemaQuestion,
+        runtimeState: RuntimeState
+    ) -> Bool
+}

--- a/Shared/Policy/Conditions/ConditionRule+ToEvaluator.swift
+++ b/Shared/Policy/Conditions/ConditionRule+ToEvaluator.swift
@@ -1,0 +1,101 @@
+//
+//  ConditionRule+ToEvaluator.swift
+//  NoesisNoema
+//
+//  Phase 1 of EPIC4 #68. Adapter that lifts the existing ConditionRule
+//  (string-keyed data) to a concrete ConditionEvaluator (typed struct).
+//
+//  This adapter is the single field-name dispatch point for Phase 1.
+//  The current PolicyEngine.evaluateCondition switch is replicated
+//  here in spirit, but each branch now produces an evaluator instead
+//  of a Bool. Phase 2 deletes the engine-side switch; Phase 3 replaces
+//  this adapter when the storage representation changes.
+//
+//  License: MIT License
+//
+
+import Foundation
+
+extension ConditionRule {
+
+    /// Convert a serialized ConditionRule into its concrete evaluator.
+    ///
+    /// Returns `nil` for fields the current PolicyEngine treats as
+    /// "unknown field — does not match" (the `default: return false`
+    /// branch). The caller can then drop the condition or force the
+    /// rule to non-match, matching current semantics.
+    ///
+    /// For `token_count`, the operator must be a numeric one
+    /// (exceeds / lessThan / equals / notEquals). String operators
+    /// (contains / notContains) on `token_count` produce `nil`,
+    /// matching the `default: return false` behaviour of the current
+    /// evaluateNumericCondition.
+    ///
+    /// Conversely, string fields (content / intent / privacy_level)
+    /// with numeric operators (exceeds / lessThan) produce `nil`,
+    /// matching evaluateStringCondition's `default: return false`.
+    func toEvaluator() -> ConditionEvaluator? {
+        switch field {
+        case "content":
+            guard let mode = stringMode(from: `operator`) else { return nil }
+            return ContentCondition(
+                matcher: StringMatcher(mode: mode),
+                pattern: value
+            )
+
+        case "token_count":
+            guard let mode = numericMode(from: `operator`) else { return nil }
+            guard let threshold = Int(value) else { return nil }
+            return TokenCountCondition(
+                comparator: NumericComparator(mode: mode),
+                threshold: threshold
+            )
+
+        case "intent":
+            guard let mode = stringMode(from: `operator`) else { return nil }
+            return IntentCondition(
+                matcher: StringMatcher(mode: mode),
+                pattern: value
+            )
+
+        case "privacy_level":
+            guard let mode = stringMode(from: `operator`) else { return nil }
+            return PrivacyLevelCondition(
+                matcher: StringMatcher(mode: mode),
+                pattern: value
+            )
+
+        default:
+            // Unknown field — current PolicyEngine returns false here.
+            // The caller represents this as "no evaluator", which the
+            // PolicyRule.evaluate() helper treats as a non-match.
+            return nil
+        }
+    }
+
+    private func stringMode(from op: Operator) -> StringMatcher.Mode? {
+        switch op {
+        case .contains:    return .contains
+        case .notContains: return .notContains
+        case .equals:      return .equals
+        case .notEquals:   return .notEquals
+        case .exceeds, .lessThan:
+            // Numeric operators on string fields: current
+            // evaluateStringCondition returns false (default branch).
+            return nil
+        }
+    }
+
+    private func numericMode(from op: Operator) -> NumericComparator.Mode? {
+        switch op {
+        case .exceeds:     return .exceeds
+        case .lessThan:    return .lessThan
+        case .equals:      return .equals
+        case .notEquals:   return .notEquals
+        case .contains, .notContains:
+            // String operators on numeric fields: current
+            // evaluateNumericCondition returns false (default branch).
+            return nil
+        }
+    }
+}

--- a/Shared/Policy/Conditions/ContentCondition.swift
+++ b/Shared/Policy/Conditions/ContentCondition.swift
@@ -1,0 +1,30 @@
+//
+//  ContentCondition.swift
+//  NoesisNoema
+//
+//  Phase 1 of EPIC4 #68. Concrete ConditionEvaluator for the question's
+//  text content. Mirrors the `case "content":` branch of the current
+//  PolicyEngine.evaluateCondition.
+//
+//  License: MIT License
+//
+
+import Foundation
+
+/// Evaluates a string match against `NoemaQuestion.content`.
+///
+/// Equivalent to the current PolicyEngine behaviour for
+/// `condition.field == "content"`. Pattern semantics (lowercased,
+/// pipe-separated alternatives) are delegated to `StringMatcher`.
+struct ContentCondition: ConditionEvaluator {
+
+    let matcher: StringMatcher
+    let pattern: String
+
+    func evaluate(
+        question: NoemaQuestion,
+        runtimeState: RuntimeState
+    ) -> Bool {
+        matcher.matches(question.content, against: pattern)
+    }
+}

--- a/Shared/Policy/Conditions/IntentCondition.swift
+++ b/Shared/Policy/Conditions/IntentCondition.swift
@@ -1,0 +1,33 @@
+//
+//  IntentCondition.swift
+//  NoesisNoema
+//
+//  Phase 1 of EPIC4 #68. Concrete ConditionEvaluator for the question's
+//  intent classification. Mirrors the `case "intent":` branch of the
+//  current PolicyEngine.evaluateCondition.
+//
+//  License: MIT License
+//
+
+import Foundation
+
+/// Evaluates a string match against `NoemaQuestion.intent.rawValue`.
+///
+/// `NoemaQuestion.intent` is optional. When the intent has not been
+/// classified for this question, the condition does not match. This
+/// preserves the current PolicyEngine behaviour exactly:
+///
+///     guard let intent = question.intent else { return false }
+struct IntentCondition: ConditionEvaluator {
+
+    let matcher: StringMatcher
+    let pattern: String
+
+    func evaluate(
+        question: NoemaQuestion,
+        runtimeState: RuntimeState
+    ) -> Bool {
+        guard let intent = question.intent else { return false }
+        return matcher.matches(intent.rawValue, against: pattern)
+    }
+}

--- a/Shared/Policy/Conditions/PrivacyLevelCondition.swift
+++ b/Shared/Policy/Conditions/PrivacyLevelCondition.swift
@@ -1,0 +1,29 @@
+//
+//  PrivacyLevelCondition.swift
+//  NoesisNoema
+//
+//  Phase 1 of EPIC4 #68. Concrete ConditionEvaluator for the question's
+//  privacy classification. Mirrors the `case "privacy_level":` branch of
+//  the current PolicyEngine.evaluateCondition.
+//
+//  License: MIT License
+//
+
+import Foundation
+
+/// Evaluates a string match against `NoemaQuestion.privacyLevel.rawValue`.
+///
+/// Unlike `IntentCondition`, `privacyLevel` is non-optional on
+/// `NoemaQuestion`, so this evaluator always has a value to compare.
+struct PrivacyLevelCondition: ConditionEvaluator {
+
+    let matcher: StringMatcher
+    let pattern: String
+
+    func evaluate(
+        question: NoemaQuestion,
+        runtimeState: RuntimeState
+    ) -> Bool {
+        matcher.matches(question.privacyLevel.rawValue, against: pattern)
+    }
+}

--- a/Shared/Policy/Conditions/TokenCountCondition.swift
+++ b/Shared/Policy/Conditions/TokenCountCondition.swift
@@ -1,0 +1,38 @@
+//
+//  TokenCountCondition.swift
+//  NoesisNoema
+//
+//  Phase 1 of EPIC4 #68. Concrete ConditionEvaluator for an estimated
+//  token count of `NoemaQuestion.content`. Mirrors the `case "token_count":`
+//  branch of the current PolicyEngine.evaluateCondition.
+//
+//  License: MIT License
+//
+
+import Foundation
+
+/// Evaluates a numeric comparison against the estimated token count of
+/// `NoemaQuestion.content`.
+///
+/// Token estimation uses the same deterministic approximation as the
+/// current PolicyEngine: `max(1, content.count / 4)`. Comparison
+/// semantics are delegated to `NumericComparator`.
+struct TokenCountCondition: ConditionEvaluator {
+
+    let comparator: NumericComparator
+    let threshold: Int
+
+    func evaluate(
+        question: NoemaQuestion,
+        runtimeState: RuntimeState
+    ) -> Bool {
+        let count = Self.estimateTokenCount(question.content)
+        return comparator.matches(count, against: threshold)
+    }
+
+    /// Deterministic token estimation: ~4 characters per token, with a
+    /// floor of 1. Identical to PolicyEngine.estimateTokenCount.
+    static func estimateTokenCount(_ content: String) -> Int {
+        max(1, content.count / 4)
+    }
+}

--- a/Shared/Policy/Operators/NumericComparator.swift
+++ b/Shared/Policy/Operators/NumericComparator.swift
@@ -1,0 +1,42 @@
+//
+//  NumericComparator.swift
+//  NoesisNoema
+//
+//  Phase 1 of EPIC4 #68. Operator strategy for numeric-typed conditions.
+//  See docs/EPIC4_Policy_Engine_Extensibility_Design.md (section 4.2).
+//
+//  License: MIT License
+//
+
+import Foundation
+
+/// Value-typed comparison strategy for numeric-valued conditions.
+///
+/// Encapsulates the four current numeric operators. Adding a new mode
+/// (between, percentage, etc.) is a strategy-level change; condition
+/// types and `PolicyEngine` do not need to be touched.
+struct NumericComparator {
+
+    enum Mode {
+        case exceeds
+        case lessThan
+        case equals
+        case notEquals
+    }
+
+    let mode: Mode
+
+    /// Apply the strategy.
+    /// - Parameters:
+    ///   - candidate: The runtime value being checked.
+    ///   - threshold: The threshold from the rule.
+    /// - Returns: `true` if the candidate matches under this mode.
+    func matches(_ candidate: Int, against threshold: Int) -> Bool {
+        switch mode {
+        case .exceeds:    return candidate > threshold
+        case .lessThan:   return candidate < threshold
+        case .equals:     return candidate == threshold
+        case .notEquals:  return candidate != threshold
+        }
+    }
+}

--- a/Shared/Policy/Operators/StringMatcher.swift
+++ b/Shared/Policy/Operators/StringMatcher.swift
@@ -5,6 +5,13 @@
 //  Phase 1 of EPIC4 #68. Operator strategy for string-typed conditions.
 //  See docs/EPIC4_Policy_Engine_Extensibility_Design.md (section 4.2).
 //
+//  Semantics are kept strictly identical to the current
+//  PolicyEngine.evaluateStringCondition implementation. In particular,
+//  empty pattern alternatives are NOT filtered out, because the current
+//  implementation does not filter them either, and Swift's
+//  `String.contains("")` is `true`. Phase 1 commits to no behavioural
+//  change.
+//
 //  License: MIT License
 //
 
@@ -18,9 +25,9 @@ import Foundation
 ///
 /// `pattern` may contain pipe-separated alternatives (for example,
 /// `"SSN|password|credit card"`); a `.contains` match returns `true`
-/// when the candidate contains any of the alternatives. This preserves
-/// the semantics of the current `PolicyEngine.evaluateStringCondition`
-/// implementation.
+/// when the candidate contains any alternative. This preserves the
+/// semantics of the current `PolicyEngine.evaluateStringCondition`
+/// implementation byte-for-byte.
 struct StringMatcher {
 
     enum Mode {
@@ -38,27 +45,28 @@ struct StringMatcher {
     ///   - pattern: The pattern from the rule, possibly pipe-separated.
     /// - Returns: `true` if the candidate matches under this mode.
     func matches(_ candidate: String, against pattern: String) -> Bool {
+        // Lowercase the whole pattern first, then split. This matches
+        // the current PolicyEngine implementation exactly. Do NOT
+        // filter empty alternatives; Swift's `String.contains("")` is
+        // `true` and the current behaviour relies on that.
+        let conditionValue = pattern.lowercased()
+        let testValue = candidate.lowercased()
+        let patterns = conditionValue
+            .split(separator: "|")
+            .map { String($0).trimmingCharacters(in: .whitespaces) }
+
         switch mode {
         case .contains:
-            // Pipe-separated OR semantics, lowercase compare,
-            // matching the current implementation in PolicyEngine.
-            let lowered = candidate.lowercased()
-            return pattern
-                .split(separator: "|")
-                .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
-                .filter { !$0.isEmpty }
-                .contains(where: { lowered.contains($0) })
+            return patterns.contains { testValue.contains($0) }
 
         case .notContains:
-            return !StringMatcher(mode: .contains)
-                .matches(candidate, against: pattern)
+            return !patterns.contains { testValue.contains($0) }
 
         case .equals:
-            return candidate.compare(pattern, options: .caseInsensitive) == .orderedSame
+            return testValue == conditionValue
 
         case .notEquals:
-            return !StringMatcher(mode: .equals)
-                .matches(candidate, against: pattern)
+            return testValue != conditionValue
         }
     }
 }

--- a/Shared/Policy/Operators/StringMatcher.swift
+++ b/Shared/Policy/Operators/StringMatcher.swift
@@ -1,0 +1,64 @@
+//
+//  StringMatcher.swift
+//  NoesisNoema
+//
+//  Phase 1 of EPIC4 #68. Operator strategy for string-typed conditions.
+//  See docs/EPIC4_Policy_Engine_Extensibility_Design.md (section 4.2).
+//
+//  License: MIT License
+//
+
+import Foundation
+
+/// Value-typed comparison strategy for string-valued conditions.
+///
+/// Encapsulates the four current string operators. Adding a new mode
+/// (regex, fuzzyMatch, etc.) is a strategy-level change; condition
+/// types and `PolicyEngine` do not need to be touched.
+///
+/// `pattern` may contain pipe-separated alternatives (for example,
+/// `"SSN|password|credit card"`); a `.contains` match returns `true`
+/// when the candidate contains any of the alternatives. This preserves
+/// the semantics of the current `PolicyEngine.evaluateStringCondition`
+/// implementation.
+struct StringMatcher {
+
+    enum Mode {
+        case contains
+        case notContains
+        case equals
+        case notEquals
+    }
+
+    let mode: Mode
+
+    /// Apply the strategy.
+    /// - Parameters:
+    ///   - candidate: The runtime value being checked.
+    ///   - pattern: The pattern from the rule, possibly pipe-separated.
+    /// - Returns: `true` if the candidate matches under this mode.
+    func matches(_ candidate: String, against pattern: String) -> Bool {
+        switch mode {
+        case .contains:
+            // Pipe-separated OR semantics, lowercase compare,
+            // matching the current implementation in PolicyEngine.
+            let lowered = candidate.lowercased()
+            return pattern
+                .split(separator: "|")
+                .map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+                .filter { !$0.isEmpty }
+                .contains(where: { lowered.contains($0) })
+
+        case .notContains:
+            return !StringMatcher(mode: .contains)
+                .matches(candidate, against: pattern)
+
+        case .equals:
+            return candidate.compare(pattern, options: .caseInsensitive) == .orderedSame
+
+        case .notEquals:
+            return !StringMatcher(mode: .equals)
+                .matches(candidate, against: pattern)
+        }
+    }
+}

--- a/Shared/Policy/PolicyRule+Evaluate.swift
+++ b/Shared/Policy/PolicyRule+Evaluate.swift
@@ -1,0 +1,51 @@
+//
+//  PolicyRule+Evaluate.swift
+//  NoesisNoema
+//
+//  Phase 1 of EPIC4 #68. Adds a non-mutating `evaluate(...)` to PolicyRule
+//  so that the rule itself, not PolicyEngine, owns its evaluation.
+//
+//  The body delegates to ConditionRule.toEvaluator() per condition and
+//  ANDs the results, matching the current PolicyEngine.evaluateConditions
+//  behaviour byte-for-byte. Phase 2 deletes PolicyEngine's switch chain
+//  and routes via this method.
+//
+//  This file does NOT change PolicyRule's stored properties or its
+//  initializers. It only adds a method, so it is safe to land alongside
+//  the existing PolicyEngine path.
+//
+//  License: MIT License
+//
+
+import Foundation
+
+extension PolicyRule {
+
+    /// Evaluate this rule against a question and runtime state.
+    ///
+    /// All conditions must hold (AND logic). A condition that cannot be
+    /// converted to a `ConditionEvaluator` (unknown field, mismatched
+    /// operator/field combination, non-integer numeric value) is treated
+    /// as a non-match — identical to the current PolicyEngine behaviour
+    /// where such cases hit `default: return false` in the inner switch.
+    ///
+    /// - Returns: `true` if every condition holds, `false` otherwise.
+    func evaluate(
+        question: NoemaQuestion,
+        runtimeState: RuntimeState
+    ) -> Bool {
+        // AND logic: every condition must produce an evaluator AND
+        // every evaluator must return true. A nil evaluator (untranslatable
+        // condition) short-circuits the rule to non-match, just like the
+        // existing engine's `default: return false`.
+        for condition in conditions {
+            guard let evaluator = condition.toEvaluator() else {
+                return false
+            }
+            if !evaluator.evaluate(question: question, runtimeState: runtimeState) {
+                return false
+            }
+        }
+        return true
+    }
+}


### PR DESCRIPTION
## Type

Phase 1 implementation for **EPIC4 #68 — PolicyEngine extensibility**.

Code only. Design was approved separately and merged to main as `docs/EPIC4_Policy_Engine_Extensibility_Design.md`.

## What landed

10 small commits, each one independently reviewable, the whole thing additive to main. **Nothing existing is changed.** The new path runs *alongside* the legacy switch chain, not in place of it. Phase 2 will delete the legacy path; Phase 1 only proves they agree.

### New protocol

- `Shared/Policy/Conditions/ConditionEvaluator.swift` — pure synchronous predicate. No `Sendable` annotation, no actor isolation, no async, no throws. Per Max guidance.

### New strategy structs

- `Shared/Policy/Operators/StringMatcher.swift` — `contains` / `notContains` / `equals` / `notEquals` over strings. Pipe-separated OR alternatives, case-insensitive, **byte-for-byte** matching the current `PolicyEngine.evaluateStringCondition` (including the no-filter-on-empty-alternatives detail; see commit 4992f87).
- `Shared/Policy/Operators/NumericComparator.swift` — `exceeds` / `lessThan` / `equals` / `notEquals` over `Int`.

### New concrete conditions

- `Shared/Policy/Conditions/ContentCondition.swift`
- `Shared/Policy/Conditions/TokenCountCondition.swift` (with the same `max(1, content.count / 4)` token estimator, intentionally duplicated for self-containment; see the commit message for the cleanup deferral)
- `Shared/Policy/Conditions/IntentCondition.swift` (preserves the `guard let intent = ... else { return false }` semantic)
- `Shared/Policy/Conditions/PrivacyLevelCondition.swift`

### Adapter and rule-side evaluation

- `Shared/Policy/Conditions/ConditionRule+ToEvaluator.swift` — single dispatch point that converts a serialized `ConditionRule` into the appropriate concrete evaluator. Returns `nil` for every case where the legacy engine would have hit a `default: return false` (unknown field, mismatched operator/field, non-integer numeric value).
- `Shared/Policy/PolicyRule+Evaluate.swift` — `PolicyRule.evaluate(question:runtimeState:)`. AND logic over conditions; a `nil` evaluator short-circuits to `false`.

### Parity test

- `Apps/macOS/NoesisNoema/Tests/PolicyEngineTests/ConditionEvaluatorParityTests.swift` — 23 fixtures, each asserting that the legacy `PolicyEngine.evaluate` and the new `PolicyRule.evaluate` agree on whether the rule matches.

## What did NOT change

- `PolicyEngine.swift` is untouched.
- `PolicyRule.swift` is untouched.
- `ConditionRule.swift`, `Operator.swift`, `ConstraintAction.swift` are untouched.
- `ConstraintStore.swift` (JSON persistence) is untouched.
- `EditablePolicyRule.swift` and the entire `Constraint*View*` family are untouched.
- Existing `PolicyEngineTests`, `ConstraintPersistenceTests`, `RouterDeterminismTests`, `ExecutionCoordinatorTests` are untouched.
- The 4-step evaluation algorithm and the `BLOCK > FORCE_LOCAL > FORCE_CLOUD > REQUIRE_CONFIRMATION > WARN` precedence hierarchy are unchanged.
- No `Sendable`, no `nonisolated`, no async anywhere.

## Why parallel paths in Phase 1

The design (section 4 + 7) commits to a parallel-path approach:
- Phase 1 introduces the new path.
- Both paths run on the same inputs.
- The parity test guarantees they produce identical match/no-match decisions.
- Phase 2 deletes the legacy path — knowing in advance that no behaviour can shift.

Doing it in two phases keeps every individual commit small and reverts cheap.

## Phase 1 success criterion

`ConditionEvaluatorParityTests` passes locally (and once `ci.yml` is wired to actually run XCTest in a follow-up, it will gate Phase 2 there too).

## What I'd appreciate Taka eyes on specifically

1. **Commit 4992f87** — the StringMatcher self-correction. I caught myself adding `.filter { !$0.isEmpty }` that the legacy path doesn't have. Confirming you'd prefer me to flag those self-catches in commit messages this way (rather than silently fix them in the previous commit's content).
2. **TokenCountCondition** duplicates `estimateTokenCount` instead of reaching into PolicyEngine. The other choice was to make `PolicyEngine.estimateTokenCount` `internal`. I picked duplication because the design (§4.5) says conditions should be self-contained. Acceptable for Phase 1?
3. **`toEvaluator()` returning `nil`** is the central mechanism for preserving the legacy `default: return false` paths. Any cleaner alternative you'd want to see (e.g., a `NoOpCondition` that always returns false)? I considered it and went with `nil` because it removes a vacuous type from the catalogue, but I'm willing to flip if you prefer.
4. **Parity test count** — 23 fixtures. Anything obviously missing? I deliberately did not include throwing actions (`.block`) in the parity tests because they short-circuit before the per-rule match decision.

## Status

Draft. Moves to Ready for Review after Taka's first pass. After approval, **a separate PR** (not this one) will land Phase 2.

## Related

- Branch: `feature/ep4-issue68-phase1-condition-evaluator` (will be deleted on merge per Taka's flow)
- Design: `docs/EPIC4_Policy_Engine_Extensibility_Design.md` (in main)
- Issue: #68 (closes after Phase 4 ships)
- Predecessor: original PolicyEngine implementation by Claude (Sonnet 4.6) via Copilot; this PR is Opus 4.7 reforming that work under Taka's adjudication.
