### PR TITLE
R2: route MobileHomeView through coordinator

### DIFF
--- a/Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift
+++ b/Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift
@@ -14,6 +14,7 @@ struct MobileHomeView: View {
 
     @State private var question: String = ""
     @State private var isLoading: Bool = false
+    @State private var errorMessage: String?
     @State private var selectedLLMModel: String = "Jan-V1-4B"
     @State private var selectedLLMPreset: String = ModelManager.shared.currentLLMPreset
 
@@ -26,8 +27,25 @@ struct MobileHomeView: View {
 
     @FocusState private var questionFocused: Bool
 
+    /// Hybrid runtime entry point. R2 (ADR-0008 Decision 1) routes
+    /// MobileHomeView inference through this coordinator instead of calling the
+    /// ModelManager monolith directly.
+    private let executionCoordinator: ExecutionCoordinating
+
     // Keep in sync with TabBarView height
     private let tabBarHeight: CGFloat = 60
+
+    /// - Parameter executionCoordinator: Hybrid runtime entry point. R2
+    ///   (ADR-0008 Decision 1) routes MobileHomeView inference through this
+    ///   coordinator. Defaults to a fresh `HybridExecutionCoordinator` so the
+    ///   existing `MobileHomeView()` call site (`#Preview`) needs no change and
+    ///   tests can inject a stub. NOTE: the default value news up a coordinator
+    ///   — mirrors `ChatView` (R2 PR #83), `@main` (`NoesisNoemaMobileApp`), and
+    ///   `MinimalClientView`'s `#Preview`. `HybridExecutionCoordinator` is
+    ///   stateless, so a per-view instance is safe.
+    init(executionCoordinator: ExecutionCoordinating = HybridExecutionCoordinator()) {
+        self.executionCoordinator = executionCoordinator
+    }
 
     var availableEmbeddingModels: [String] { ModelManager.shared.availableEmbeddingModels }
     var availableLLMModels: [String] { ModelManager.shared.availableLLMModels }
@@ -57,6 +75,18 @@ struct MobileHomeView: View {
             }
         }
         .ignoresSafeArea(.all)
+        .alert(
+            "Couldn’t generate an answer",
+            isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { presented in if !presented { errorMessage = nil } }
+            ),
+            presenting: errorMessage
+        ) { _ in
+            Button("OK", role: .cancel) { }
+        } message: { message in
+            Text(message)
+        }
     }
 
     // MARK: - Mode Picker Section
@@ -357,18 +387,39 @@ struct MobileHomeView: View {
         questionFocused = false
         isLoading = true
 
+        // R2 (ADR-0008 Decision 1): route inference through the execution
+        // coordinator instead of calling the ModelManager monolith directly.
+        // The heavy RAG + llama work runs off the main thread inside the
+        // executor (LocalExecutor hops off-main for retrieval and inference);
+        // this @MainActor Task only marshals UI state and the QA store.
         Task { @MainActor in
-            let result = await ModelManager.shared.generateAsyncAnswer(question: question)
-            let newPair = documentManager.addQAPair(question: question, answer: result)
-            let sources = ModelManager.shared.lastRetrievedChunks
-            QAContextStore.shared.put(
-                qaId: newPair.id,
-                question: newPair.question,
-                answer: newPair.answer,
-                sources: sources,
-                embedder: ModelManager.shared.currentEmbeddingModel
-            )
-            question = ""
+            do {
+                let response = try await executionCoordinator.execute(
+                    request: NoemaRequest(query: trimmed)
+                )
+
+                let newPair = documentManager.addQAPair(
+                    question: trimmed,
+                    answer: response.text
+                )
+
+                // Citations now arrive on the response (ExecutionResult.sources
+                // → NoemaResponse.sources) instead of via ModelManager's mutable
+                // `lastRetrievedChunks` side effect. `embedder` is model/config,
+                // not inference — reading it from ModelManager stays (ADR-0008).
+                QAContextStore.shared.put(
+                    qaId: newPair.id,
+                    question: newPair.question,
+                    answer: newPair.answer,
+                    sources: response.sources,
+                    embedder: ModelManager.shared.currentEmbeddingModel
+                )
+                question = ""
+            } catch {
+                // ADR-0000: no silent fallback. Surface the failure to the user;
+                // do NOT fall back to a stub or to ModelManager as a backup.
+                errorMessage = error.localizedDescription
+            }
             isLoading = false
         }
     }


### PR DESCRIPTION
## ADR-0008 R2 (part 2) — route MobileHomeView through the execution coordinator

Applies the pattern merged for `ChatView` (PR #83) to `MobileHomeView` — the last screen that called the v0.3 `ModelManager` monolith directly for inference. **This completes R2's screen migration.**

### Change — one file

`Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift` only. The type plumbing (`ExecutionResult.sources`, `NoemaResponse.sources`, `Chunk: Equatable`, coordinator threading) already landed in `main` with R2 ChatView, so no type/coordinator changes were needed.

`startAsk()`:
- **Inference:** `ModelManager.generateAsyncAnswer` → `coordinator.execute(request: NoemaRequest(query:))` (`HybridExecutionCoordinator`).
- **Citations:** from `response.sources` instead of `ModelManager.lastRetrievedChunks` (mutable side effect).
- **Coordinator injection:** added an `init(executionCoordinator: ExecutionCoordinating = HybridExecutionCoordinator())` — mirrors `ChatView`'s exact wiring (including the flagged "news one up" default). The only call site (`#Preview { MobileHomeView() }`) needs no change.
- **Error handling (ADR-0000):** execution failure surfaces in an alert — no silent fallback to a stub or to `ModelManager`.
- **`embedder`** (`currentEmbeddingModel`) still comes from `ModelManager` — a model/config concern, not inference.
- **Untouched:** autotune / preset / runtime-mode / model-switch code paths — legitimate `ModelManager` config usage, deliberately left as-is.

UX preserved: same loading state, `documentManager.addQAPair`, `QAContextStore.put`, focus/clear behavior.

### grep `MobileHomeView.swift`
- `generateAsyncAnswer` → **gone**
- `lastRetrievedChunks` → **gone** (one match remains — an explanatory comment, not a call)
- `currentEmbeddingModel` + autotune/preset/model-switch `ModelManager` calls → **remain** (config, as intended)

### Build status — verified
- **macOS** (`NoesisNoema` scheme, Debug): ✅ `** BUILD SUCCEEDED **`
- **iOS Simulator** (`NoesisNoemaMobile` scheme, arm64, Debug): ✅ `** BUILD SUCCEEDED **`

No new warnings. No test changes needed (no type changes; no positional result construction affected).

### R2 status — complete

Both app screens that performed inference are now coordinator-routed:
- `ChatView` — PR #83 (merged)
- `MobileHomeView` — this PR

The v0.3 `ModelManager` monolith is no longer called for inference or citations from the UI. **Next up:** R3 (enforce Privacy Step 4.5 — network cutoff on the local path) and the on-device smoke test (UAT U1/U2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)