### PR TITLE
refactor(policy): EPIC4 #68 Phase 2 — PolicyEngine becomes a pure orchestrator

### DIFF
--- a/Apps/macOS/NoesisNoema/Tests/PolicyEngineTests/ConditionEvaluatorParityTests.swift
+++ b/Apps/macOS/NoesisNoema/Tests/PolicyEngineTests/ConditionEvaluatorParityTests.swift
@@ -1,31 +1,45 @@
 // NoesisNoema is a knowledge graph framework for building AI applications.
-// Phase 1 of EPIC4 #68 PolicyEngine extensibility.
+// EPIC4 #68 PolicyEngine extensibility.
 //
-// This test asserts that PolicyRule.evaluate(question:runtimeState:)
-// (the new protocol-based path landed in Phase 1) produces the same
-// per-rule match/no-match decision as the legacy PolicyEngine path
-// (the switch chain that still lives in PolicyEngine.swift) for every
-// fixture below.
+// History:
+//   - Phase 1 introduced this test as a parity gate. It compared the
+//     legacy PolicyEngine switch chain against the new
+//     PolicyRule.evaluate(...) path, asserting they produced identical
+//     match decisions across the fixtures below.
+//   - Phase 2 deleted the legacy path. The two paths were behaviourally
+//     equivalent at that point (this test was green at merge time),
+//     making the deletion safe.
+//   - Post-Phase 2, this test is no longer comparing two paths — there
+//     is only one path. Each fixture now exercises that single path
+//     and asserts the expected match/no-match decision encoded in the
+//     test name. The test continues to serve as a regression detector
+//     for the per-condition decisions that the legacy switch used to
+//     enforce, particularly the `default: return false` cases.
 //
-// Phase 1's success criterion is exactly this: the new path is
-// behaviourally indistinguishable from the legacy path on the existing
-// surface. Phase 2 deletes the legacy path; if any divergence existed
-// at that point, this test would already be red and the deletion would
-// be unsafe. Hence the test is the gate, not the convenience.
+// What each test name encodes:
+//   - "*_Match" — the rule SHOULD match this question.
+//   - "*_NoMatch" — the rule should NOT match this question.
+//   - "*_DoesNotMatch" — historically a `default: return false` case
+//     in the legacy engine; should not match (asserted explicitly).
 //
 // License: MIT License
 
 import XCTest
 @testable import NoesisNoema
 
-/// Parity test between the legacy PolicyEngine evaluation path and the
-/// new PolicyRule.evaluate(...) path introduced in Phase 1.
+/// Per-condition match-decision regression tests for the
+/// PolicyRule.evaluate(...) path.
 ///
 /// We do not call PolicyEngine.evaluate(...) here because that function
 /// also exercises sort + conflict resolution; we want a focused test on
 /// the per-rule match decision. Each fixture is a single rule plus a
-/// question; we assert the legacy and new evaluators agree on whether
-/// the rule matches.
+/// question; we assert via PolicyEngine that the rule produces the
+/// expected match outcome.
+///
+/// See file header for the historical context: this test started life
+/// as a parity gate between the legacy PolicyEngine switch chain and
+/// the new ConditionEvaluator-based path. Phase 2 removed the legacy
+/// path; this test is preserved as a regression detector.
 final class ConditionEvaluatorParityTests: XCTestCase {
 
     // MARK: - Fixture helpers (style-aligned with PolicyEngineTests.swift)
@@ -74,44 +88,56 @@ final class ConditionEvaluatorParityTests: XCTestCase {
         )
     }
 
-    /// Run the rule through both the legacy PolicyEngine path and the
-    /// new PolicyRule.evaluate path, and assert they agree on whether
-    /// the rule matched.
+    /// Run the rule through the (now sole) PolicyEngine path, and assert
+    /// the per-rule match outcome. We use PolicyEngine.evaluate with a
+    /// `.warn` action: appliedConstraints is non-empty iff the rule
+    /// matched.
     ///
