### PR TITLE
chore(git): remove stale xcframework LFS tracking line from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
-NoesisNoema/Frameworks/xcframeworks/*.xcframework filter=lfs diff=lfs merge=lfs -text
 *.pbxproj -text
 *.pbxproj merge=union


### PR DESCRIPTION
## Remove stale xcframework LFS tracking line

`.gitattributes` carried a line (added 2025-11-01) that tracks vendored
xcframeworks via git LFS:

```
NoesisNoema/Frameworks/xcframeworks/*.xcframework filter=lfs diff=lfs merge=lfs -text
```

This **contradicts** the vendoring policy in `.gitignore` (added 2025-08-28),
which explicitly forbids committing vendored llama.cpp xcframeworks:

```
# Local frameworks (do not commit vendored xcframeworks)
llama.xcframework/
**/llama.xcframework/
```

### Policy (authoritative)
The xcframework is **vendored out-of-git**:
- llama.cpp follows upstream in a separate repo
- the xcframework is (re)built locally via a shell script (iOS + macOS slices)
- the build resolves it via `FRAMEWORK_SEARCH_PATHS`

`.gitignore` is the single source of truth. The stale `.gitattributes` LFS line
was harmless in effect (it only triggers if such a file is staged, which
`.gitignore` prevents) but it is a **live trap** — it makes committing the
xcframework look routine when policy says not to. (It already caused one wasted
investigation cycle.)

### Change
- Remove the one stale line. `*.pbxproj` attributes are unaffected.

### Not in scope
- The README still doesn't document the vendoring/build-script workflow — a
  separate follow-up.
- If the team ever decides to reverse the policy and DO commit the xcframework
  via LFS (23 MB, reasonable), that is a deliberate decision requiring a
  `.gitignore` change + an ADR — not this PR.