### PR TITLE
R3: enforce Privacy Step 4.5 (non-bypassable local-only network cutoff)

### DIFF
--- a/NoesisNoemaTests/Runtime/PrivacyEnforcementTests.swift
+++ b/NoesisNoemaTests/Runtime/PrivacyEnforcementTests.swift
@@ -1,0 +1,202 @@
+// NoesisNoema - Hybrid Routing Runtime
+// Privacy Enforcement Tests — Privacy Step 4.5 (ADR-0008 Decision 4)
+// Created: 2026-05-22 (R3: enforce execution-flow.md Step 4.5)
+// License: MIT License
+//
+// These tests cover R3's two enforcement layers:
+//
+//   Layer 1 — the coordinator guard. `HybridExecutionCoordinator.execute`
+//   runs a mandatory, non-bypassable privacy check between routing and
+//   execution. Its decision is the pure function
+//   `HybridExecutionCoordinator.evaluatePrivacyStep45(...)`, exercised
+//   directly here: a privacy-local request that did not route on-device (or
+//   that would permit cloud fallback) yields `.violated`, which the
+//   coordinator turns into a thrown `ExecutionError.privacyViolation` —
+//   never an agent/network call.
+//
+//   Layer 2 — the structural "zero network" guarantee. The CI form of
+//   "zero network transmission" is: the network-capable executor
+//   (`agentExecutor`) is never reached on a local route. The mock agent
+//   below FAILS the test if its `execute` is ever invoked.
+//
+// NOTE: `HybridExecutionCoordinator.buildQuestion` currently hardcodes
+// `privacyLevel: .auto` (the request-level privacy picker is pending), so a
+// `.local` Question cannot yet be driven through the public `execute(request:)`
+// API. The enforcement rule is therefore verified at the pure-function level
+// (`evaluatePrivacyStep45`), and the coordinator path verifies that a
+// locally-routed request never reaches the agent. This is a source-level
+// guard — the NoesisNoemaTests target has no run scheme (caveat from R1).
+
+import XCTest
+@testable import NoesisNoema
+
+/// Local executor stand-in — returns a deterministic result, no I/O.
+final class R3StubLocalExecutor: Executor {
+    private(set) var executeCallCount = 0
+
+    func execute(query: String, sessionId: UUID) async throws -> ExecutionResult {
+        executeCallCount += 1
+        return ExecutionResult(
+            output: "[r3-stub-local] \(query)",
+            traceId: UUID(),
+            timestamp: Date()
+        )
+    }
+}
+
+/// Agent (network-capable) executor stand-in that must NEVER run on a local
+/// route. If `execute` is invoked the test fails — this is the CI form of the
+/// "zero network transmission" guarantee (execution-flow.md Step 4.5).
+final class R3NeverReachedAgentExecutor: Executor {
+    private(set) var executeWasCalled = false
+
+    func execute(query: String, sessionId: UUID) async throws -> ExecutionResult {
+        executeWasCalled = true
+        XCTFail("AgentExecutor (network path) was reached — the local-only guarantee is broken")
+        throw ExecutionError.privacyViolation("agent executor must never run for a local route")
+    }
+}
+
+final class PrivacyEnforcementTests: XCTestCase {
+
+    // MARK: - Layer 1: evaluatePrivacyStep45 (pure enforcement rule)
+
+    func testEvaluate_localPrivacy_routedLocalNoFallback_isSatisfied() {
+        // The canonical privacy-local outcome: Router STEP 2 returns
+        // routeTarget=.local, fallbackAllowed=false, ruleId=.PRIVACY_LOCAL.
+        let decision = RoutingDecision(
+            routeTarget: .local,
+            model: "llama-3.2-8b",
+            reason: "User requested local-only execution (privacy constraint)",
+            ruleId: .PRIVACY_LOCAL,
+            fallbackAllowed: false
+        )
+
+        let verdict = HybridExecutionCoordinator.evaluatePrivacyStep45(
+            privacyLevel: .local,
+            routingDecision: decision
+        )
+
+        XCTAssertEqual(verdict, .satisfied,
+                       "privacy-local + on-device route + no fallback must be .satisfied")
+    }
+
+    func testEvaluate_localPrivacy_forcedCloud_isViolated() {
+        // The real bypass path: Router STEP 1 (policy) runs before STEP 2, so a
+        // policy .forceCloud (or human .forceRemote override) can route a
+        // privacy-local Question to cloud. Step 4.5 must REFUSE this.
+        let decision = RoutingDecision(
+            routeTarget: .cloud,
+            model: "gpt-4",
+            reason: "Policy constraint forced cloud execution",
+            ruleId: .POLICY_FORCE_CLOUD,
+            fallbackAllowed: false
+        )
+
+        let verdict = HybridExecutionCoordinator.evaluatePrivacyStep45(
+            privacyLevel: .local,
+            routingDecision: decision
+        )
+
+        guard case .violated = verdict else {
+            return XCTFail("privacy_level=local routed to cloud must be .violated, got \(verdict)")
+        }
+    }
+
+    func testEvaluate_localPrivacy_localRouteButFallbackAllowed_isViolated() {
+        // A local route that still permits cloud fallback is not zero-network:
+        // a local failure could spill to cloud. Step 4.5 forbids it.
+        let decision = RoutingDecision(
+            routeTarget: .local,
+            model: "llama-3.2-8b",
+            reason: "Token count within threshold, local model capable",
+            ruleId: .AUTO_LOCAL,
+            fallbackAllowed: true
+        )
+
+        let verdict = HybridExecutionCoordinator.evaluatePrivacyStep45(
+            privacyLevel: .local,
+            routingDecision: decision
+        )
+
+        guard case .violated = verdict else {
+            return XCTFail("local-only request must forbid cloud fallback, got \(verdict)")
+        }
+    }
+
+    func testEvaluate_privacyLocalRuleId_forcedCloud_isViolated() {
+        // Defense-in-depth: even if the Question's privacyLevel were not .local,
+        // a routing decision tagged ruleId=.PRIVACY_LOCAL still triggers
+        // enforcement (the OR clause).
+        let decision = RoutingDecision(
+            routeTarget: .cloud,
+            model: "gpt-4",
+            reason: "mismatched decision",
+            ruleId: .PRIVACY_LOCAL,
+            fallbackAllowed: false
+        )
+
+        let verdict = HybridExecutionCoordinator.evaluatePrivacyStep45(
+            privacyLevel: .auto,
+            routingDecision: decision
+        )
+
+        guard case .violated = verdict else {
+            return XCTFail("ruleId=.PRIVACY_LOCAL routed to cloud must be .violated, got \(verdict)")
+        }
+    }
+
+    func testEvaluate_autoPrivacy_imposesNoConstraint() {
+        // A non-privacy (auto) request: Step 4.5 does not constrain it.
+        let decision = RoutingDecision(
+            routeTarget: .local,
+            model: "llama-3.2-8b",
+            reason: "Token count within threshold, local model capable",
+            ruleId: .AUTO_LOCAL,
+            fallbackAllowed: true
+        )
+
+        let verdict = HybridExecutionCoordinator.evaluatePrivacyStep45(
+            privacyLevel: .auto,
+            routingDecision: decision
+        )
+
+        XCTAssertEqual(verdict, .notApplicable,
+                       "an auto-privacy request must not be constrained by Step 4.5")
+    }
+
+    // MARK: - ExecutionError.privacyViolation (structured error contract)
+
+    func testPrivacyViolation_isStructuredEquatableError() {
+        let error = ExecutionError.privacyViolation("routed off-device")
+
+        XCTAssertNotNil(error.errorDescription,
+                        "privacyViolation must carry a human-readable description")
+        XCTAssertEqual(error, ExecutionError.privacyViolation("routed off-device"),
+                       "privacyViolation is Equatable on its detail")
+        XCTAssertNotEqual(error, ExecutionError.emptyOutput,
+                          "privacyViolation is a distinct ExecutionError case")
+    }
+
+    // MARK: - Layer 2: a local route never reaches the agent executor
+
+    func testHybridCoordinator_localRoute_neverReachesAgentExecutor() async throws {
+        // A short, tool-free, non-privacy query routes AUTO_LOCAL (Router
+        // STEP 3). The agent (network) executor must never be invoked — if it
+        // is, R3NeverReachedAgentExecutor fails the test.
+        let localExecutor = R3StubLocalExecutor()
+        let agentExecutor = R3NeverReachedAgentExecutor()
+        let coordinator = HybridExecutionCoordinator(
+            localExecutor: localExecutor,
+            agentExecutor: agentExecutor
+        )
+
+        let response = try await coordinator.execute(request: NoemaRequest(query: "Hi"))
+
+        XCTAssertEqual(localExecutor.executeCallCount, 1,
+                       "a locally-routed request must use the local executor")
+        XCTAssertFalse(agentExecutor.executeWasCalled,
+                       "a locally-routed request must never reach the network executor")
+        XCTAssertFalse(response.text.isEmpty)
+    }
+}