-    /// We use the legacy path indirectly: PolicyEngine.evaluate with a
-    /// `.warn` action returns a result whose appliedConstraints is
-    /// non-empty iff the rule matched. The new path is queried directly.
-    private func assertParity(
+    /// `expected` encodes the historical decision the legacy switch
+    /// chain produced for this fixture; preserving that decision is
+    /// the regression contract.
+    private func assertMatchDecision(
         rule: PolicyRule,
         question: NoemaQuestion,
         state: RuntimeState,
+        expected: Bool,
         file: StaticString = #file,
         line: UInt = #line
     ) {
-        let legacyMatched: Bool
         do {
             let result = try PolicyEngine.evaluate(
                 question: question,
                 runtimeState: state,
                 rules: [rule]
             )
-            legacyMatched = !result.appliedConstraints.isEmpty
+            let matched = !result.appliedConstraints.isEmpty
+            XCTAssertEqual(
+                matched,
+                expected,
+                "Match decision regression: matched=\(matched) expected=\(expected)",
+                file: file,
+                line: line
+            )
         } catch {
-            // A throw here would only happen for .block actions, which
-            // we do not use as the action for parity-test rules above.
-            XCTFail("Unexpected throw from legacy path: \(error)", file: file, line: line)
-            return
+            // A throw would only happen for .block actions, which we do
+            // not use as the action for these regression rules.
+            XCTFail("Unexpected throw from engine: \(error)", file: file, line: line)
         }
+    }
 
-        let newMatched = rule.evaluate(question: question, runtimeState: state)
-
-        XCTAssertEqual(
-            legacyMatched,
-            newMatched,
-            "Parity violation: legacy=\(legacyMatched) new=\(newMatched)",
-            file: file,
-            line: line
-        )
+    // Convenience wrappers that read better at call sites than passing
+    // a raw `expected:` everywhere. Each call site already states the
+    // expected outcome in its test name; these helpers make that
+    // contract explicit.
+    private func assertMatches(rule: PolicyRule, question: NoemaQuestion, state: RuntimeState,
+                               file: StaticString = #file, line: UInt = #line) {
+        assertMatchDecision(rule: rule, question: question, state: state,
+                            expected: true, file: file, line: line)
+    }
+    private func assertDoesNotMatch(rule: PolicyRule, question: NoemaQuestion, state: RuntimeState,
+                                    file: StaticString = #file, line: UInt = #line) {
+        assertMatchDecision(rule: rule, question: question, state: state,
+                            expected: false, file: file, line: line)
     }
 
     // MARK: - Content field
@@ -121,7 +147,7 @@ final class ConditionEvaluatorParityTests: XCTestCase {
         let r = makeRule(conditions: [
             ConditionRule(field: "content", operator: .contains, value: "sensitive")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertMatches(rule: r, question: q, state: makeRuntimeState())
     }
 
     func testParity_Content_Contains_CaseInsensitive() {
@@ -129,7 +155,7 @@ final class ConditionEvaluatorParityTests: XCTestCase {
         let r = makeRule(conditions: [
             ConditionRule(field: "content", operator: .contains, value: "LOWERCASE")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertMatches(rule: r, question: q, state: makeRuntimeState())
     }
 
     func testParity_Content_Contains_NoMatch() {
@@ -137,7 +163,7 @@ final class ConditionEvaluatorParityTests: XCTestCase {
         let r = makeRule(conditions: [
             ConditionRule(field: "content", operator: .contains, value: "goodbye")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertDoesNotMatch(rule: r, question: q, state: makeRuntimeState())
     }
 
     func testParity_Content_Contains_PipeSeparatedOR_Match() {
@@ -145,7 +171,7 @@ final class ConditionEvaluatorParityTests: XCTestCase {
         let r = makeRule(conditions: [
             ConditionRule(field: "content", operator: .contains, value: "SSN|password|credit card")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertMatches(rule: r, question: q, state: makeRuntimeState())
     }
 
     func testParity_Content_Contains_PipeSeparatedOR_NoneMatch() {
@@ -153,7 +179,7 @@ final class ConditionEvaluatorParityTests: XCTestCase {
         let r = makeRule(conditions: [
             ConditionRule(field: "content", operator: .contains, value: "SSN|password|credit card")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertDoesNotMatch(rule: r, question: q, state: makeRuntimeState())
     }
 
     func testParity_Content_NotContains() {
@@ -161,7 +187,7 @@ final class ConditionEvaluatorParityTests: XCTestCase {
         let r = makeRule(conditions: [
             ConditionRule(field: "content", operator: .notContains, value: "goodbye")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertMatches(rule: r, question: q, state: makeRuntimeState())
     }
 
     func testParity_Content_Equals_CaseInsensitive() {
@@ -169,7 +195,7 @@ final class ConditionEvaluatorParityTests: XCTestCase {
         let r = makeRule(conditions: [
             ConditionRule(field: "content", operator: .equals, value: "hello")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertMatches(rule: r, question: q, state: makeRuntimeState())
     }
 
     func testParity_Content_NotEquals() {
@@ -177,7 +203,7 @@ final class ConditionEvaluatorParityTests: XCTestCase {
         let r = makeRule(conditions: [
             ConditionRule(field: "content", operator: .notEquals, value: "world")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertMatches(rule: r, question: q, state: makeRuntimeState())
     }
 
     // MARK: - token_count field
@@ -188,7 +214,7 @@ final class ConditionEvaluatorParityTests: XCTestCase {
         let r = makeRule(conditions: [
             ConditionRule(field: "token_count", operator: .exceeds, value: "1000")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertMatches(rule: r, question: q, state: makeRuntimeState())
     }
 
     func testParity_TokenCount_Exceeds_NoMatch() {
@@ -196,7 +222,7 @@ final class ConditionEvaluatorParityTests: XCTestCase {
         let r = makeRule(conditions: [
             ConditionRule(field: "token_count", operator: .exceeds, value: "1000")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertDoesNotMatch(rule: r, question: q, state: makeRuntimeState())
     }
 
     func testParity_TokenCount_LessThan() {
@@ -204,29 +230,29 @@ final class ConditionEvaluatorParityTests: XCTestCase {
         let r = makeRule(conditions: [
             ConditionRule(field: "token_count", operator: .lessThan, value: "1000")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertMatches(rule: r, question: q, state: makeRuntimeState())
     }
 
     func testParity_TokenCount_NonIntegerValue_DoesNotMatch() {
-        // PolicyEngine.evaluateNumericCondition: Int(condition.value) returns
-        // nil, falls through to `return false`. We want parity: new path also
-        // returns false (toEvaluator returns nil -> rule.evaluate returns false).
+        // Historical legacy semantic: Int(condition.value) returns nil
+        // and the rule does not match. Preserved by ConditionRule.toEvaluator
+        // returning nil for non-integer numeric values.
         let q = makeQuestion(content: "short")
         let r = makeRule(conditions: [
             ConditionRule(field: "token_count", operator: .exceeds, value: "not a number")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertDoesNotMatch(rule: r, question: q, state: makeRuntimeState())
     }
 
     func testParity_TokenCount_StringOperator_DoesNotMatch() {
-        // .contains on token_count is a malformed rule. Legacy hits the
-        // `default: return false` in evaluateNumericCondition. New path
-        // returns false via toEvaluator -> nil.
+        // Historical legacy semantic: .contains on token_count is
+        // malformed and the rule does not match. Preserved by the
+        // numeric/string operator gating in toEvaluator.
         let q = makeQuestion(content: "anything")
         let r = makeRule(conditions: [
             ConditionRule(field: "token_count", operator: .contains, value: "100")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertDoesNotMatch(rule: r, question: q, state: makeRuntimeState())
     }
 
     // MARK: - intent field
@@ -236,27 +262,28 @@ final class ConditionEvaluatorParityTests: XCTestCase {
         let r = makeRule(conditions: [
             ConditionRule(field: "intent", operator: .equals, value: "analytical")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertMatches(rule: r, question: q, state: makeRuntimeState())
     }
 
     func testParity_Intent_Nil_DoesNotMatch() {
-        // question.intent is nil. Legacy: `guard let intent = ... else { return false }`.
-        // New: IntentCondition.evaluate same guard.
+        // Historical legacy semantic: `guard let intent = ... else { return false }`.
+        // Preserved by IntentCondition.evaluate's same guard.
         let q = makeQuestion(intent: nil)
         let r = makeRule(conditions: [
             ConditionRule(field: "intent", operator: .equals, value: "analytical")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertDoesNotMatch(rule: r, question: q, state: makeRuntimeState())
     }
 
     func testParity_Intent_NumericOperator_DoesNotMatch() {
-        // .exceeds on intent is malformed. Legacy hits default in
-        // evaluateStringCondition. New path returns false via toEvaluator.
+        // Historical legacy semantic: numeric operator on string field
+        // hit the inner switch's `default: return false`. Preserved by
+        // toEvaluator returning nil.
         let q = makeQuestion(intent: .analytical)
         let r = makeRule(conditions: [
             ConditionRule(field: "intent", operator: .exceeds, value: "1")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertDoesNotMatch(rule: r, question: q, state: makeRuntimeState())
     }
 
     // MARK: - privacy_level field
@@ -266,7 +293,7 @@ final class ConditionEvaluatorParityTests: XCTestCase {
         let r = makeRule(conditions: [
             ConditionRule(field: "privacy_level", operator: .equals, value: "auto")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertMatches(rule: r, question: q, state: makeRuntimeState())
     }
 
     func testParity_PrivacyLevel_Equals_NoMatch() {
@@ -274,19 +301,19 @@ final class ConditionEvaluatorParityTests: XCTestCase {
         let r = makeRule(conditions: [
             ConditionRule(field: "privacy_level", operator: .equals, value: "auto")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertDoesNotMatch(rule: r, question: q, state: makeRuntimeState())
     }
 
     // MARK: - Unknown field
 
     func testParity_UnknownField_DoesNotMatch() {
-        // Legacy: `default: return false`. New: toEvaluator returns nil ->
-        // rule.evaluate returns false.
+        // Historical legacy semantic: outer `default: return false` for
+        // unknown field name. Preserved by toEvaluator returning nil.
         let q = makeQuestion(content: "anything")
         let r = makeRule(conditions: [
             ConditionRule(field: "future_unimplemented_field", operator: .contains, value: "x")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertDoesNotMatch(rule: r, question: q, state: makeRuntimeState())
     }
 
     // MARK: - Multiple conditions (AND logic)
@@ -297,7 +324,7 @@ final class ConditionEvaluatorParityTests: XCTestCase {
             ConditionRule(field: "content",       operator: .contains, value: "test"),
             ConditionRule(field: "privacy_level", operator: .equals,   value: "auto")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertMatches(rule: r, question: q, state: makeRuntimeState())
     }
 
     func testParity_MultipleConditions_OneFails() {
@@ -306,7 +333,7 @@ final class ConditionEvaluatorParityTests: XCTestCase {
             ConditionRule(field: "content",       operator: .contains, value: "test"),
             ConditionRule(field: "privacy_level", operator: .equals,   value: "auto")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertDoesNotMatch(rule: r, question: q, state: makeRuntimeState())
     }
 
     func testParity_MultipleConditions_OneIsUnknownField() {
@@ -317,16 +344,16 @@ final class ConditionEvaluatorParityTests: XCTestCase {
             ConditionRule(field: "content", operator: .contains, value: "test"),
             ConditionRule(field: "future",  operator: .contains, value: "x")
         ])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertDoesNotMatch(rule: r, question: q, state: makeRuntimeState())
     }
 
     // MARK: - Empty conditions
 
     func testParity_EmptyConditions_Matches() {
-        // PolicyEngine.evaluateConditions: allSatisfy on empty list is true.
+        // Historical legacy semantic: allSatisfy on empty list is true.
         // PolicyRule.evaluate: same (loop body never executes; returns true).
         let q = makeQuestion(content: "anything")
         let r = makeRule(conditions: [])
-        assertParity(rule: r, question: q, state: makeRuntimeState())
+        assertMatches(rule: r, question: q, state: makeRuntimeState())
     }
 }

--- a/Shared/Policy/PolicyEngine.swift
+++ b/Shared/Policy/PolicyEngine.swift
@@ -1,11 +1,18 @@
 // NoesisNoema is a knowledge graph framework for building AI applications.
 // This file implements the deterministic Policy Engine as a pure function.
 // Created: 2026-02-21
+// Phase 2 of EPIC4 #68: PolicyEngine reduced to a pure orchestrator.
+//   - STEP 3 now delegates per-rule evaluation to PolicyRule.evaluate(...).
+//   - The legacy switch-chain (evaluateConditions / evaluateCondition /
+//     evaluateStringCondition / evaluateNumericCondition / estimateTokenCount)
+//     has been removed. Its responsibilities now live in
+//     Shared/Policy/Conditions/* and Shared/Policy/Operators/*, behind the
+//     ConditionEvaluator protocol.
 // License: MIT License
 
 import Foundation
 
-/// Deterministic Policy Engine - Pure Function Implementation
+/// Deterministic Policy Engine - Pure Orchestrator
 ///
 /// Purity Contract:
 /// 1. Deterministic: Same inputs → same outputs (always)
@@ -16,11 +23,18 @@ import Foundation
 /// Evaluation Order (Section 3.7):
 /// Step 1: Filter enabled constraints
 /// Step 2: Sort by (priority, id) for deterministic ordering
-/// Step 3: Evaluate conditions and collect matching constraints
+/// Step 3: Evaluate each rule via PolicyRule.evaluate(...) and collect matches
 /// Step 4: Apply conflict resolution with precedence hierarchy
 ///
 /// Precedence Hierarchy (Section 3.7):
 /// BLOCK > FORCE_LOCAL > FORCE_CLOUD > REQUIRE_CONFIRMATION > WARN
+///
+/// Extensibility (EPIC4 #68):
+/// New condition kinds and new operators are added by introducing new
+/// `ConditionEvaluator`-conforming structs and new operator strategy
+/// structs respectively. PolicyEngine itself is not modified for those
+/// additions; it operates uniformly on whatever evaluators a PolicyRule
+/// resolves to.
 struct PolicyEngine {
 
     /// Evaluate policy constraints against a question
@@ -48,10 +62,13 @@ struct PolicyEngine {
             }
         }
 
-        // STEP 3: Evaluate conditions and collect matching constraints
+        // STEP 3: Evaluate conditions and collect matching constraints.
+        // Per-rule evaluation is owned by PolicyRule itself (Phase 1
+        // introduced `PolicyRule.evaluate(question:runtimeState:)`).
+        // PolicyEngine no longer inspects the shape of any condition.
         var matchedRules: [PolicyRule] = []
         for rule in sortedRules {
-            if evaluateConditions(rule.conditions, question: question, runtimeState: runtimeState) {
+            if rule.evaluate(question: question, runtimeState: runtimeState) {
                 matchedRules.append(rule)
             }
         }
@@ -61,119 +78,6 @@ struct PolicyEngine {
     }
 
     // MARK: - Private Pure Functions
-
-    /// Evaluate all conditions for a constraint (AND logic)
-    /// - Parameters:
-    ///   - conditions: List of conditions to evaluate
-    ///   - question: The question being evaluated
-    ///   - runtimeState: Current runtime state
-    /// - Returns: True if all conditions match, false otherwise
-    private static func evaluateConditions(
-        _ conditions: [ConditionRule],
-        question: NoemaQuestion,
-        runtimeState: RuntimeState
-    ) -> Bool {
-        // All conditions must be true (AND logic)
-        return conditions.allSatisfy { condition in
-            evaluateCondition(condition, question: question, runtimeState: runtimeState)
-        }
-    }
-
-    /// Evaluate a single condition
-    /// - Parameters:
-    ///   - condition: The condition to evaluate
-    ///   - question: The question being evaluated
-    ///   - runtimeState: Current runtime state
-    /// - Returns: True if condition matches, false otherwise
-    private static func evaluateCondition(
-        _ condition: ConditionRule,
-        question: NoemaQuestion,
-        runtimeState: RuntimeState
-    ) -> Bool {
-        switch condition.field {
-        case "content":
-            return evaluateStringCondition(condition, value: question.content)
-
-        case "token_count":
-            let tokenCount = estimateTokenCount(question.content)
-            return evaluateNumericCondition(condition, value: tokenCount)
-
-        case "intent":
-            guard let intent = question.intent else { return false }
-            return evaluateStringCondition(condition, value: intent.rawValue)
-
-        case "privacy_level":
-            return evaluateStringCondition(condition, value: question.privacyLevel.rawValue)
-
-        default:
-            // Unknown field - condition does not match
-            return false
-        }
-    }
-
-    /// Evaluate string-based condition
-    /// - Parameters:
-    ///   - condition: The condition with operator
-    ///   - value: The string value to test
-    /// - Returns: True if condition matches
-    private static func evaluateStringCondition(
-        _ condition: ConditionRule,
-        value: String
-    ) -> Bool {
-        let conditionValue = condition.value.lowercased()
-        let testValue = value.lowercased()
-
-        switch condition.operator {
-        case .contains:
-            // Support pipe-separated OR patterns (e.g., "SSN|credit card|password")
-            let patterns = conditionValue.split(separator: "|").map { String($0).trimmingCharacters(in: .whitespaces) }
-            return patterns.contains { testValue.contains($0) }
-
-        case .notContains:
-            let patterns = conditionValue.split(separator: "|").map { String($0).trimmingCharacters(in: .whitespaces) }
-            return !patterns.contains { testValue.contains($0) }
-
-        case .equals:
-            return testValue == conditionValue
-
-        case .notEquals:
-            return testValue != conditionValue
-
-        default:
-            return false
-        }
-    }
-
-    /// Evaluate numeric-based condition
-    /// - Parameters:
-    ///   - condition: The condition with operator
-    ///   - value: The numeric value to test
-    /// - Returns: True if condition matches
-    private static func evaluateNumericCondition(
-        _ condition: ConditionRule,
-        value: Int
-    ) -> Bool {
-        guard let conditionValue = Int(condition.value) else {
-            return false
-        }
-
-        switch condition.operator {
-        case .exceeds:
-            return value > conditionValue
-
-        case .lessThan:
-            return value < conditionValue
-
-        case .equals:
-            return value == conditionValue
-
-        case .notEquals:
-            return value != conditionValue
-
-        default:
-            return false
-        }
-    }
 
     /// Resolve conflicts between multiple matching constraints
     /// Applies precedence hierarchy: BLOCK > FORCE_LOCAL > FORCE_CLOUD > REQUIRE_CONFIRMATION > WARN
@@ -225,15 +129,5 @@ struct PolicyEngine {
             warnings: warnings,
             requiresConfirmation: requiresConfirmation
         )
-    }
-
-    /// Estimate token count from text content
-    /// This is a deterministic approximation (4 chars ≈ 1 token)
-    /// - Parameter content: The text content
-    /// - Returns: Estimated token count
-    private static func estimateTokenCount(_ content: String) -> Int {
-        // Simple deterministic estimation: ~4 characters per token
-        // This matches typical tokenization ratios for English text
-        return max(1, content.count / 4)
     }
 }


### PR DESCRIPTION
## Type

Phase 2 implementation for **EPIC4 #68 — PolicyEngine extensibility**.

External-surgery only. Two commits, both small. Behaviour is unchanged.

## What changes

### `Shared/Policy/PolicyEngine.swift` — orchestrator only

Removed (~90 lines):

- `private static func evaluateConditions(_:question:runtimeState:)`
- `private static func evaluateCondition(_:question:runtimeState:)`
- `private static func evaluateStringCondition(_:value:)`
- `private static func evaluateNumericCondition(_:value:)`
- `private static func estimateTokenCount(_:)`

STEP 3 of the 4-step algorithm now calls `rule.evaluate(question:runtimeState:)` (introduced in Phase 1 via PR #76, now in main). PolicyEngine itself contains zero references to specific field names or operators.

File size: 8837 → 5597 bytes.

### `Apps/macOS/NoesisNoema/Tests/PolicyEngineTests/ConditionEvaluatorParityTests.swift` — repurposed

Phase 1's parity gate compared legacy vs new paths. Phase 2 deletes the legacy path, so the same test is now repurposed as a **regression detector** for the per-condition decisions the legacy switch used to enforce.

- File header and class doc comment updated.
- `assertParity(...)` renamed/refactored to `assertMatchDecision(rule:question:state:expected:)` plus thin convenience wrappers (`assertMatches`, `assertDoesNotMatch`).
- All 23 fixtures retained; no expected outcome changes.

## What stays

- `static func evaluate(question:runtimeState:rules:)` signature — unchanged.
- STEP 1 (filter), STEP 2 (sort), STEP 4 (resolveConflicts) bodies — byte-for-byte identical.
- Precedence hierarchy — unchanged.
- Determinism, side-effect-freeness, throws-only-on-BLOCK — unchanged.
- `PolicyRule.swift`, `ConditionRule.swift`, `Operator.swift`, `ConstraintAction.swift`, `ConstraintStore.swift`, `EditablePolicyRule.swift`, the entire `Constraint*View*` family — untouched.
- Existing `PolicyEngineTests.swift`, `ConstraintPersistenceTests.swift`, `RouterDeterminismTests.swift`, `ExecutionCoordinatorTests.swift` — untouched.

## Why this is safe

Phase 1 (PR #76) introduced the new `ConditionEvaluator` protocol and its implementations, then proved across 23 fixtures that the new path produced identical match decisions to the legacy switch. With that proof on main, Phase 2 simply removes the legacy alternative. The regression detector (the parity test, now repurposed) continues to enforce the per-condition decisions going forward.

## Extensibility — achieved at this point

After this PR merges:

- Adding a new condition kind (e.g. `TimeOfDayCondition`, `ConnectivityCondition`) is **a new struct conforming to `ConditionEvaluator` plus a new dispatch arm in `ConditionRule.toEvaluator()`**. No edit to `PolicyEngine.swift`.
- Adding a new operator (e.g. `regex`, `fuzzy`) is **a new strategy struct in `Shared/Policy/Operators/`**. No edit to `PolicyEngine.swift`.
- `PolicyEngine.swift` contains **zero references** to specific field names or operator kinds.

This is the structural extensibility goal Max and Taka set for #68. Phase 4 will demonstrate it concretely by adding one new condition without touching `PolicyEngine.swift`.

## Test plan

`PolicyEngineTests.swift` and `ConditionEvaluatorParityTests.swift` should both pass without modification (only the latter has its comments + helpers updated; the test fixtures and expected outcomes are identical).

## What I'd appreciate Taka eyes on

1. **The deleted helpers** — confirming none of them were called from outside `PolicyEngine.swift` (they were `private static`, so this should be guaranteed by the language; flagging anyway for explicit ack).
2. **The renamed parity helpers** (`assertMatches` / `assertDoesNotMatch`) — readability check at the call sites.
3. **`estimateTokenCount` was deleted from PolicyEngine** per our agreement (Phase 1 review prompt 2; the duplication in `TokenCountCondition` is intentional for self-containment).

## Status

Draft, awaiting review. After merge, **Phase 3** (Codable strategy verification — confirming the existing `policy-constraints.json` fixture decodes through the protocol-based path) will land in a separate PR on a separate branch from clean main.

## Related

- Branch: `feature/ep4-issue68-phase2-engine-orchestrator` (deleted on merge per Taka's flow)
- Design: `docs/EPIC4_Policy_Engine_Extensibility_Design.md` §4.4 (PolicyEngine = pure orchestrator)
- Phase 1 (predecessor): #76, merged
- Issue: #68 (closes after Phase 4 ships)
