### PR TITLE
R2: route ChatView through coordinator (citations via ExecutionResult/NoemaResponse)

### DIFF
--- a/Apps/iOS/NoesisNoemaMobile/Views/ChatView.swift
+++ b/Apps/iOS/NoesisNoemaMobile/Views/ChatView.swift
@@ -12,8 +12,14 @@ struct ChatScreen: View {
     @ObservedObject var documentManager: DocumentManager
     @ObservedObject private var modelManager = ModelManager.shared
 
+    /// Hybrid runtime entry point. R2 (ADR-0008 Decision 1) routes ChatView
+    /// inference through this coordinator instead of calling the ModelManager
+    /// monolith directly. Injected from `ChatView`.
+    let executionCoordinator: ExecutionCoordinating
+
     @State private var question: String = ""
     @State private var isLoading: Bool = false
+    @State private var errorMessage: String?
     @FocusState private var questionFocused: Bool
 
     var body: some View {
@@ -39,6 +45,18 @@ struct ChatScreen: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(Color.white)
         .overlay(loadingOverlay)
+        .alert(
+            "Couldn’t generate an answer",
+            isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { presented in if !presented { errorMessage = nil } }
+            ),
+            presenting: errorMessage
+        ) { _ in
+            Button("OK", role: .cancel) { }
+        } message: { message in
+            Text(message)
+        }
     }
 
     private var contentArea: some View {
@@ -100,20 +118,41 @@ struct ChatScreen: View {
         questionFocused = false
         isLoading = true
 
-        // PERFORMANCE: Run entire RAG pipeline off main thread
-        Task.detached(priority: .userInitiated) {
-            let result = await ModelManager.shared.generateAsyncAnswer(question: trimmed)
+        // R2 (ADR-0008 Decision 1): route inference through the execution
+        // coordinator instead of calling the ModelManager monolith directly.
+        // The heavy RAG + llama work runs off the main thread inside the
+        // executor (LocalExecutor hops off-main for retrieval and inference);
+        // this @MainActor Task only marshals UI state and the QA store.
+        Task { @MainActor in
+            do {
+                let response = try await executionCoordinator.execute(
+                    request: NoemaRequest(query: trimmed)
+                )
 
-            await MainActor.run {
-                let newPair = documentManager.addQAPair(question: trimmed, answer: result)
-                Task {
-                    let sources = await MainActor.run { ModelManager.shared.lastRetrievedChunks }
-                    let embedder = await MainActor.run { ModelManager.shared.currentEmbeddingModel }
-                    QAContextStore.shared.put(qaId: newPair.id, question: newPair.question, answer: newPair.answer, sources: sources, embedder: embedder)
-                }
+                let newPair = documentManager.addQAPair(
+                    question: trimmed,
+                    answer: response.text
+                )
+
+                // Citations now arrive on the response (ExecutionResult.sources
+                // → NoemaResponse.sources) instead of via ModelManager's mutable
+                // `lastRetrievedChunks` side effect. `embedder` is model/config,
+                // not inference — reading it from ModelManager stays (ADR-0008).
+                let embedder = modelManager.currentEmbeddingModel
+                QAContextStore.shared.put(
+                    qaId: newPair.id,
+                    question: newPair.question,
+                    answer: newPair.answer,
+                    sources: response.sources,
+                    embedder: embedder
+                )
                 question = ""
-                isLoading = false
+            } catch {
+                // ADR-0000: no silent fallback. Surface the failure to the user;
+                // do NOT fall back to a stub or to ModelManager as a backup.
+                errorMessage = error.localizedDescription
             }
+            isLoading = false
         }
     }
 }
@@ -122,8 +161,35 @@ struct ChatScreen: View {
 struct ChatView: View {
     @ObservedObject var documentManager: DocumentManager
 
+    /// Hybrid runtime entry point, injected into `ChatScreen`.
+    private let executionCoordinator: ExecutionCoordinating
+
+    /// - Parameters:
+    ///   - documentManager: Shared document/QA-history store.
+    ///   - executionCoordinator: Hybrid runtime entry point. R2 (ADR-0008
+    ///     Decision 1) routes ChatView inference through this coordinator.
+    ///     Defaults to a fresh `HybridExecutionCoordinator` so the existing
+    ///     `ChatView(documentManager:)` call site in `TabRootView` (and the
+    ///     `#Preview`) need no change and tests can inject a stub.
+    ///     NOTE: the default value news up a coordinator — mirrors `@main`
+    ///     (`NoesisNoemaMobileApp` news up `HybridExecutionCoordinator()`) and
+    ///     `MinimalClientView`'s `#Preview`. `HybridExecutionCoordinator` is
+    ///     stateless, so a per-`ChatView` instance is safe. Wiring `ChatView`
+    ///     to the app-level coordinator is deferred (would require touching
+    ///     `TabRootView`/`RootView`, out of R2 scope).
+    init(
+        documentManager: DocumentManager,
+        executionCoordinator: ExecutionCoordinating = HybridExecutionCoordinator()
+    ) {
+        self.documentManager = documentManager
+        self.executionCoordinator = executionCoordinator
+    }
+
     var body: some View {
-        ChatScreen(documentManager: documentManager)
+        ChatScreen(
+            documentManager: documentManager,
+            executionCoordinator: executionCoordinator
+        )
     }
 }
 

--- a/NoesisNoemaTests/Runtime/ExecutorTests.swift
+++ b/NoesisNoemaTests/Runtime/ExecutorTests.swift
@@ -243,4 +243,92 @@ final class ExecutorTests: XCTestCase {
         XCTAssertNotNil(result.timestamp)
         // No route field exists - architectural compliance verified
     }
+
+    // MARK: - ExecutionResult.sources Tests (R2 — ADR-0008)
+    //
+    // R2 added `sources: [Chunk]` to ExecutionResult so retrieval citations
+    // travel out via the return value instead of ModelManager's mutable
+    // `lastRetrievedChunks` side effect. The field defaults to [] for
+    // back-compat and ExecutionResult stays a pure Equatable data struct.
+
+    func testExecutionResult_SourcesDefaultsToEmpty() {
+        // A result built without `sources` must expose an empty citation list,
+        // never nil — the default keeps pre-R2 call sites source-compatible.
+        let result = ExecutionResult(
+            output: "Test",
+            traceId: UUID(),
+            timestamp: Date()
+        )
+
+        XCTAssertEqual(result.sources, [], "sources must default to [] when omitted")
+    }
+
+    func testExecutionResult_CarriesProvidedSources() {
+        // ExecutionResult must round-trip retrieval chunks as citations, and
+        // its synthesized Equatable must take `sources` into account.
+        let chunk = Chunk(
+            content: "Paris is the capital of France.",
+            embedding: [0.1, 0.2, 0.3],
+            sourceTitle: "Geography",
+            sourcePath: "/docs/geo.pdf",
+            page: 12
+        )
+        let traceId = UUID()
+        let timestamp = Date()
+
+        let result = ExecutionResult(
+            output: "Paris.",
+            sources: [chunk],
+            traceId: traceId,
+            timestamp: timestamp
+        )
+
+        XCTAssertEqual(result.sources, [chunk], "sources must round-trip the provided chunks")
+
+        // Equatable now covers sources: same fields but different sources ⇒ not equal.
+        let withoutSources = ExecutionResult(
+            output: "Paris.",
+            traceId: traceId,
+            timestamp: timestamp
+        )
+        XCTAssertNotEqual(result, withoutSources,
+                          "ExecutionResult equality must reflect `sources`")
+    }
+
+    func testAgentExecutor_ProducesEmptySources() async throws {
+        // R2: the remote/agent path performs no local retrieval, so its
+        // ExecutionResult carries an empty citation list (remote citations
+        // are a later task).
+        let executor = AgentExecutor(client: MockAgentClient())
+
+        let result = try await executor.execute(query: "Test", sessionId: UUID())
+
+        XCTAssertEqual(result.sources, [], "AgentExecutor must produce empty sources")
+    }
+
+    func testLocalExecutor_ResultCarriesRetrievalSources() async {
+        // R2 contract (ADR-0008): LocalExecutor surfaces the chunks it
+        // retrieved as ExecutionResult.sources — severing the inference +
+        // citations dependency on ModelManager.lastRetrievedChunks. In the
+        // model-less / RAGpack-less unit-test environment execute() throws an
+        // ExecutionError before returning (R1 / ADR-0000); full population is
+        // verified by the on-device smoke test (UAT U1). This is the
+        // source-level guard for the success path.
+        let executor = LocalExecutor()
+        do {
+            let result = try await executor.execute(query: "Hello world",
+                                                    sessionId: UUID())
+            // Reached only with a real model + RAGpack present.
+            XCTAssertFalse(result.output.isEmpty,
+                           "A returned ExecutionResult must carry a real answer")
+            for chunk in result.sources {
+                XCTAssertFalse(chunk.content.isEmpty,
+                               "Every cited chunk must carry content")
+            }
+        } catch is ExecutionError {
+            // Expected in the model-less unit-test environment.
+        } catch {
+            XCTFail("LocalExecutor must throw ExecutionError, got \(type(of: error)): \(error)")
+        }
+    }
 }

--- a/Shared/Execution/ExecutionCoordinator.swift
+++ b/Shared/Execution/ExecutionCoordinator.swift
@@ -25,10 +25,20 @@ struct NoemaRequest {
 /// Response object from execution
 struct NoemaResponse {
     let text: String
+
+    /// Retrieved knowledge chunks that grounded the answer (citations).
+    ///
+    /// Threaded through from `ExecutionResult.sources` by the canonical
+    /// `HybridExecutionCoordinator` (ADR-0008 R2) so the UI receives citations
+    /// from the response instead of reading `ModelManager`'s mutable state.
+    /// Defaults to `[]` so existing call sites remain source-compatible.
+    let sources: [Chunk]
+
     let sessionId: UUID
 
-    init(text: String, sessionId: UUID) {
+    init(text: String, sources: [Chunk] = [], sessionId: UUID) {
         self.text = text
+        self.sources = sources
         self.sessionId = sessionId
     }
 }
@@ -227,8 +237,14 @@ final class ExecutionCoordinator: ExecutionCoordinating {
 
         log("✅ Execution complete: sessionId=\(request.sessionId)")
 
+        // TODO R4: this Preview-only coordinator delegates local execution to
+        // ModelManager.generateAsyncAnswer (a String, not an ExecutionResult),
+        // so it has no ExecutionResult.sources to thread through — citations are
+        // empty here. The canonical HybridExecutionCoordinator propagates real
+        // sources. This coordinator is slated for removal in R4 (ADR-0008).
         let response = NoemaResponse(
             text: responseText,
+            sources: [],
             sessionId: request.sessionId
         )
 

--- a/Shared/RAG/Chunk.swift
+++ b/Shared/RAG/Chunk.swift
@@ -7,7 +7,11 @@
 
 import Foundation
 
-struct Chunk: Codable {
+// Equatable: synthesized. All stored properties are Equatable, so Swift
+// generates ==. Required so ExecutionResult (which now carries [Chunk] as
+// citations, ADR-0008 R2) keeps its synthesized Equatable conformance.
+// Adding the conformance is purely additive — no existing behavior changes.
+struct Chunk: Codable, Equatable {
     var content: String
     var embedding: [Float]
     // metadata for citation popover

--- a/Shared/Runtime/Execution/HybridExecutionCoordinator.swift
+++ b/Shared/Runtime/Execution/HybridExecutionCoordinator.swift
@@ -172,8 +172,13 @@ final class HybridExecutionCoordinator: ExecutionCoordinating {
         )
         await TraceCollector.shared.record(executionTrace)
 
+        // R2 (ADR-0008): propagate retrieval citations from the executor's
+        // ExecutionResult into the response so the UI no longer reads them from
+        // ModelManager's mutable state. Local path carries real chunks; the
+        // remote/agent path carries [] (remote citations are a later task).
         return NoemaResponse(
             text: result.output,
+            sources: result.sources,
             sessionId: request.sessionId
         )
     }

--- a/Shared/Runtime/Executors/AgentExecutor.swift
+++ b/Shared/Runtime/Executors/AgentExecutor.swift
@@ -55,6 +55,7 @@ final class AgentExecutor: Executor {
 
         return ExecutionResult(
             output: response,
+            sources: [],  // R2: remote path has no local retrieval; remote citations are a later task
             traceId: traceId,
             timestamp: Date()
         )

--- a/Shared/Runtime/Executors/ExecutionResult.swift
+++ b/Shared/Runtime/Executors/ExecutionResult.swift
@@ -2,6 +2,7 @@
 // ExecutionResult data structure
 // Created: 2026-03-07
 // Updated: 2026-03-08 - Removed route field (routing authority belongs to Router)
+// Updated: 2026-05-22 - R2 (ADR-0008): added sources (retrieved chunks / citations)
 // License: MIT License
 
 import Foundation
@@ -20,6 +21,15 @@ struct ExecutionResult: Equatable {
     /// The generated output text
     let output: String
 
+    /// Retrieved knowledge chunks that grounded this result (citations).
+    ///
+    /// Populated by `LocalExecutor` from RAG retrieval so callers receive
+    /// citations through the return value instead of reading `ModelManager`'s
+    /// mutable state as a side effect (ADR-0008 R2). Empty for the remote/agent
+    /// path — remote citations are a later task. Defaults to `[]` so existing
+    /// call sites remain source-compatible.
+    let sources: [Chunk]
+
     /// Unique trace identifier for observability
     let traceId: UUID
 
@@ -28,10 +38,12 @@ struct ExecutionResult: Equatable {
 
     init(
         output: String,
+        sources: [Chunk] = [],
         traceId: UUID,
         timestamp: Date
     ) {
         self.output = output
+        self.sources = sources
         self.traceId = traceId
         self.timestamp = timestamp
     }

--- a/Shared/Runtime/Executors/LocalExecutor.swift
+++ b/Shared/Runtime/Executors/LocalExecutor.swift
@@ -2,6 +2,7 @@
 // LocalExecutor - Local LLM execution (on-device RAG + llama.cpp)
 // Created: 2026-03-07
 // Updated: 2026-05-21 (R1: wired to real RAG pipeline; stub removed per ADR-0008)
+// Updated: 2026-05-22 (R2: return retrieved chunks as ExecutionResult.sources)
 // License: MIT License
 
 import Foundation
@@ -79,8 +80,11 @@ final class LocalExecutor: Executor {
             throw ExecutionError.emptyOutput
         }
 
+        // R2 (ADR-0008): carry the retrieved chunks out as citations. The same
+        // `chunks` already used to build the context above — no extra retrieval.
         return ExecutionResult(
             output: answer,
+            sources: chunks,
             traceId: traceId,
             timestamp: Date()
         )


### PR DESCRIPTION
## ADR-0008 R2 — route ChatView through the execution coordinator

R1 (PR #80) wired `LocalExecutor` to the real RAG+llama pipeline. **R2 routes the app's ChatView through the execution coordinator** so the v0.3 monolith (`ModelManager`) is no longer called directly for inference or citations. `ChatView` only — `MobileHomeView` follows in a separate PR (see below).

### The problem

`ChatView.startAsk()` previously did inference via `ModelManager.generateAsyncAnswer` and read citations from `ModelManager.lastRetrievedChunks` (a mutable side effect). Both must go through `HybridExecutionCoordinator` instead. For citations to travel `LocalExecutor → ExecutionResult → NoemaResponse → ChatView`, both result types needed a citations field.

### Files changed (7)

| # | File | Change |
|---|------|--------|
| 1 | `Shared/Runtime/Executors/ExecutionResult.swift` | Add `sources: [Chunk]` (default `[]`). Stays a pure immutable `Equatable` data struct (ADR-0000). |
| 2 | `Shared/Runtime/Executors/LocalExecutor.swift` | Return the already-retrieved `chunks` as `sources` — no new retrieval; R1 logic/off-MainActor structure untouched. |
| 3 | `Shared/Runtime/Executors/AgentExecutor.swift` | Pass `sources: []` — remote path has no local retrieval (remote citations are a later task). |
| 4 | `Shared/Execution/ExecutionCoordinator.swift` | Add `sources: [Chunk]` to `NoemaResponse` (defined here). Preview-only coordinator passes `sources: []` with a `// TODO R4` note (removed in R4). |
| 5 | `Shared/Runtime/Execution/HybridExecutionCoordinator.swift` | **Canonical coordinator** — propagate `ExecutionResult.sources` into `NoemaResponse.sources`. No routing/policy/override changes. |
| 6 | `Apps/iOS/NoesisNoemaMobile/Views/ChatView.swift` | Replace `ModelManager.generateAsyncAnswer` with `coordinator.execute`; read citations from `response.sources`; inject coordinator; surface errors. |
| +1 | `Shared/RAG/Chunk.swift` | Conform `Chunk: Equatable` (synthesized) — required so `ExecutionResult` keeps its synthesized `==`. Purely additive; lower-risk than a custom `==` that ignores `sources`. Explicitly anticipated by the task. |

Tests: `NoesisNoemaTests/Runtime/ExecutorTests.swift` — added source-level guards for the new `sources` field (defaults to `[]`, round-trips chunks, `AgentExecutor` produces `[]`, `LocalExecutor` success-path contract). Source-level only — the `NoesisNoemaTests` target has no run scheme (known caveat from R1).

### How `Chunk` Equatable was handled

`Chunk` is a struct whose stored properties are all `Equatable`, so `struct Chunk: Codable, Equatable` gives a **synthesized** `==`. Chosen over making `ExecutionResult.==` ignore `sources` because it is purely additive (no behavior change, no semantic surprise) and keeps `ExecutionResult` equality honest.

### How ChatView receives the coordinator

Mirrors the **Minimal Client Interface** pattern: `@main` (`NoesisNoemaMobileApp`) news up a `HybridExecutionCoordinator` and passes it down (`RootView` → `MinimalClientView`). `ChatView` takes `executionCoordinator: ExecutionCoordinating` via its initializer, **defaulting to a fresh `HybridExecutionCoordinator()`** so the existing `ChatView(documentManager:)` call site in `TabRootView` and the `#Preview` need no change, and tests can inject a stub. The default value news one up — flagged: it mirrors `@main` and `MinimalClientView`'s `#Preview`, and `HybridExecutionCoordinator` is stateless so a per-`ChatView` instance is safe. Wiring `ChatView` to the *app-level* coordinator instance would require touching `TabRootView`/`RootView` (out of R2 scope).

### Build status — verified

- **macOS** (`NoesisNoema` scheme, Debug): ✅ `** BUILD SUCCEEDED **`
- **iOS Simulator** (`NoesisNoemaMobile` scheme, arm64, Debug): ✅ `** BUILD SUCCEEDED **`

No new warnings introduced by these changes.

### ADR-0000 compliance

- No stub / no silent fallback: on execution failure `ChatView` shows an alert; it does **not** fall back to `ModelManager`.
- `ExecutionResult` remains a pure data struct.
- `embedder` (`currentEmbeddingModel`) still comes from `ModelManager` — a model/config concern, not inference; R2 only severs the inference + citations side-effect dependency.

### Remaining

- **`MobileHomeView`** — next PR (same pattern; has autotune/preset complexity, deliberately not in this PR).
- On-device smoke test (UAT U1) — verifies real citation population end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)