### PR TITLE
Phase 2: default model → Llama 3.2 3B Q4_K_M (bundled)

### DIFF
--- a/Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift
+++ b/Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift
@@ -19,7 +19,7 @@ struct MobileHomeView: View {
     @State private var question: String = ""
     @State private var isLoading: Bool = false
     @State private var errorMessage: String?
-    @State private var selectedLLMModel: String = "Jan-V1-4B"
+    @State private var selectedLLMModel: String = "Llama 3.2 3B"
     @State private var selectedLLMPreset: String = ModelManager.shared.currentLLMPreset
 
     @State private var isAutotuningModel: Bool = false

--- a/Apps/iOS/NoesisNoemaMobile/Views/SettingsView.swift
+++ b/Apps/iOS/NoesisNoemaMobile/Views/SettingsView.swift
@@ -13,7 +13,7 @@ struct SettingsView: View {
     @ObservedObject private var modelManager = ModelManager.shared
 
     @State private var selectedEmbeddingModel: String = "default-embedding"
-    @State private var selectedLLMModel: String = "Jan-V1-4B"
+    @State private var selectedLLMModel: String = "Llama 3.2 3B"
     @State private var selectedLLMPreset: String = ModelManager.shared.currentLLMPreset
     @State private var isAutotuningModel: Bool = false
     @State private var recommendedReady: Bool = false

--- a/Apps/macOS/NoesisNoema/ModelRegistry/Core/ModelRegistry.swift
+++ b/Apps/macOS/NoesisNoema/ModelRegistry/Core/ModelRegistry.swift
@@ -21,6 +21,25 @@ actor ModelRegistry {
     /// Predefined model specifications (fallbacks)
     private let predefinedSpecs: [ModelSpec] = [
         ModelSpec(
+            id: "llama-3.2-3b",
+            name: "Llama 3.2 3B",
+            modelFile: "Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+            version: "3B",
+            metadata: GGUFMetadata(
+                architecture: "llama",
+                parameterCount: 3.2,
+                contextLength: 131072,
+                quantization: "Q4_K_M",
+                layerCount: 28,
+                embeddingDimension: 3072,
+                feedForwardDimension: 8192,
+                attentionHeads: 24,
+                supportsFlashAttention: true
+            ),
+            tags: ["llama", "small", "q4_k_m", "long-context", "instruct"],
+            description: "Llama 3.2 3B Instruct, Q4_K_M quantization — default on-device model"
+        ),
+        ModelSpec(
             id: "jan-v1-4b",
             name: "Jan-V1-4B",
             modelFile: "Jan-v1-4B-Q4_K_M.gguf",

--- a/Shared/LLMModel.swift
+++ b/Shared/LLMModel.swift
@@ -56,7 +56,7 @@ class LLMModel: @unchecked Sendable {
 
         // Step 1: Resolve model path
         print("🔍 [LLMModel] STEP 1: Resolving model path...")
-        let fileName = modelFile.isEmpty ? "Jan-v1-4B-Q4_K_M.gguf" : modelFile
+        let fileName = modelFile.isEmpty ? "Llama-3.2-3B-Instruct-Q4_K_M.gguf" : modelFile
         print("   File name: \(fileName)")
         let modelPath = try resolveModelPath(fileName: fileName)
         print("✅ [LLMModel] Model path resolved: \(modelPath)")

--- a/Shared/Llama/LlamaState.swift
+++ b/Shared/Llama/LlamaState.swift
@@ -49,8 +49,8 @@ class LlamaState: ObservableObject {
         let primaryFile = "llama3-8b.gguf"
         let secondaryFile = "Jan-v1-4B-Q4_K_M.gguf"
         #else
-        let primaryFile = "Jan-v1-4B-Q4_K_M.gguf"
-        let secondaryFile = "llama3-8b.gguf"
+        let primaryFile = "Llama-3.2-3B-Instruct-Q4_K_M.gguf"
+        let secondaryFile = "Jan-v1-4B-Q4_K_M.gguf"
         #endif
         func findInBundle(_ file: String) -> URL? {
             let nameNoExt = (file as NSString).deletingPathExtension

--- a/Shared/ModelManager.swift
+++ b/Shared/ModelManager.swift
@@ -23,7 +23,7 @@ class ModelManager: ObservableObject {
 
     // MARK: - UI-facing additions
     @Published private(set) var currentEmbeddingModel: EmbeddingModel = EmbeddingModel(name: "nomic-embed-text")
-    @Published private(set) var currentLLMModel: LLMModel = LLMModel(name: "Jan-V1-4B", modelFile: "Jan-v1-4B-Q4_K_M.gguf", version: "v1", isEmbedded: true)
+    @Published private(set) var currentLLMModel: LLMModel = LLMModel(name: "Llama 3.2 3B", modelFile: "Llama-3.2-3B-Instruct-Q4_K_M.gguf", version: "3.2", isEmbedded: true)
     @Published private(set) var currentLLMPreset: String = "auto"
 
     // Hardware-level runtime mode (macOS UI)
@@ -67,12 +67,19 @@ class ModelManager: ObservableObject {
             }
             SystemLog().logEvent(event: "[ModelManager] Restored last model: \(lastModelIDString)")
         } else {
-            // Pick first available model as default
-            if let firstModel = availableModels.first {
-                selectedModelID = ModelID(firstModel.id)
-                currentModelID = firstModel.id
-                currentLLMModel = LLMModel(name: firstModel.name, modelFile: firstModel.modelFile, version: firstModel.version, isEmbedded: true)
-                SystemLog().logEvent(event: "[ModelManager] Set default model: \(firstModel.name)")
+            // Prefer the configured default model — the one currentLLMModel is
+            // declared with — when its file is among the available models;
+            // otherwise fall back to the first available model. Matching on
+            // modelFile (not name) keeps the declared default authoritative
+            // even when several models are bundled.
+            let configuredFile = currentLLMModel.modelFile
+            let defaultModel = availableModels.first(where: { $0.modelFile == configuredFile })
+                ?? availableModels.first
+            if let defaultModel {
+                selectedModelID = ModelID(defaultModel.id)
+                currentModelID = defaultModel.id
+                currentLLMModel = LLMModel(name: defaultModel.name, modelFile: defaultModel.modelFile, version: defaultModel.version, isEmbedded: true)
+                SystemLog().logEvent(event: "[ModelManager] Set default model: \(defaultModel.name)")
             }
         }
     }


### PR DESCRIPTION
## Phase 2 — switch the default on-device LLM to Llama 3.2 3B Instruct (Q4_K_M)

Code-side change: the app now expects **`Llama-3.2-3B-Instruct-Q4_K_M.gguf`** as its default bundled model instead of `Jan-v1-4B-Q4_K_M.gguf`. Same **bundled** distribution method (DL-based distribution is a separate future task). The ~2GB `.gguf` is vendored out-of-git and placed manually by Taka — see **Manual steps** below.

### Code changes (6 files)

| File | Change |
|---|---|
| `Shared/ModelManager.swift` | `currentLLMModel` default → `LLMModel(name: "Llama 3.2 3B", modelFile: "Llama-3.2-3B-Instruct-Q4_K_M.gguf", version: "3.2", isEmbedded: true)`. Also: `setDefaultModel()`'s no-prior-selection branch now prefers the **configured default** (matched by `modelFile`) over the arbitrary alphabetically-first model — so the declared default stays authoritative even if both ggufs are bundled. The `lastSelectedModelID` restore path is unchanged. |
| `Apps/macOS/NoesisNoema/ModelRegistry/Core/ModelRegistry.swift` | Added a `Llama 3.2 3B` predefined `ModelSpec` (llama arch, 3.2B, 128K ctx, Q4_K_M, 28 layers). **Jan-V1-4B kept** as a selectable entry. |
| `Shared/LLMModel.swift` | `generateAsync` empty-`modelFile` fallback filename → new gguf. |
| `Shared/Llama/LlamaState.swift` | `defaultModelUrl` iOS branch: primary → new gguf, secondary → Jan (was `llama3-8b`). macOS branch untouched. |
| `Apps/iOS/.../SettingsView.swift`, `MobileHomeView.swift` | `selectedLLMModel` `@State` default string → `"Llama 3.2 3B"` (initial picker/header display consistency). |

### `.gitignore`

Already ignores `*.gguf` (`.gitignore:355`) — **confirmed, no change needed**. The model is never committed (same vendoring policy as the `llama.xcframework`).

### ⚠️ Chat template — flagged, NOT changed (needs on-device decision)

**This is the key finding.** `buildPrompt()` in `Shared/Llama/NoesisCompletionPipeline.swift` hardcodes the **ChatML** template:
```
<|im_start|>system … <|im_end|>
<|im_start|>user … <|im_end|>
<|im_start|>assistant
```
ChatML is the **Qwen/Jan** template. **Llama 3.2 uses a different instruct template** (`<|start_header_id|>role<|end_header_id|>` … `<|eot_id|>`). A wrong template produces garbled/low-quality output even though the model loads fine.

**Why it is not fixed in this PR** (per the task's "stop and report if large/uncertain"): I traced the bridge. `LibLlama.swift:407` tokenizes with `llama_tokenize(..., add_bos: true, parse_special: false)`:
- **BOS is auto-added** → a literal `<|begin_of_text|>` must NOT be in the prompt string.
- **`parse_special: false`** → template control tokens are tokenized as *ordinary text*, not real special tokens. The current ChatML setup already relies on this (Qwen models tolerate ChatML-as-text well). Whether Llama 3.2 produces acceptable output with its template-as-literal-text — or whether `parse_special` must be flipped to `true` (a deeper bridge change affecting all tokenization) — **cannot be determined without on-device testing**.

Generation **stop** is safe regardless: `completion_loop` ends on the native `llama_vocab_is_eog` check (`LibLlama.swift:249`), which recognizes Llama 3.2's `<|eot_id|>`/`<|end_of_text|>` from the GGUF vocab. The manual `<|im_end|>` string-match in the loop is a redundant secondary check that simply won't fire for Llama 3.2 (harmless).

**Options for the follow-up (recommend Taka verify on-device, then pick):**
- **Option A (most correct):** rewrite `buildPrompt()` to the Llama 3.2 template **and** flip the `tokenize` call to `parse_special: true` so control tokens become real special tokens. Verify Jan still works (or drop Jan). Needs on-device output review.
- **Option B (partial):** rewrite `buildPrompt()` to the Llama 3.2 template, keep `parse_special: false`. Strictly better than feeding ChatML to a Llama model (the model sees its own structure), but control tokens remain literal text.
- **Option C:** make `buildPrompt()` model-aware (architecture from `currentLLMModel`/registry) so Jan and Llama 3.2 each get their own template — best if both models stay selectable.

This should be its own small PR with on-device verification — it is exactly the "garbled output" risk the task called out, and guessing the format/flag without running it is not safe.

### Build status — verified

- **macOS** (`NoesisNoema`, Debug): ✅ `** BUILD SUCCEEDED **`
- **iOS Simulator** (`NoesisNoemaMobile`, arm64, Debug): ✅ `** BUILD SUCCEEDED **`

The `.gguf` is a **runtime** resource (resolved via `Bundle.main.url`), not a compile-time dependency — so the Swift code compiles fully **without** the file present. The build does not fail without it; the model only matters at run time.

---

## Manual steps for Taka

1. **Download** `Llama-3.2-3B-Instruct-Q4_K_M.gguf` (~2GB) from Hugging Face — e.g. `bartowski/Llama-3.2-3B-Instruct-GGUF` (the `Q4_K_M` build) or an equivalent. Verify the **Llama 3.2 Community License** is acceptable for the intended use.
2. **Place it** where bundle resolution expects it — the same Xcode group/folder Jan-4B's gguf sits in: **`Apps/macOS/NoesisNoema/Resources/Models/`** (this folder is in the synchronized resource group; `resolveModelPath` / `ModelRegistry` search `Resources/Models`, `Models`, and the bundle root). Add it to the app target's bundled resources exactly as Jan-4B was added (iOS `NoesisNoemaMobile` target membership; the macOS-folder synchronized group already covers `Resources/Models`).
3. **Confirm it is not staged by git**: `git status` should not list the `.gguf` (`.gitignore` rule `*.gguf` covers it).
4. **Build + run on device** and verify: (a) the model loads; (b) **a question returns a coherent answer** — if output is garbled/low-quality, the chat template (above) needs the Option A/B/C fix; (c) the header shows "Llama 3.2 3B"; (d) citations still populate.
5. **Optionally** remove the old `Jan-v1-4B-Q4_K_M.gguf` from the bundle if shipping only one model (smaller binary). With it removed, `setDefaultModel` trivially selects Llama 3.2 3B; with both kept, the new `setDefaultModel` logic still picks Llama 3.2 3B as the configured default.

Once the gguf is placed and the app is built, the app will run **Llama 3.2 3B** with the header reflecting the new model — **subject to the chat-template verification in step 4b.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)