### PR TITLE
Phase 1: restore full UI (TabRootView/MobileHomeView), app-level coordinator, deep search reconnect

### DIFF
--- a/Apps/iOS/NoesisNoemaMobile/RootView.swift
+++ b/Apps/iOS/NoesisNoemaMobile/RootView.swift
@@ -11,10 +11,14 @@ struct RootView: View {
     let executionCoordinator: ExecutionCoordinating
 
     var body: some View {
-        MinimalClientView(executionCoordinator: executionCoordinator)
+        // Phase 1: render the full tabbed UI (Chat / History / Settings).
+        // The app-level executionCoordinator from @main is threaded through.
+        // MinimalClientView (the EPIC1 vertical-slice MVP) remains reachable
+        // as a debug screen via SettingsView ▸ Advanced (DEBUG builds).
+        TabRootView(executionCoordinator: executionCoordinator)
     }
 }
 
 #Preview {
-    RootView(executionCoordinator: ExecutionCoordinator())
+    RootView(executionCoordinator: HybridExecutionCoordinator())
 }

--- a/Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift
+++ b/Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift
@@ -10,7 +10,11 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct MobileHomeView: View {
-    @StateObject private var documentManager = DocumentManager()
+    /// Shared QA/document store, injected by `TabRootView` so the Chat tab,
+    /// History tab, and Settings tab all observe the same instance.
+    /// (Phase 1: was a view-owned `@StateObject` — that isolated MobileHomeView's
+    /// history from the other tabs; now injected.)
+    @ObservedObject var documentManager: DocumentManager
 
     @State private var question: String = ""
     @State private var isLoading: Bool = false
@@ -35,15 +39,16 @@ struct MobileHomeView: View {
     // Keep in sync with TabBarView height
     private let tabBarHeight: CGFloat = 60
 
-    /// - Parameter executionCoordinator: Hybrid runtime entry point. R2
-    ///   (ADR-0008 Decision 1) routes MobileHomeView inference through this
-    ///   coordinator. Defaults to a fresh `HybridExecutionCoordinator` so the
-    ///   existing `MobileHomeView()` call site (`#Preview`) needs no change and
-    ///   tests can inject a stub. NOTE: the default value news up a coordinator
-    ///   — mirrors `ChatView` (R2 PR #83), `@main` (`NoesisNoemaMobileApp`), and
-    ///   `MinimalClientView`'s `#Preview`. `HybridExecutionCoordinator` is
-    ///   stateless, so a per-view instance is safe.
-    init(executionCoordinator: ExecutionCoordinating = HybridExecutionCoordinator()) {
+    /// - Parameters:
+    ///   - documentManager: Shared QA/document store (injected by `TabRootView`).
+    ///   - executionCoordinator: Hybrid runtime entry point. In the app this is
+    ///     the single coordinator threaded from `@main`; the default
+    ///     (`HybridExecutionCoordinator()`) exists only for `#Preview`/tests.
+    init(
+        documentManager: DocumentManager,
+        executionCoordinator: ExecutionCoordinating = HybridExecutionCoordinator()
+    ) {
+        self.documentManager = documentManager
         self.executionCoordinator = executionCoordinator
     }
 
@@ -491,5 +496,5 @@ struct HistoryCard: View {
 }
 
 #Preview {
-    MobileHomeView()
+    MobileHomeView(documentManager: DocumentManager())
 }

--- a/Apps/iOS/NoesisNoemaMobile/Views/SettingsView.swift
+++ b/Apps/iOS/NoesisNoemaMobile/Views/SettingsView.swift
@@ -29,6 +29,14 @@ struct SettingsView: View {
     @State private var debugTiming: Bool = false
     @State private var debugMemory: Bool = false
 
+    // Retrieval: Deep Search opt-in. Persisted in UserDefaults and read by
+    // LocalExecutor (off by default — DeepSearch runs heavier multi-round
+    // retrieval). Fully on-device, so R3's privacy guarantee is unaffected.
+    @AppStorage(LocalExecutor.deepSearchDefaultsKey) private var deepSearchEnabled: Bool = false
+
+    // Debug: present the MinimalClientView (EPIC1 vertical-slice) screen.
+    @State private var showMinimalClient: Bool = false
+
     var availableEmbeddingModels: [String] { ModelManager.shared.availableEmbeddingModels }
     var availableLLMModels: [String] { ModelManager.shared.availableLLMModels }
     var availableLLMPresets: [String] { ModelManager.shared.availableLLMPresets }
@@ -40,6 +48,7 @@ struct SettingsView: View {
                 presetSection
                 runtimeSection
                 ragDocumentSection
+                retrievalSection
                 advancedSection
             }
             .padding(.horizontal, 16)
@@ -50,6 +59,29 @@ struct SettingsView: View {
         .onAppear {
             runtimeMode = ModelManager.shared.getRuntimeMode()
             useRecommended = (runtimeMode == .recommended)
+        }
+        .sheet(isPresented: $showMinimalClient) {
+            // Debug screen reached from Advanced ▸ Open Minimal Client.
+            // It is a self-contained diagnostic; a fresh coordinator is fine
+            // (HybridExecutionCoordinator is stateless).
+            MinimalClientView(executionCoordinator: HybridExecutionCoordinator())
+        }
+    }
+
+    // MARK: - Retrieval Section
+    @ViewBuilder
+    private var retrievalSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Retrieval")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.secondary)
+
+            Toggle("Deep Search", isOn: $deepSearchEnabled)
+                .font(.system(size: 15))
+
+            Text("Multi-round local query expansion for broader retrieval. Runs fully on-device. Slower than standard retrieval — off by default.")
+                .font(.caption)
+                .foregroundColor(.secondary)
         }
     }
 
@@ -241,6 +273,23 @@ struct SettingsView: View {
             Text("Debug options for development. These are placeholder toggles and do not affect functionality yet.")
                 .font(.caption)
                 .foregroundColor(.secondary)
+
+            #if DEBUG
+            Divider()
+                .padding(.vertical, 4)
+
+            Button {
+                showMinimalClient = true
+            } label: {
+                Label("Open Minimal Client", systemImage: "ladybug")
+                    .font(.system(size: 15))
+            }
+            .buttonStyle(.bordered)
+
+            Text("EPIC1 vertical-slice debug screen (prompt → coordinator → response). Debug builds only; not shipped in Release.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            #endif
         }
     }
 

--- a/Apps/iOS/NoesisNoemaMobile/Views/TabRootView.swift
+++ b/Apps/iOS/NoesisNoemaMobile/Views/TabRootView.swift
@@ -8,6 +8,11 @@
 import SwiftUI
 
 struct TabRootView: View {
+    /// App-level hybrid runtime entry point, threaded from @main via RootView.
+    let executionCoordinator: ExecutionCoordinating
+
+    /// One shared store for all tabs — questions asked on the Chat tab
+    /// (MobileHomeView) appear in History, and Settings imports the same store.
     @StateObject private var documentManager = DocumentManager()
     @State private var selectedTab = 0
 
@@ -18,18 +23,18 @@ struct TabRootView: View {
         ZStack(alignment: .bottom) {
             Group {
                 switch selectedTab {
-                case 0:
-                    let view: ChatView = ChatView(documentManager: documentManager)
-                    view
                 case 1:
-                    let view: HistoryView = HistoryView(documentManager: documentManager)
-                    view
+                    HistoryView(documentManager: documentManager)
                 case 2:
-                    let view: SettingsView = SettingsView(documentManager: documentManager)
-                    view
+                    SettingsView(documentManager: documentManager)
                 default:
-                    let view: ChatView = ChatView(documentManager: documentManager)
-                    view
+                    // Tab 0 (and fallback): the full chat screen with the
+                    // Model/Preset header. Routes inference through the shared
+                    // app-level coordinator (no per-view news-up).
+                    MobileHomeView(
+                        documentManager: documentManager,
+                        executionCoordinator: executionCoordinator
+                    )
                 }
             }
             .padding(.bottom, tabBarHeight)
@@ -43,5 +48,5 @@ struct TabRootView: View {
 }
 
 #Preview {
-    TabRootView()
+    TabRootView(executionCoordinator: HybridExecutionCoordinator())
 }

--- a/Shared/Runtime/Executors/LocalExecutor.swift
+++ b/Shared/Runtime/Executors/LocalExecutor.swift
@@ -3,6 +3,7 @@
 // Created: 2026-03-07
 // Updated: 2026-05-21 (R1: wired to real RAG pipeline; stub removed per ADR-0008)
 // Updated: 2026-05-22 (R2: return retrieved chunks as ExecutionResult.sources)
+// Updated: 2026-05-22 (Phase 1: optional DeepSearch retrieval behind a UserDefaults flag)
 // License: MIT License
 
 import Foundation
@@ -25,6 +26,16 @@ import Foundation
 ///   inference is local (llama.cpp). Enforcement of the network cutoff is
 ///   tracked in R3 and verified by UAT U2.
 final class LocalExecutor: Executor {
+
+    /// UserDefaults key for the "Deep Search" retrieval setting.
+    ///
+    /// When `true`, Stage 1 retrieval uses `DeepSearch` (multi-round local
+    /// query expansion + MMR) instead of a single-pass `LocalRetriever`.
+    /// Off by default — DeepSearch runs several retrieval rounds and is
+    /// noticeably heavier; the user opts in via SettingsView ▸ Advanced.
+    /// Both retrievers are fully local (no network), so R3's Privacy Step 4.5
+    /// guarantee is unaffected by either choice.
+    static let deepSearchDefaultsKey = "deepSearchEnabled"
 
     /// Number of chunks to retrieve, platform-tuned (matches prior v0.3 behavior).
     private var defaultTopK: Int {
@@ -50,10 +61,19 @@ final class LocalExecutor: Executor {
         let traceId = UUID()
 
         // Stage 1: Retrieve relevant chunks (local, off main thread).
+        // Both retrieval paths are local-only; DeepSearch is opt-in (heavier).
         let topK = defaultTopK
+        let useDeepSearch = UserDefaults.standard.bool(forKey: Self.deepSearchDefaultsKey)
         let chunks = await Task.detached(priority: .userInitiated) {
-            let retriever = LocalRetriever(store: VectorStore.shared)
-            return retriever.retrieve(query: query, k: topK, trace: false)
+            if useDeepSearch {
+                var config = DeepSearch.Config()
+                config.topK = topK
+                return DeepSearch(store: VectorStore.shared, config: config)
+                    .retrieve(query: query)
+            } else {
+                let retriever = LocalRetriever(store: VectorStore.shared)
+                return retriever.retrieve(query: query, k: topK, trace: false)
+            }
         }.value
 
         // Stage 2: Build context from retrieved chunks.


### PR DESCRIPTION
## Phase 1 — restore the full iOS UI + finish the coordinator wiring

After ADR-0008 R1–R4, the iOS app still rendered only `MinimalClientView` (the EPIC1 vertical-slice debug screen). The full UI already existed in the codebase but was not wired to the entry point. This PR restores it. **Mostly re-wiring, not rewriting** — the engines were already alive.

### Step 1 — full UI restored; MinimalClientView kept as a debug screen

- `RootView` now renders **`TabRootView`** (Chat / History / Settings tabs) instead of `MinimalClientView`.
- `TabRootView` **tab 0 = `MobileHomeView`** (the chat screen with the manuscript-style Model/Preset header, matching `docs/assets/noesisnoema_ios.png`) instead of `ChatView`. Tabs 1/2 stay `HistoryView`/`SettingsView`.
- **MinimalClientView debug toggle:** `SettingsView ▸ Advanced` gains a `#if DEBUG` "Open Minimal Client" button that presents `MinimalClientView` as a sheet. Chosen as the **least-invasive** approach: the *entry point* is `#if DEBUG`-gated (absent in Release builds), so no coordinator threading into `SettingsView` is needed — the debug screen is self-contained and gets its own fresh (stateless) `HybridExecutionCoordinator`. `MinimalClientView` is **kept, not deleted**.

### Step 2 — app-level coordinator threaded through (pays down R2 debt)

The single `HybridExecutionCoordinator` created in `@main` is now threaded **`@main` → `RootView` → `TabRootView` → `MobileHomeView`**. The in-app path no longer relies on the per-view `= HybridExecutionCoordinator()` default flagged in PR #83; that default is retained **only** for `#Preview`/tests. No routing/policy/privacy logic changed — dependency wiring only.

**Init adaptation:** `MobileHomeView.documentManager` changed from a view-owned `@StateObject` to an injected `@ObservedObject`. `DocumentManager` is **not** a singleton, so a view-owned instance isolated MobileHomeView's QA history from the History/Settings tabs — injecting `TabRootView`'s shared store fixes that (a question asked on the Chat tab now appears in History). `ChatView` is no longer referenced by the app; left in place (not deleted — orphan cleanup is out of scope).

### Step 3 — feedback loop verified (no redesign)

The 👍/👎 path **compiles and is connected**. On iOS: `HistoryView` → `HistoryDetailSheet` (tap a history row) → `submitFeedback` → `FeedbackStore.shared.save(...)` **and** `RewardBus.shared.publish(...)`. `RewardBus` has real subscribers — `SemanticAnswerCache`, `OnlineSGDReranker` (`subscribeDocFeedback`), and `ParamBandit` consumes it — so it is **not** an orphaned publisher.

**Findings for the later feedback/operations review:**
- **Possible double-publish.** `HistoryDetailSheet.submitFeedback` calls `FeedbackStore.shared.save(rec)` *and* `RewardBus.shared.publish(...)` — but `FeedbackStore.save` itself **also** publishes to `RewardBus` (`FeedbackStore.swift:96`). A single 👍/👎 tap therefore emits **two** `RewardEvent`s. Likely unintended double-counting; worth de-duplicating.
- **`QADetailView` is the macOS detail view**, not the iOS one. It is used by `Shared/ContentView.swift` (macOS `ContentView`). The iOS History tab uses `HistoryDetailSheet` (defined in `HistoryView.swift`) — which has its own citations-free feedback UI. Both publish to `RewardBus`. The iOS feedback loop is intact via `HistoryDetailSheet`; `QADetailView` is simply a separate (macOS) screen.

### Step 4 — Deep Search reconnected to the retrieval path

- `LocalExecutor.execute` Stage 1 retrieval can now use `DeepSearch` (multi-round local query expansion + MMR) instead of single-pass `LocalRetriever`, **behind a flag** (`LocalExecutor.deepSearchDefaultsKey`, a `UserDefaults` key).
- **Decision: OFF by default + a Settings toggle.** DeepSearch runs several retrieval rounds per query (`rounds × breadth` retrieve calls) and is noticeably heavier — not "clearly cheap" — so on-by-default would regress on-device latency. `SettingsView ▸ Retrieval` has the `@AppStorage`-bound toggle.
- The swap sits at the single retrieval call site in `LocalExecutor.execute`. Both retrievers return `[Chunk]`, so `ExecutionResult.sources`/citation plumbing is unchanged. Retrieval stays **off the MainActor** (inside `Task.detached`, R1 perf intent). `DeepSearch` imports **only `Foundation`** — confirmed local-only — so R3's Privacy Step 4.5 guarantee is unaffected.

### Files changed (5)

| File | Change |
|---|---|
| `Apps/iOS/NoesisNoemaMobile/RootView.swift` | render `TabRootView` |
| `Apps/iOS/NoesisNoemaMobile/Views/TabRootView.swift` | `executionCoordinator` param; tab 0 = `MobileHomeView` |
| `Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift` | injected `documentManager`; coordinator via init |
| `Apps/iOS/NoesisNoemaMobile/Views/SettingsView.swift` | Retrieval section (Deep Search toggle) + `#if DEBUG` MinimalClient entry |
| `Shared/Runtime/Executors/LocalExecutor.swift` | optional `DeepSearch` retrieval behind the flag |

### Build status — verified

- **macOS** (`NoesisNoema`, Debug): ✅ `** BUILD SUCCEEDED **`
- **iOS Simulator** (`NoesisNoemaMobile`, arm64, Debug): ✅ `** BUILD SUCCEEDED **`

No new warnings. No bit-rot encountered — `TabRootView`/`HistoryView`/`SettingsView`/`MobileHomeView` all compiled with only the init adaptation described above.

### Next

Phase 2 — model update to Llama 3.2 3B (separate prompt). Suggested follow-ups from Step 3: de-duplicate the `FeedbackStore.save` + `RewardBus.publish` double-publish; decide whether the orphaned `ChatView` should be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)