--- a/Shared/Execution/ExecutionCoordinator.swift
+++ b/Shared/Execution/ExecutionCoordinator.swift
@@ -261,7 +261,8 @@ final class ExecutionCoordinator: ExecutionCoordinating {
             duration: duration,
             timestamp: startTime,
             decisionReason: routingDecision.reason,
-            error: executionError
+            error: executionError,
+            privacyEnforced: nil  // Preview-only coordinator; no Step 4.5 enforcement (TODO R4)
         )
 
         log("📊 Trace: id=\(executionTrace.traceId), duration=\(String(format: "%.3f", duration))s, route=\(executionTrace.executor)")

--- a/Shared/Runtime/Execution/HybridExecutionCoordinator.swift
+++ b/Shared/Runtime/Execution/HybridExecutionCoordinator.swift
@@ -141,6 +141,46 @@ final class HybridExecutionCoordinator: ExecutionCoordinating {
             ? localExecutor
             : agentExecutor
 
+        // Step 6.5: Privacy enforcement — MANDATORY and non-bypassable.
+        // ADR-0008 Decision 4 / execution-flow.md Step 4.5.
+        //
+        // This ENFORCES the routing decision; it does not re-decide. For a
+        // privacy-local request the Router already returns routeTarget=.local,
+        // fallbackAllowed=false (Router STEP 2). But Router STEP 1 (policy)
+        // runs *before* STEP 2 — a policy .forceCloud or a human .forceRemote
+        // override can yield routeTarget=.cloud even for a Question whose
+        // privacyLevel is .local. The spec makes privacy non-bypassable, so a
+        // privacy-local request that did not route on-device is refused here:
+        // it can never reach agentExecutor (the only network-capable executor).
+        let privacyVerdict = Self.evaluatePrivacyStep45(
+            privacyLevel: question.privacyLevel,
+            routingDecision: routingDecision
+        )
+        let privacyEnforced = (privacyVerdict == .satisfied)
+        if case .violated(let violation) = privacyVerdict {
+            // Log the enforcement with traceId via the standard trace path,
+            // then throw — the agent/network executor is never invoked.
+            let violationTrace = ExecutionTrace(
+                traceId: traceId,
+                query: request.query,
+                route: routingDecision,
+                policy: policyTrace,
+                routing: routingTrace,
+                routingSteps: routingStepTrace,
+                executor: "PrivacyGuard",
+                duration: Date().timeIntervalSince(executionStart),
+                timestamp: executionStart,
+                decisionReason: routingDecision.reason,
+                error: violation,
+                privacyEnforced: true
+            )
+            await TraceCollector.shared.record(violationTrace)
+
+            // ADR-0000: structured throw — never silently degrade, never fall
+            // through to the agent executor.
+            throw ExecutionError.privacyViolation(violation)
+        }
+
         // Step 7: Execute.
         var executionError: String? = nil
         let result: ExecutionResult
@@ -168,7 +208,8 @@ final class HybridExecutionCoordinator: ExecutionCoordinating {
             duration: totalDuration,
             timestamp: executionStart,
             decisionReason: routingDecision.reason,
-            error: executionError
+            error: executionError,
+            privacyEnforced: privacyEnforced
         )
         await TraceCollector.shared.record(executionTrace)
 
@@ -263,5 +304,55 @@ final class HybridExecutionCoordinator: ExecutionCoordinating {
             debugMode: false,
             overrideMode: overrideMode
         )
+    }
+
+    // MARK: - Privacy Enforcement (ADR-0008 Decision 4 / execution-flow.md Step 4.5)
+
+    /// Verdict of the mandatory privacy-enforcement check.
+    enum PrivacyEnforcementVerdict: Equatable {
+        /// The request is not privacy-local; Step 4.5 imposes no constraint.
+        case notApplicable
+        /// The request is privacy-local and routed on-device with no cloud
+        /// fallback — the local-only invariant holds.
+        case satisfied
+        /// The request is privacy-local but would route off-device (or would
+        /// permit cloud fallback). Execution must be refused. The associated
+        /// value is a human-readable description for the error and the trace.
+        case violated(String)
+    }
+
+    /// Evaluate Privacy Step 4.5 for a routed request.
+    ///
+    /// Pure function — no I/O, no state — so the enforcement rule is
+    /// deterministic and unit-testable in isolation. It ENFORCES the routing
+    /// decision; it does not re-decide.
+    ///
+    /// The authoritative trigger is the Question object's `privacyLevel` (the
+    /// spec keys off it). `.PRIVACY_LOCAL` — the Router's corresponding ruleId
+    /// — is OR-ed in as defense-in-depth.
+    ///
+    /// A privacy-local request is `satisfied` only when it routes on-device
+    /// (`routeTarget == .local`) with no cloud fallback (`fallbackAllowed ==
+    /// false`); any other outcome is `violated`.
+    static func evaluatePrivacyStep45(
+        privacyLevel: PrivacyLevel,
+        routingDecision: RoutingDecision
+    ) -> PrivacyEnforcementVerdict {
+        let privacyLocal = privacyLevel == .local
+            || routingDecision.ruleId == .PRIVACY_LOCAL
+        guard privacyLocal else { return .notApplicable }
+
+        guard routingDecision.routeTarget == .local
+            && routingDecision.fallbackAllowed == false
+        else {
+            return .violated(
+                "privacy_level=local but routeTarget="
+                + "\(routingDecision.routeTarget.rawValue), fallbackAllowed="
+                + "\(routingDecision.fallbackAllowed) (ruleId="
+                + "\(routingDecision.ruleId.rawValue)). A local-only request must "
+                + "execute on-device with no cloud fallback; refusing to proceed."
+            )
+        }
+        return .satisfied
     }
 }

