### PR TITLE
fix(ios): chat transcript display, OS color scheme, history role separation, clear-history

### DIFF
--- a/Apps/iOS/NoesisNoemaMobile/Views/HistoryView.swift
+++ b/Apps/iOS/NoesisNoemaMobile/Views/HistoryView.swift
@@ -46,7 +46,7 @@ struct HistoryView: View {
             }
         }
         .frame(maxWidth: CGFloat.infinity, maxHeight: CGFloat.infinity)
-        .background(Color.white)
+        .background(Color(.systemBackground))
         .sheet(isPresented: $showDetailSheet) {
             if let qa = selectedQA {
                 HistoryDetailSheet(qa: qa)

--- a/Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift
+++ b/Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift
@@ -2,18 +2,18 @@
 //  MobileHomeView.swift
 //  NoesisNoemaMobile
 //
-//  Full-screen iOS redesign for Noesis Noema
-//  iOS 18+ optimized layout with proper safe area handling
+//  Chat screen: a model/preset header, an inline conversation transcript, and
+//  a bottom-pinned question input. The transcript renders documentManager's
+//  Q&A pairs as a conversation so an answer appears HERE immediately after
+//  asking — no History-tab round-trip (UAT #3). The browsable archive lives in
+//  the History tab; the Chat tab no longer embeds a history list (UAT #4).
 //
 
 import SwiftUI
-import UniformTypeIdentifiers
 
 struct MobileHomeView: View {
     /// Shared QA/document store, injected by `TabRootView` so the Chat tab,
     /// History tab, and Settings tab all observe the same instance.
-    /// (Phase 1: was a view-owned `@StateObject` — that isolated MobileHomeView's
-    /// history from the other tabs; now injected.)
     @ObservedObject var documentManager: DocumentManager
 
     @State private var question: String = ""
@@ -27,7 +27,6 @@ struct MobileHomeView: View {
     @State private var autotuneWarning: String? = nil
 
     @State private var runtimeMode: RuntimeMode = ModelManager.shared.getRuntimeMode()
-    @State private var showImporter = false
 
     @FocusState private var questionFocused: Bool
 
@@ -36,8 +35,8 @@ struct MobileHomeView: View {
     /// ModelManager monolith directly.
     private let executionCoordinator: ExecutionCoordinating
 
-    // Keep in sync with TabBarView height
-    private let tabBarHeight: CGFloat = 60
+    /// Anchor id for the in-flight "Generating…" indicator (auto-scroll target).
+    private static let loadingIndicatorID = "transcript.loading.indicator"
 
     /// - Parameters:
     ///   - documentManager: Shared QA/document store (injected by `TabRootView`).
@@ -52,34 +51,25 @@ struct MobileHomeView: View {
         self.executionCoordinator = executionCoordinator
     }
 
-    var availableEmbeddingModels: [String] { ModelManager.shared.availableEmbeddingModels }
     var availableLLMModels: [String] { ModelManager.shared.availableLLMModels }
     var availableLLMPresets: [String] { ModelManager.shared.availableLLMPresets }
 
     var body: some View {
-        GeometryReader { proxy in
-            let fullHeight = proxy.size.height
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    modePickerSection
-                    modelSelectorSection
-                    promptInputSection
-                    actionButtonsSection
-                    historySection
-                }
+        VStack(spacing: 0) {
+            modelSelectorSection
                 .padding(.horizontal, 16)
-                .padding(.top, 16)
-                .padding(.bottom, tabBarHeight) // keep content above the tab bar
-                .frame(minHeight: fullHeight)   // ensure content at least fills the viewport
-            }
-            .frame(width: proxy.size.width, height: fullHeight)
-            .background(Color(.systemGroupedBackground))
-            .scrollDismissesKeyboard(.interactively)
-            .onAppear {
-                runtimeMode = ModelManager.shared.getRuntimeMode()
-            }
+                .padding(.top, 12)
+                .padding(.bottom, 8)
+
+            transcriptSection
+
+            inputBar
         }
-        .ignoresSafeArea(.all)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemBackground))
+        .onAppear {
+            runtimeMode = ModelManager.shared.getRuntimeMode()
+        }
         .alert(
             "Couldn’t generate an answer",
             isPresented: Binding(
@@ -94,44 +84,7 @@ struct MobileHomeView: View {
         }
     }
 
-    // MARK: - Mode Picker Section
-
-    @ViewBuilder
-    private var modePickerSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Runtime Parameters")
-                .font(.subheadline)
-                .fontWeight(.semibold)
-                .foregroundStyle(.secondary)
-
-            HStack(spacing: 12) {
-                Picker("", selection: $runtimeMode) {
-                    Text("Use recommended").tag(RuntimeMode.recommended)
-                    Text("Override").tag(RuntimeMode.override)
-                }
-                .pickerStyle(.segmented)
-                .onChange(of: runtimeMode) { newValue in
-                    ModelManager.shared.setRuntimeMode(newValue)
-                    if newValue == .recommended {
-                        recommendedReady = true
-                    }
-                }
-                .accessibilityLabel("Runtime parameters mode")
-
-                Button("Reset") {
-                    resetAll()
-                }
-                .buttonStyle(.bordered)
-                .disabled(runtimeMode != .override)
-                .accessibilityLabel("Reset to recommended parameters")
-            }
-        }
-        .padding(16)
-        .background(.regularMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-    }
-
-    // MARK: - Model Selector Section
+    // MARK: - Model Selector Section (acts as the chat header)
 
     @ViewBuilder
     private var modelSelectorSection: some View {
@@ -211,153 +164,110 @@ struct MobileHomeView: View {
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
-    // MARK: - Prompt Input Section
+    // MARK: - Conversation Transcript
 
-    @ViewBuilder
-    private var promptInputSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Your Question")
-                .font(.subheadline)
-                .fontWeight(.semibold)
-                .foregroundStyle(.secondary)
-
-            ZStack(alignment: .topLeading) {
-                TextEditor(text: $question)
-                    .frame(minHeight: 100, idealHeight: 120, maxHeight: 200)
-                    .padding(12)
-                    .background(
-                        RoundedRectangle(cornerRadius: 12)
-                            .fill(Color(.systemBackground))
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(questionFocused ? Color.accentColor : Color.secondary.opacity(0.2), lineWidth: questionFocused ? 2 : 1)
-                    )
-                    .focused($questionFocused)
-                    .disabled(isLoading)
-                    .toolbar {
-                        ToolbarItemGroup(placement: .keyboard) {
-                            Spacer()
-                            Button("Done") {
-                                questionFocused = false
-                            }
+    /// The live conversation. Renders `documentManager.qaHistory` as chat turns
+    /// (question bubble + answer) so the answer is visible on the Chat tab the
+    /// moment `startAsk()` completes. Auto-scrolls to the newest turn.
+    private var transcriptSection: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                if documentManager.qaHistory.isEmpty && !isLoading {
+                    emptyTranscript
+                } else {
+                    LazyVStack(alignment: .leading, spacing: 16) {
+                        ForEach(documentManager.qaHistory) { qa in
+                            QATurnView(qa: qa)
+                                .id(qa.id)
+                        }
+                        if isLoading {
+                            generatingIndicator
+                                .id(Self.loadingIndicatorID)
                         }
                     }
-
-                if question.isEmpty {
-                    Text("Enter your question")
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 18)
-                        .padding(.vertical, 16)
-                        .allowsHitTesting(false)
+                    .padding(16)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
-
-            HStack {
-                Spacer()
-                Text("\(question.count) characters")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .scrollDismissesKeyboard(.interactively)
+            .onChange(of: documentManager.qaHistory.count) { _ in
+                scrollToLatest(proxy)
+            }
+            .onChange(of: isLoading) { _ in
+                scrollToLatest(proxy)
             }
         }
     }
 
-    // MARK: - Action Buttons Section
-
-    @ViewBuilder
-    private var actionButtonsSection: some View {
-        VStack(spacing: 12) {
-            Button(action: { startAsk() }) {
-                HStack {
-                    if isLoading {
-                        ProgressView()
-                            .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                            .scaleEffect(0.8)
-                    }
-                    Text(isLoading ? "Asking..." : "Ask")
-                        .fontWeight(.semibold)
-                }
-                .frame(maxWidth: .infinity, minHeight: 50)
-            }
-            .buttonStyle(.borderedProminent)
-            .disabled(question.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isLoading)
-            .accessibilityLabel("Submit question")
-
-            Button(action: { showImporter = true }) {
-                Label("Choose RAG Document", systemImage: "doc.zipper")
-                    .frame(maxWidth: .infinity, minHeight: 50)
-            }
-            .buttonStyle(.bordered)
-            .disabled(isLoading)
-            .fileImporter(
-                isPresented: $showImporter,
-                allowedContentTypes: [UTType.zip]
-            ) { result in
-                if case let .success(url) = result {
-                    documentManager.importDocument(file: url)
-                }
-            }
-            .accessibilityLabel("Import RAG document")
-        }
-    }
-
-    // MARK: - History Section
-
-    @ViewBuilder
-    private var historySection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("History")
-                .font(.title3)
-                .fontWeight(.bold)
-                .padding(.top, 8)
-
-            if documentManager.qaHistory.isEmpty {
-                emptyHistoryView
-            } else {
-                historyList
+    private func scrollToLatest(_ proxy: ScrollViewProxy) {
+        withAnimation(.easeOut(duration: 0.25)) {
+            if isLoading {
+                proxy.scrollTo(Self.loadingIndicatorID, anchor: .bottom)
+            } else if let last = documentManager.qaHistory.last {
+                proxy.scrollTo(last.id, anchor: .bottom)
             }
         }
     }
 
-    @ViewBuilder
-    private var emptyHistoryView: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "text.bubble")
-                .font(.system(size: 48))
+    private var emptyTranscript: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "bubble.left.and.bubble.right")
+                .font(.system(size: 44))
                 .foregroundStyle(.secondary)
-            Text("No questions yet")
-                .font(.headline)
+            Text("Ask me anything.")
+                .font(.system(size: 16, weight: .medium))
                 .foregroundStyle(.secondary)
-            Text("Ask a question to get started")
-                .font(.subheadline)
-                .foregroundStyle(.tertiary)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 24)
+        .padding(.top, 72)
     }
 
-    @ViewBuilder
-    private var historyList: some View {
-        LazyVStack(spacing: 12) {
-            ForEach(documentManager.qaHistory) { qa in
-                HistoryCard(qa: qa, isLoading: isLoading) {
-                    if !isLoading {
-                        questionFocused = false
-                        documentManager.selectedQAPair = qa
+    private var generatingIndicator: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+            Text("Generating…")
+                .font(.system(size: 14))
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+        }
+    }
+
+    // MARK: - Input Bar (pinned to the bottom)
+
+    private var inputBar: some View {
+        HStack(spacing: 10) {
+            TextField("Type your question…", text: $question)
+                .textFieldStyle(.plain)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(Color(.secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 18))
+                .focused($questionFocused)
+                .disabled(isLoading)
+                .onSubmit(startAsk)
+
+            Button(action: startAsk) {
+                ZStack {
+                    if isLoading {
+                        ProgressView()
+                    } else {
+                        Image(systemName: "arrow.up.circle.fill")
+                            .font(.system(size: 30))
                     }
                 }
+                .frame(width: 32, height: 32)
             }
+            .disabled(isLoading || question.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .accessibilityLabel("Submit question")
         }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(Color(.systemBackground))
+        .overlay(alignment: .top) { Divider() }
     }
 
     // MARK: - Helper Methods
-
-    private func resetAll() {
-        ModelManager.shared.resetToRecommended()
-        runtimeMode = .recommended
-        recommendedReady = true
-        question = ""
-    }
 
     private func handleLLMModelChange(_ newValue: String) {
         selectedLLMModel = newValue
@@ -448,50 +358,39 @@ struct Badge: View {
     }
 }
 
-struct HistoryCard: View {
+/// One conversation turn — the question as a trailing bubble, the answer below
+/// it. Uses semantic colors so it adapts to light/dark mode.
+private struct QATurnView: View {
     let qa: QAPair
-    let isLoading: Bool
-    let action: () -> Void
 
     var body: some View {
-        Button(action: action) {
-            VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                    Image(systemName: "questionmark.circle.fill")
-                        .foregroundStyle(.tint)
-
-                    Text(qa.question)
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(.primary)
-                        .lineLimit(2)
-                        .multilineTextAlignment(.leading)
-
-                    Spacer()
-
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                HStack {
-                    Image(systemName: "text.bubble")
-                        .foregroundStyle(.secondary)
-
-                    Text(qa.answer)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(3)
-                        .multilineTextAlignment(.leading)
-                }
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Spacer(minLength: 48)
+                Text(qa.question)
+                    .font(.system(size: 15))
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .background(Color(.secondarySystemBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
             }
-            .padding(16)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(.regularMaterial)
-            .clipShape(RoundedRectangle(cornerRadius: 12))
+
+            HStack {
+                Text(qa.answer)
+                    .font(.system(size: 15))
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .background(Color(.tertiarySystemBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                Spacer(minLength: 48)
+            }
         }
-        .buttonStyle(.plain)
-        .disabled(isLoading)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/Apps/iOS/NoesisNoemaMobile/Views/SettingsView.swift
+++ b/Apps/iOS/NoesisNoemaMobile/Views/SettingsView.swift
@@ -37,6 +37,9 @@ struct SettingsView: View {
     // Debug: present the MinimalClientView (EPIC1 vertical-slice) screen.
     @State private var showMinimalClient: Bool = false
 
+    // Data: confirmation gate for the destructive "Clear History" action.
+    @State private var showClearConfirm: Bool = false
+
     var availableEmbeddingModels: [String] { ModelManager.shared.availableEmbeddingModels }
     var availableLLMModels: [String] { ModelManager.shared.availableLLMModels }
     var availableLLMPresets: [String] { ModelManager.shared.availableLLMPresets }
@@ -49,13 +52,14 @@ struct SettingsView: View {
                 runtimeSection
                 ragDocumentSection
                 retrievalSection
+                dataSection
                 advancedSection
             }
             .padding(.horizontal, 16)
             .padding(.top, 16)
         }
         .frame(maxWidth: CGFloat.infinity, maxHeight: CGFloat.infinity)
-        .background(Color.white)
+        .background(Color(.systemBackground))
         .onAppear {
             runtimeMode = ModelManager.shared.getRuntimeMode()
             useRecommended = (runtimeMode == .recommended)
@@ -293,9 +297,51 @@ struct SettingsView: View {
         }
     }
 
+    // MARK: - Data Section
+    @ViewBuilder
+    private var dataSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Data")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.secondary)
+
+            Button(role: .destructive) {
+                showClearConfirm = true
+            } label: {
+                Label("Clear History", systemImage: "trash")
+                    .font(.system(size: 15))
+            }
+            .buttonStyle(.bordered)
+            .tint(.red)
+
+            Text("Deletes all saved Q&A history, cached answers, and feedback from this device. This cannot be undone.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .confirmationDialog(
+            "Delete all Q&A history?",
+            isPresented: $showClearConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Delete All", role: .destructive) { clearAllHistory() }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("This permanently removes your Q&A history, cached answers, and feedback from this device. It cannot be undone.")
+        }
+    }
+
     // MARK: - Helper Methods
     private func showModelPicker() {
         // Placeholder for a real model picker
+    }
+
+    /// Clears every store that backs user Q&A data. Invoked only after the
+    /// explicit confirmation dialog in `dataSection` — there is no auto-wipe.
+    private func clearAllHistory() {
+        documentManager.clearQAHistroy()    // qaHistory + selection + persisted file
+        QAContextStore.shared.removeAll()   // in-memory per-QA citation context
+        FeedbackStore.shared.clearAll()         // encrypted feedback file
+        SemanticAnswerCache.shared.clearCache() // cached semantic answers
     }
 }
 

--- a/Shared/Feedback/FeedbackStore.swift
+++ b/Shared/Feedback/FeedbackStore.swift
@@ -97,6 +97,21 @@ final class FeedbackStore {
         }
     }
 
+    /// Delete all stored feedback by removing the encrypted store file.
+    /// Used by the "Clear History" action; `loadAll()` then returns `[]`.
+    func clearAll() {
+        queue.async {
+            let fm = FileManager.default
+            if fm.fileExists(atPath: self.fileURL.path) {
+                do {
+                    try fm.removeItem(at: self.fileURL)
+                } catch {
+                    print("[FeedbackStore] clearAll error: \(error)")
+                }
+            }
+        }
+    }
+
     func loadAll() throws -> [FeedbackRecord] {
         let fm = FileManager.default
         guard fm.fileExists(atPath: fileURL.path) else { return [] }

--- a/Shared/RAG/QAContextStore.swift
+++ b/Shared/RAG/QAContextStore.swift
@@ -34,4 +34,10 @@ final class QAContextStore {
     func remove(_ qaId: UUID) {
         queue.async(flags: .barrier) { self.ctx.removeValue(forKey: qaId) }
     }
+
+    /// Drop every stored per-QA context. Used by the "Clear History" action so
+    /// the citation/feedback context is wiped alongside the QA history.
+    func removeAll() {
+        queue.async(flags: .barrier) { self.ctx.removeAll() }
+    }
 }

--- a/Shared/RAG/SemanticAnswerCache.swift
+++ b/Shared/RAG/SemanticAnswerCache.swift
@@ -181,6 +181,14 @@ final class SemanticAnswerCache {
         let denom = (sqrtf(max(na, 1e-9)) * sqrtf(max(nb, 1e-9)))
         return denom == 0 ? 0 : dot/denom
     }
+    /// Clears the entire semantic answer cache (cached answers + the
+    /// QA→cache-id map). Used by the "Clear History" action so cached answers
+    /// do not survive a user-initiated data wipe.
+    func clearCache() {
+        index.clear()
+        sync.async { self.qaToCacheId.removeAll() }
+    }
+
     // Test helper
     func resetForTests() {
         index.clear()


### PR DESCRIPTION
## UAT fixes — 4 issues from on-device iPhone testing

On-device UAT (after Phase 1 #87 + Phase 2 #88) surfaced 4 issues. All fixes are view-layer plus a confirmation-gated data-clear action; the execution path (coordinator/Router/PolicyEngine/LocalExecutor/privacy) and citation plumbing are untouched.

### #3 — Chat showed no answer (jumped straight to history) — **fixed**

`MobileHomeView` had no conversation transcript: `startAsk()` appended to `documentManager.qaHistory` and cleared the field, but answers only appeared in the History tab. **Before:** ask → answer "disappears". **After:** the Chat tab has an inline transcript — the answer renders immediately below the question.

- New `transcriptSection`: a `ScrollView` of chat turns (`QATurnView` — question bubble + answer below), data source `documentManager.qaHistory`. `ScrollViewReader` **auto-scrolls** to the newest turn (and to a "Generating…" indicator while `isLoading`). Empty state: "Ask me anything."
- `MobileHomeView` restructured into a chat layout: **model/preset header + transcript + bottom-pinned input bar**.
- `startAsk()` and all coordinator/citation code are **byte-for-byte unchanged** — view-layer only.

### #4 — History duplicated on the Chat tab — **fixed**

Removed `historySection` / `historyList` / `emptyHistoryView` (and the now-unused `HistoryCard`) from `MobileHomeView`. Also removed `modePickerSection` (runtime params) and the RAG-import button — both fully covered by the Settings tab. **Net role separation:** Chat = live conversation, History = browsable archive, Settings = configuration. `HistoryView` is unchanged and remains the archive.

> **Kept** `modelSelectorSection` in MobileHomeView as the header: it is the **only working model switcher** — `SettingsView`'s "Change Model" button is a placeholder stub (`showModelPicker()` does nothing). Removing it would have regressed model switching. Flagged for a follow-up (wire up Settings' model picker, then the Chat header can become display-only).

### #1 / #2 — Dark/Light inconsistency; unreadable white-on-white — **fixed**

Hardcoded `.background(Color.white)` (non-adaptive — stays white in dark mode) replaced with `Color(.systemBackground)`:
- `HistoryView.swift:49` → `Color(.systemBackground)` (consistent with `HistoryDetailSheet`'s existing usage).
- `SettingsView.swift:58` → `Color(.systemBackground)`.
- `MobileHomeView` — rebuilt with semantic colors throughout (`systemBackground` / `secondarySystemBackground` / `tertiarySystemBackground`, `.primary`/`.secondary` text).

**No forced `preferredColorScheme`** exists anywhere in the iOS app (verified by grep) — the app already follows the OS setting; the hardcoded white backgrounds were the entire bug. Text already used semantic `.primary`/`.secondary` — no hardcoded text colors in the active views.

**Dead views skipped (stated):** `ChatView.swift` is orphaned since Phase 1 (no references — `TabRootView` uses `MobileHomeView`); `FullScreenTestView.swift` is a dead dev view (only its own `PreviewProvider`). Their `Color.white` was left as-is — polishing never-rendered code is noise. **Recommend deleting `ChatView`/`FullScreenTestView` in a cleanup PR.**

### UAT data cleanup — **Clear History action (confirmation-gated)**

`SettingsView` gains a **"Data"** section with a destructive **"Clear History"** button → a `confirmationDialog` ("Delete all Q&A history?" — *Delete All* / *Cancel*). **No auto-wipe, no launch-time deletion** — deletion happens only on explicit confirm.

`clearAllHistory()` clears every store backing user Q&A data:
| Store | What it holds | Clear method |
|---|---|---|
| `DocumentManager.qaHistory` | Q&A history + selection (persisted file via `PersistenceStore`) | `clearQAHistroy()` *(existing)* |
| `QAContextStore` | in-memory per-QA citation context | `removeAll()` *(added)* |
| `FeedbackStore` | encrypted feedback file (`feedback.enc`) | `clearAll()` *(added — deletes the file)* |
| `SemanticAnswerCache` | cached answers + QA→cache map | `clearCache()` *(added — production twin of the test-only `resetForTests()`)* |

### Build status — verified

- **macOS** (`NoesisNoema`, Debug): ✅ `** BUILD SUCCEEDED **`
- **iOS Simulator** (`NoesisNoemaMobile`, arm64, Debug): ✅ `** BUILD SUCCEEDED **`

No new warnings.

### Files changed (6)

`MobileHomeView.swift` (restructure), `HistoryView.swift` (color), `SettingsView.swift` (color + Clear History), `QAContextStore.swift` / `FeedbackStore.swift` / `SemanticAnswerCache.swift` (clear methods). Three conventional commits.

### ⚠️ Notes for the maintainer

- **The Llama 3.2 gguf was found *staged* in the working tree** (Phase 2 manual placement) — I **unstaged it** (`.gitignore` `*.gguf` vendoring policy; a ~2GB file must never be committed). The file remains on disk for builds. The **`project.pbxproj` is modified** (Phase 2 bundle-resource wiring) and was **left as uncommitted WIP** — it is *not* part of this PR. Also: the placed file is lowercased `llama-3.2-3b-instruct-q4_k_m.gguf` while Phase 2 code expects mixed-case `Llama-3.2-3B-Instruct-Q4_K_M.gguf` — **verify on-device resolution** (iOS filesystem is case-sensitive).
- **Feedback double-publish** (separate known issue, not addressed here): `HistoryDetailSheet.submitFeedback` calls `FeedbackStore.save()` *and* `RewardBus.publish()`, but `FeedbackStore.save()` itself also publishes — one 👍/👎 emits two `RewardEvent`s. Flagged in Phase 1; still open.
- Follow-ups: delete orphaned `ChatView`/`FullScreenTestView`; wire `SettingsView`'s placeholder model picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)