--- a/Shared/Runtime/Executors/ExecutionError.swift
+++ b/Shared/Runtime/Executors/ExecutionError.swift
@@ -1,6 +1,7 @@
 // NoesisNoema - Hybrid Routing Runtime
 // ExecutionError - Structured execution errors
 // Created: 2026-05-21 (R1: monolith decomposition)
+// Updated: 2026-05-22 (R3: privacyViolation — Privacy Step 4.5 enforcement)
 // License: MIT License
 
 import Foundation
@@ -24,6 +25,16 @@ enum ExecutionError: Error, LocalizedError, Equatable {
     /// Inference returned an empty result.
     case emptyOutput
 
+    /// A privacy-local request was about to be routed off-device.
+    ///
+    /// Raised by the coordinator's mandatory privacy-enforcement step
+    /// (ADR-0008 Decision 4 / execution-flow.md Step 4.5): a request whose
+    /// Question carries `privacyLevel == .local` MUST execute on-device with
+    /// no cloud fallback. If the routing decision would send it to the
+    /// network/agent executor, execution is refused here — never silently
+    /// degraded, never routed off-device.
+    case privacyViolation(String)
+
     var errorDescription: String? {
         switch self {
         case .modelUnavailable(let detail):
@@ -34,6 +45,8 @@ enum ExecutionError: Error, LocalizedError, Equatable {
             return "Local inference failed: \(detail)"
         case .emptyOutput:
             return "Local inference produced an empty result."
+        case .privacyViolation(let detail):
+            return "Privacy enforcement blocked execution: \(detail)"
         }
     }
 }

--- a/Shared/Runtime/Tracing/ExecutionTrace.swift
+++ b/Shared/Runtime/Tracing/ExecutionTrace.swift
@@ -23,4 +23,13 @@ struct ExecutionTrace: Codable {
     let timestamp: Date
     let decisionReason: String?
     let error: String?
+    /// Privacy Step 4.5 enforcement outcome (ADR-0008 Decision 4).
+    /// `true`  → the request was privacy-local; the on-device, no-fallback
+    ///           invariant was enforced (or a violation was refused).
+    /// `false` → the privacy-enforcement step ran; request was not local-only.
+    /// `nil`   → trace predates R3 (no privacy-enforcement step), or the
+    ///           constructing coordinator does not run Step 4.5.
+    /// Optional, so existing decoders (TraceQuery, persisted trace files) are
+    /// unaffected by the missing key — mirrors how `routingSteps` was added.
+    let privacyEnforced: Bool?
 }


### PR DESCRIPTION
## ADR-0008 Decision 4 — enforce Privacy Step 4.5

`execution-flow.md` Step 4.5 requires privacy to be **enforced**, not merely decided. `Router` already *decides* correctly (`privacyLevel == .local` → `routeTarget: .local, fallbackAllowed: false`), but `HybridExecutionCoordinator` had **no enforcement layer** — zero-network was only an implicit consequence of the Router being correct. R3 adds the mandatory, non-bypassable guard. It **enforces** the decision; it does not re-decide.

### Layer 1 — coordinator guard

Where: a new **Step 6.5** in `HybridExecutionCoordinator.execute`, between executor selection (Step 6) and execution (Step 7).

Precise condition (pure function `evaluatePrivacyStep45(privacyLevel:routingDecision:)`):
- **Trigger** (`privacyLocal`): `question.privacyLevel == .local` — the authoritative trigger, since the spec keys off the Question object — **OR** `routingDecision.ruleId == .PRIVACY_LOCAL` as defense-in-depth.
- When `privacyLocal`: the request is **`satisfied`** only if `routeTarget == .local` **and** `fallbackAllowed == false`. Any other outcome → **`violated`** → the coordinator records a trace and **throws `ExecutionError.privacyViolation`**; `agentExecutor` is never invoked.
- Otherwise → `notApplicable`.

This catches a **real bypass path**, not just a theoretical one: Router STEP 1 (policy) runs *before* STEP 2 (privacy), so a policy `.forceCloud` or a human `.forceRemote` override can route a privacy-local Question to cloud. Step 4.5 refuses it. ADR-0000: structured throw — no silent fallback, no stub, no degrade.

### Structured error

`ExecutionError.privacyViolation(String)` — new case (distinct, `Equatable`, `LocalizedError`): a privacy-local request was about to be routed off-device.

### Trace log

`ExecutionTrace.privacyEnforced: Bool?` — new **optional** field. `true` = request was privacy-local and the on-device invariant was enforced (or a violation refused); `false` = Step 4.5 ran on a non-local request; `nil` = trace from a coordinator without Step 4.5. Optional so existing decoders (`TraceQuery`) and persisted trace files are unaffected — mirrors how `routingSteps` was added. Logged with the existing `traceId` via `TraceCollector`, **including a trace recorded immediately before a violation throw**.

### Layer 2 — structural "zero network" finding

Audited every file on the local execution path — `LocalExecutor`, `LocalRetriever`, `VectorStore`, `EmbeddingModel`/`MMR`/`QueryIterator`, `LLMModel`, `NoesisCompletionPipeline` (`runNoesisCompletion` → llama.cpp), `Chunk`:

> **No networking API anywhere on the local path.** Every file imports only `Foundation` (one RAG file also `Combine`). A repo-wide scan for `URLSession` / `import Network` / `NWConnection` / sockets found exactly three files: `HTTPAgentClient.swift` (the cloud/agent path, reached only via `AgentExecutor`), its test, and `GoogleDriveDownloader.swift` (model-file download — not the inference path). The local path is structurally network-incapable.

### Files changed (5)

| File | Change |
|---|---|
| `Shared/Runtime/Execution/HybridExecutionCoordinator.swift` | Step 6.5 guard + pure `evaluatePrivacyStep45` + `PrivacyEnforcementVerdict`; `privacyEnforced` on the Step 8 trace |
| `Shared/Runtime/Executors/ExecutionError.swift` | new `privacyViolation(String)` case |
| `Shared/Runtime/Tracing/ExecutionTrace.swift` | new optional `privacyEnforced: Bool?` field |
| `Shared/Execution/ExecutionCoordinator.swift` | one line: `privacyEnforced: nil` at its `ExecutionTrace` call site — **compiler-required** once the field is added (non-Hybrid, Preview-only coordinator; no Step 4.5) |
| `NoesisNoemaTests/Runtime/PrivacyEnforcementTests.swift` | **new** — Layer 1 + Layer 2 guards |

`ExecutionTrace` follows its own precedent (`routingSteps`): the new optional field is `let` with no default, so the compiler requires both construction sites to pass it — hence the one-line `ExecutionCoordinator.swift` change. Reported per task instructions.

### Test

`PrivacyEnforcementTests.swift` (source-level guard — the `NoesisNoemaTests` target has no run scheme, caveat from R1):
- **Layer 1:** `evaluatePrivacyStep45` — privacy-local on-device/no-fallback → `.satisfied`; privacy-local forced-cloud, local-with-fallback, and `.PRIVACY_LOCAL`-ruleId-to-cloud → all `.violated`; auto-privacy → `.notApplicable`. Plus the `privacyViolation` structured-error contract.
- **Layer 2:** `R3NeverReachedAgentExecutor` — a mock agent executor that **fails the test if its `execute` is ever called** (the CI form of "zero network transmission"). A locally-routed request must use the local executor and never reach the network executor.

Note: `buildQuestion` currently hardcodes `privacyLevel: .auto` (request-level privacy picker pending), so a `.local` Question cannot yet be driven through the public `execute(request:)` API — the enforcement rule is therefore verified at the pure-function level, which is why the guard's decision logic was extracted into the testable `evaluatePrivacyStep45`.

### Build status — verified

- **macOS** (`NoesisNoema`, Debug): ✅ `** BUILD SUCCEEDED **`
- **iOS Simulator** (`NoesisNoemaMobile`, arm64, Debug): ✅ `** BUILD SUCCEEDED **`

No new warnings (the `ExecutionCoordinator.swift:78` warning is pre-existing — the `ModelManager.shared` init default param, unrelated to R3).

### Outcome

A `privacyLevel == .local` request **can never reach `agentExecutor`** — this is now **enforced** (mandatory Step 6.5 guard, structured throw), **logged** (`ExecutionTrace.privacyEnforced` + traceId), and **tested** (pure-function verdict tests + the never-reached agent mock). Routing/PolicyEngine decision logic unchanged; no global network hook.

**Next:** R4 (collapse the duplicate coordinator trio), R5 (UAT in CI), on-device smoke test (U1/U2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)