### PR TITLE
feat(runtime): session memory — multi-turn context (ADR-0009)

### DIFF
--- a/Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift
+++ b/Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift
@@ -307,10 +307,17 @@ struct MobileHomeView: View {
         // The heavy RAG + llama work runs off the main thread inside the
         // executor (LocalExecutor hops off-main for retrieval and inference);
         // this @MainActor Task only marshals UI state and the QA store.
+        //
+        // ADR-0009: session memory is the visible transcript only — the UI
+        // owns "what's visible" so the request carries exactly that. We
+        // pre-apply BOTH caps (3 turns AND 45-minute window) here via the
+        // shared helper so the executor doesn't need to know them.
+        let history = SessionMemory.history(from: documentManager.qaHistory)
+
         Task { @MainActor in
             do {
                 let response = try await executionCoordinator.execute(
-                    request: NoemaRequest(query: trimmed)
+                    request: NoemaRequest(query: trimmed, history: history)
                 )
 
                 let newPair = documentManager.addQAPair(

--- a/NoesisNoemaTests/Runtime/SessionMemoryTests.swift
+++ b/NoesisNoemaTests/Runtime/SessionMemoryTests.swift
@@ -1,0 +1,161 @@
+// NoesisNoema - Hybrid Routing Runtime
+// Session Memory Tests (ADR-0009)
+// Created: 2026-05-26
+// License: MIT License
+//
+// Source-level tests for ADR-0009 (Session Memory). The test target is not
+// wired to a run scheme in this repo, so these compile-checked tests serve as
+// executable documentation of the invariants — they will run wherever the
+// target is wired in (e.g. via Xcode's test scheme).
+
+import XCTest
+@testable import NoesisNoema
+
+final class SessionMemoryTests: XCTestCase {
+
+    // MARK: - SessionMemory.history (ADR-0009 Decision 2)
+
+    /// 5 turns spanning >45 min ⇒ only the ≤3 most-recent **in-window** turns
+    /// survive, in chronological order.
+    func test_history_appliesBothCaps_3turnsAnd45MinWindow() {
+        let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+        // Build five turns: t-90m, t-60m (both outside the 45-min window),
+        // then t-20m, t-10m, t-2m (all inside) — the helper should drop the
+        // first two and return the three recent in-window turns in order.
+        let qaPairs: [QAPair] = [
+            QAPair(question: "Q-90", answer: "A-90", date: now.addingTimeInterval(-90 * 60)),
+            QAPair(question: "Q-60", answer: "A-60", date: now.addingTimeInterval(-60 * 60)),
+            QAPair(question: "Q-20", answer: "A-20", date: now.addingTimeInterval(-20 * 60)),
+            QAPair(question: "Q-10", answer: "A-10", date: now.addingTimeInterval(-10 * 60)),
+            QAPair(question: "Q-2",  answer: "A-2",  date: now.addingTimeInterval(-2  * 60)),
+        ]
+
+        let history = SessionMemory.history(from: qaPairs, now: now)
+
+        XCTAssertEqual(history.count, 3, "must apply both the 45-min window and the 3-turn cap")
+        XCTAssertEqual(history.map(\.question), ["Q-20", "Q-10", "Q-2"],
+                       "must return the three most recent in-window turns, oldest→newest")
+    }
+
+    /// >3 turns all inside the 45-min window ⇒ only the 3 most recent survive.
+    func test_history_capsToThreeWhenAllInWindow() {
+        let now = Date(timeIntervalSinceReferenceDate: 2_000_000)
+        let qaPairs: [QAPair] = (1...5).map { i in
+            QAPair(
+                question: "Q\(i)",
+                answer: "A\(i)",
+                // 30m, 25m, 20m, 15m, 10m ago — all inside the 45m window.
+                date: now.addingTimeInterval(TimeInterval(-(35 - i * 5) * 60))
+            )
+        }
+
+        let history = SessionMemory.history(from: qaPairs, now: now)
+
+        XCTAssertEqual(history.map(\.question), ["Q3", "Q4", "Q5"])
+    }
+
+    /// Empty transcript ⇒ empty history (ADR-0009 Decision 2 — single-turn).
+    func test_history_emptyInput_returnsEmpty() {
+        XCTAssertEqual(SessionMemory.history(from: []), [])
+    }
+
+    /// Turns missing a `date` are excluded — without a timestamp we cannot
+    /// prove they are in-window. Conservative-by-design.
+    func test_history_excludesUndatedTurns() {
+        let now = Date(timeIntervalSinceReferenceDate: 3_000_000)
+        let qaPairs: [QAPair] = [
+            QAPair(question: "no-date", answer: "x", date: nil),
+            QAPair(question: "dated", answer: "y", date: now.addingTimeInterval(-5 * 60)),
+        ]
+
+        let history = SessionMemory.history(from: qaPairs, now: now)
+
+        XCTAssertEqual(history.map(\.question), ["dated"])
+    }
+
+    // MARK: - NoemaRequest contract (ADR-0006-safe additive default)
+
+    /// Existing call sites that omit `history` must still compile and yield
+    /// an empty history field — ADR-0009 Decision 2 (empty ⇒ single-turn).
+    func test_noemaRequest_historyDefaultsToEmpty() {
+        let r1 = NoemaRequest(query: "q")
+        let r2 = NoemaRequest(query: "q", sessionId: UUID())
+        XCTAssertEqual(r1.history, [])
+        XCTAssertEqual(r2.history, [])
+    }
+
+    func test_noemaRequest_carriesHistoryWhenProvided() {
+        let turn = ConversationTurn(question: "prior?", answer: "yes.", date: Date())
+        let req = NoemaRequest(query: "follow-up?", history: [turn])
+        XCTAssertEqual(req.history, [turn])
+    }
+
+    // MARK: - buildPrompt (ChatML rendering, no template change)
+
+    /// Empty history ⇒ prompt is identical to the prior single-turn build
+    /// (no extra `<|im_start|>user` / `<|im_start|>assistant` turns inserted
+    /// before the current question).
+    func test_buildPrompt_emptyHistory_unchangedSingleTurnShape() {
+        let prompt = buildPrompt(
+            question: "What is RAG?",
+            context: "Some context.",
+            history: []
+        )
+        // Exactly one user turn and one trailing assistant opener.
+        XCTAssertEqual(occurrences(of: "<|im_start|>user", in: prompt), 1)
+        XCTAssertEqual(occurrences(of: "<|im_start|>assistant", in: prompt), 1)
+        XCTAssertTrue(prompt.contains("Question: What is RAG?"))
+        XCTAssertTrue(prompt.contains("Context:\nSome context."))
+    }
+
+    /// Prior turns render as ChatML user/assistant pairs BEFORE the current
+    /// question. The current question carries the retrieved Context;
+    /// historical turns do not.
+    func test_buildPrompt_rendersPriorTurnsBeforeCurrent() {
+        let now = Date()
+        let history = [
+            ConversationTurn(question: "Who fought in WW2?", answer: "Allies vs Axis.", date: now.addingTimeInterval(-600)),
+            ConversationTurn(question: "When did it end?", answer: "1945.", date: now.addingTimeInterval(-60)),
+        ]
+        let prompt = buildPrompt(
+            question: "Continue describing the war",
+            context: "Battle of the Bulge began in December 1944.",
+            history: history
+        )
+
+        // 2 prior user turns + 1 current = 3 user turns; 2 prior assistant
+        // turns + 1 trailing assistant opener = 3 assistant markers.
+        XCTAssertEqual(occurrences(of: "<|im_start|>user", in: prompt), 3)
+        XCTAssertEqual(occurrences(of: "<|im_start|>assistant", in: prompt), 3)
+
+        // Historical turns appear verbatim, BEFORE the current question.
+        let currentRange = prompt.range(of: "Continue describing the war")
+        XCTAssertNotNil(currentRange)
+        if let currentRange = currentRange {
+            let head = String(prompt[..<currentRange.lowerBound])
+            XCTAssertTrue(head.contains("Who fought in WW2?"))
+            XCTAssertTrue(head.contains("Allies vs Axis."))
+            XCTAssertTrue(head.contains("When did it end?"))
+            XCTAssertTrue(head.contains("1945."))
+            // Context attaches to the CURRENT user turn only — historical
+            // turns must not carry retrieved chunks.
+            XCTAssertFalse(head.contains("Battle of the Bulge"))
+        }
+
+        // Single system prompt at the top.
+        XCTAssertEqual(occurrences(of: "<|im_start|>system", in: prompt), 1)
+    }
+
+    // MARK: - Helpers
+
+    private func occurrences(of needle: String, in haystack: String) -> Int {
+        guard !needle.isEmpty else { return 0 }
+        var count = 0
+        var searchRange = haystack.startIndex..<haystack.endIndex
+        while let found = haystack.range(of: needle, range: searchRange) {
+            count += 1
+            searchRange = found.upperBound..<haystack.endIndex
+        }
+        return count
+    }
+}

--- a/Shared/Execution/ExecutionCoordinator.swift
+++ b/Shared/Execution/ExecutionCoordinator.swift
@@ -11,14 +11,47 @@ import OSLog
 
 // MARK: - Request/Response Models
 
+/// A prior Q&A turn carried into prompt construction as session memory.
+///
+/// Value type, deliberately leaner than `QAPair`: history at the request layer
+/// is generation input only — citations live with the answer in the visible
+/// transcript, not in the prompt. The UI builds this from the user-visible
+/// `DocumentManager.qaHistory` (ADR-0009 §1, §3).
+public struct ConversationTurn: Equatable, Hashable {
+    public let question: String
+    public let answer: String
+    public let date: Date
+
+    public init(question: String, answer: String, date: Date) {
+        self.question = question
+        self.answer = answer
+        self.date = date
+    }
+}
+
 /// Request object for execution
 struct NoemaRequest {
     let query: String
     let sessionId: UUID
 
-    init(query: String, sessionId: UUID = UUID()) {
+    /// Visible-transcript turns (ADR-0009) included in the GENERATION prompt.
+    ///
+    /// Additive, defaulted (ADR-0006 contract lock — existing call sites stay
+    /// source-compatible). The UI is the source of truth (must pre-apply the
+    /// 3-turn AND 45-minute caps before constructing the request) so the
+    /// executor sees exactly what the user sees. The order is chronological
+    /// (oldest → newest); the prompt renders them in that order.
+    /// Empty ⇒ behaves identically to single-turn (ADR-0009 Decision 2).
+    let history: [ConversationTurn]
+
+    init(
+        query: String,
+        sessionId: UUID = UUID(),
+        history: [ConversationTurn] = []
+    ) {
         self.query = query
         self.sessionId = sessionId
+        self.history = history
     }
 }
 

--- a/Shared/Execution/SessionMemory.swift
+++ b/Shared/Execution/SessionMemory.swift
@@ -1,0 +1,76 @@
+//
+//  SessionMemory.swift
+//  NoesisNoema
+//
+//  ADR-0009 (Session Memory — Multi-Turn Conversation Context):
+//  pure helpers that map the visible chat transcript (`[QAPair]`) onto the
+//  bounded `[ConversationTurn]` carried on `NoemaRequest`.
+//
+//  Subordinate to ADR-0000 §4 ("No hidden conversation memory"): this helper
+//  derives history strictly from the user-visible transcript supplied by the
+//  caller. There is no hidden store and no I/O — it is a pure value
+//  transformation, which is why it is testable in isolation.
+//
+//  License: MIT License
+//
+
+import Foundation
+
+/// ADR-0009 session-memory cap policy.
+///
+/// Lives in `Shared/Execution` next to `NoemaRequest` so the executor and the
+/// UI agree on the same caps, but the *application* of those caps is the
+/// caller's job: the UI invokes `SessionMemory.history(from:)` when
+/// constructing the request. The executor never re-derives history.
+enum SessionMemory {
+
+    /// Recency window — turns older than this are excluded
+    /// (`design/execution-flow.md` §4).
+    static let defaultWindow: TimeInterval = 45 * 60
+
+    /// Maximum turns admitted into the prompt, regardless of how many fit
+    /// inside the window (ADR-0009 Decision 2 — 3B on-device budget).
+    static let defaultMaxTurns: Int = 3
+
+    /// Map a visible transcript to the session-memory turns carried on
+    /// `NoemaRequest.history`.
+    ///
+    /// Caps are applied in this order:
+    /// 1. Drop turns whose `date` is missing — without a timestamp we cannot
+    ///    prove they fall inside the window, and admitting them silently
+    ///    would violate the recency contract.
+    /// 2. Drop turns older than `now - window`.
+    /// 3. Keep at most `maxTurns` of the most recent surviving turns,
+    ///    returned in chronological (oldest → newest) order so the prompt
+    ///    reads as a conversation.
+    ///
+    /// Empty input ⇒ empty output ⇒ single-turn behaviour
+    /// (ADR-0009 Decision 2).
+    static func history(
+        from qaHistory: [QAPair],
+        now: Date = Date(),
+        window: TimeInterval = SessionMemory.defaultWindow,
+        maxTurns: Int = SessionMemory.defaultMaxTurns
+    ) -> [ConversationTurn] {
+        guard maxTurns > 0, window > 0 else { return [] }
+
+        let cutoff = now.addingTimeInterval(-window)
+        let inWindow = qaHistory.compactMap { qa -> (QAPair, Date)? in
+            guard let date = qa.date, date >= cutoff, date <= now else {
+                return nil
+            }
+            return (qa, date)
+        }
+
+        // `qaHistory` is appended-to in chronological order, so suffix() picks
+        // the most recent N in-window turns while preserving that order.
+        let recent = Array(inWindow.suffix(maxTurns))
+        return recent.map { (qa, date) in
+            ConversationTurn(
+                question: qa.question,
+                answer: qa.answer,
+                date: date
+            )
+        }
+    }
+}

--- a/Shared/LLMModel.swift
+++ b/Shared/LLMModel.swift
@@ -45,7 +45,14 @@ class LLMModel: @unchecked Sendable {
     }
 
     /// ✅ ASYNC GENERATION - Uses unified NoesisCompletion pipeline
-    func generateAsync(prompt: String, context: String?) async throws -> String {
+    ///
+    /// ADR-0009: `history` is an additive, defaulted parameter so existing
+    /// stateless callers keep working unchanged. Empty ⇒ identical to today.
+    func generateAsync(
+        prompt: String,
+        context: String?,
+        history: [ConversationTurn] = []
+    ) async throws -> String {
         print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
         print("🎬 [LLMModel] generateAsync ENTRY POINT")
         print("   Model: \(name)")
@@ -82,7 +89,8 @@ class LLMModel: @unchecked Sendable {
             question: prompt,
             context: context,
             modelPath: modelPath,
-            params: params
+            params: params,
+            history: history
         )
 
         print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")

--- a/Shared/Llama/NoesisCompletionPipeline.swift
+++ b/Shared/Llama/NoesisCompletionPipeline.swift
@@ -39,7 +39,8 @@ public func runNoesisCompletion(
     question: String,
     context: String?,
     modelPath: String,
-    params: LlamaRuntimeParams = .balanced
+    params: LlamaRuntimeParams = .balanced,
+    history: [ConversationTurn] = []
 ) async throws -> String {
 
     let perfStart = Date()
@@ -58,7 +59,7 @@ public func runNoesisCompletion(
 
     // Step 1: Build prompt (matches CLI logic)
     let promptStart = Date()
-    let prompt = buildPrompt(question: question, context: context)
+    let prompt = buildPrompt(question: question, context: context, history: history)
     let promptTime = Date().timeIntervalSince(promptStart)
     print("📝 [NoesisCompletion] Prompt built: \(prompt.count) chars in \(String(format: "%.2f", promptTime*1000))ms")
     SystemLog().logEvent(event: String(format: "[PERF] Prompt build: %.2f ms", promptTime*1000))
@@ -196,7 +197,23 @@ public func runNoesisCompletion(
 
 // MARK: - Helper Functions (from CLI)
 
-private func buildPrompt(question: String, context: String?) -> String {
+/// Build the ChatML prompt for `runNoesisCompletion`.
+///
+/// ADR-0009: prior turns (already filtered/capped by the UI to ≤3 turns
+/// within a 45-minute window) are emitted as additional ChatML turns
+/// BEFORE the current question. The system prompt appears once at the top.
+/// Retrieved `Context` is attached to the CURRENT user turn only — history
+/// turns are reproduced verbatim with no retrieval baggage. Empty history
+/// ⇒ output identical to the prior single-turn build. The chat template
+/// itself (ChatML) is unchanged — that question is parked separately.
+///
+/// Made `internal` (was `private`) so source-level tests can verify the
+/// rendered prompt without invoking the model.
+func buildPrompt(
+    question: String,
+    context: String?,
+    history: [ConversationTurn] = []
+) -> String {
     let sys = """
     You are Noesis/Noema on-device RAG assistant.
     Answer questions using the provided context.
@@ -208,11 +225,25 @@ private func buildPrompt(question: String, context: String?) -> String {
     } else {
         print("⚠️ [buildPrompt] WARNING: No context provided - answering without RAG")
     }
+
+    var historyTurns = ""
+    for turn in history {
+        historyTurns += """
+        <|im_start|>user
+        \(turn.question)
+        <|im_end|>
+        <|im_start|>assistant
+        \(turn.answer)
+        <|im_end|>
+
+        """
+    }
+
     return """
     <|im_start|>system
     \(sys)
     <|im_end|>
-    <|im_start|>user
+    \(historyTurns)<|im_start|>user
     \(user)
     <|im_end|>
     <|im_start|>assistant

--- a/Shared/Runtime/Execution/HybridExecutionCoordinator.swift
+++ b/Shared/Runtime/Execution/HybridExecutionCoordinator.swift
@@ -182,12 +182,18 @@ final class HybridExecutionCoordinator: ExecutionCoordinating {
         }
 
         // Step 7: Execute.
+        // ADR-0009 §5: history is carried explicitly via the request and passed
+        // to the executor. Routing/policy/privacy above this point have ALREADY
+        // run on the current query alone (ADR-0009 §4 — history is generation-
+        // only). The remote/AgentExecutor path ignores history via the default
+        // protocol overload; only LocalExecutor consumes it.
         var executionError: String? = nil
         let result: ExecutionResult
         do {
             result = try await executor.execute(
                 query: request.query,
-                sessionId: request.sessionId
+                sessionId: request.sessionId,
+                history: request.history
             )
         } catch {
             executionError = error.localizedDescription

--- a/Shared/Runtime/Executors/ExecutorProtocol.swift
+++ b/Shared/Runtime/Executors/ExecutorProtocol.swift
@@ -27,4 +27,36 @@ protocol Executor {
         query: String,
         sessionId: UUID
     ) async throws -> ExecutionResult
+
+    /// Execute a query with session memory (ADR-0009).
+    ///
+    /// History is prompt-construction input only — it MUST NOT influence
+    /// routing, privacy, or retrieval (ADR-0009 Decision 4). Order is
+    /// chronological (oldest → newest); the caller pre-applies the 3-turn
+    /// AND 45-minute caps. Empty `history` ⇒ behaves identically to the
+    /// stateless overload (ADR-0009 Decision 2).
+    ///
+    /// A default implementation is provided that drops `history` and calls
+    /// the stateless overload — so existing executors (e.g. AgentExecutor)
+    /// keep their current behaviour with no changes required. The local
+    /// path overrides this to thread history into the prompt.
+    func execute(
+        query: String,
+        sessionId: UUID,
+        history: [ConversationTurn]
+    ) async throws -> ExecutionResult
+}
+
+extension Executor {
+    /// Default: ignore history and fall through to the stateless overload.
+    /// This keeps `AgentExecutor` and test mocks source-compatible — session
+    /// memory is a local-generation concern in this ADR (ADR-0009 §4 keeps
+    /// memory out of routing/retrieval; the remote path is unchanged).
+    func execute(
+        query: String,
+        sessionId: UUID,
+        history: [ConversationTurn]
+    ) async throws -> ExecutionResult {
+        try await execute(query: query, sessionId: sessionId)
+    }
 }

--- a/Shared/Runtime/Executors/LocalExecutor.swift
+++ b/Shared/Runtime/Executors/LocalExecutor.swift
@@ -46,22 +46,36 @@ final class LocalExecutor: Executor {
         #endif
     }
 
+    /// Stateless overload — delegates to the history-aware path with `[]`.
+    /// Empty history ⇒ identical behaviour to pre-ADR-0009.
+    func execute(
+        query: String,
+        sessionId: UUID
+    ) async throws -> ExecutionResult {
+        try await execute(query: query, sessionId: sessionId, history: [])
+    }
+
     /// Execute query using the local LLM + RAG pipeline.
     ///
     /// - Parameters:
     ///   - query: The user's query text
     ///   - sessionId: Session identifier
+    ///   - history: Visible prior turns (ADR-0009). Generation-only — does
+    ///     NOT influence retrieval (Stage 1) or routing. Empty ⇒ single-turn.
     /// - Returns: ExecutionResult with the generated output
     /// - Throws: ExecutionError on missing model, empty knowledge, or inference failure
     func execute(
         query: String,
-        sessionId: UUID
+        sessionId: UUID,
+        history: [ConversationTurn]
     ) async throws -> ExecutionResult {
 
         let traceId = UUID()
 
         // Stage 1: Retrieve relevant chunks (local, off main thread).
         // Both retrieval paths are local-only; DeepSearch is opt-in (heavier).
+        // ADR-0009 §4: history is NOT a retrieval input — retrieve on the
+        // current query only.
         let topK = defaultTopK
         let useDeepSearch = UserDefaults.standard.bool(forKey: Self.deepSearchDefaultsKey)
         let chunks = await Task.detached(priority: .userInitiated) {
@@ -76,7 +90,7 @@ final class LocalExecutor: Executor {
             }
         }.value
 
-        // Stage 2: Build context from retrieved chunks.
+        // Stage 2: Build context from retrieved chunks (current query only).
         let context = chunks.map { $0.content }.joined(separator: "\n\n")
 
         // Stage 3: Generate with the local model.
@@ -88,7 +102,8 @@ final class LocalExecutor: Executor {
         do {
             answer = try await model.generateAsync(
                 prompt: query,
-                context: context.isEmpty ? nil : context
+                context: context.isEmpty ? nil : context,
+                history: history
             )
         } catch {
             // ADR-0000: no silent fallback. Surface a structured error.


### PR DESCRIPTION
## Summary

Implements **[ADR-0009 (Session Memory — Multi-Turn Conversation Context)](https://github.com/rag-fish/RAGfish/blob/main/docs/adr/adr-0009.md)**.

On-device UAT (2026-05-25) found NoesisNoema processes every query statelessly: a follow-up like *"Continue describing the war"* answered *"This conversation just started…"*. This PR fixes that on the **local** path while staying subordinate to **ADR-0000 §4** ("No hidden conversation memory") — the history fed to the model is **exactly** the visible chat transcript, nothing more.

## What changed

### Contract (ADR-0006-safe, additive default)

- New value type `ConversationTurn { question, answer, date }` (`Shared/Execution/ExecutionCoordinator.swift`). Deliberately leaner than `QAPair` — generation input only, no citations baggage.
- `NoemaRequest` gains `history: [ConversationTurn] = []`. **Existing call sites compile unchanged.**

### 45-min / 3-turn enforcement (ADR-0009 Decision 2)

Applied **exactly once**, at the UI call site:

- `MobileHomeView.startAsk` calls `SessionMemory.history(from: documentManager.qaHistory)` and passes the result on the request.
- `Shared/Execution/SessionMemory.swift` is the shared, pure helper: drops undated turns, drops turns older than `now - 45m`, keeps the most recent ≤3 in chronological order. Empty input ⇒ empty output ⇒ single-turn behaviour.

The executor never re-derives the caps.

### Threading (coordinator → executor → buildPrompt)

- `Executor` protocol gains an `execute(query:sessionId:history:)` overload with a default extension that drops `history` and calls the stateless overload — `AgentExecutor` and existing test mocks stay source-compatible (memory is generation-only; the remote path is unchanged per ADR-0009 §4).
- `LocalExecutor` consumes `history` and threads it through `LLMModel.generateAsync` → `runNoesisCompletion` → `buildPrompt`.
- `HybridExecutionCoordinator` forwards `request.history` to the chosen executor in Step 7. Steps 1-6 (RuntimeState, PolicyEngine, override, Router, privacy Step 4.5) are untouched.

### Prompt format (ChatML, **template unchanged**)

Prior turns are emitted as additional ChatML user/assistant pairs **before** the current question. The system prompt appears **once** at the top. Retrieved `Context` attaches to the **current** user turn only. Empty `history` ⇒ prompt identical to today.

Sample with one prior turn:

```
<|im_start|>system
You are Noesis/Noema on-device RAG assistant. …
<|im_end|>
<|im_start|>user
Who fought in WW2?
<|im_end|>
<|im_start|>assistant
Allies vs Axis.
<|im_end|>
<|im_start|>user
Question: Continue describing the war

Context:
Battle of the Bulge began in December 1944.
<|im_end|>
<|im_start|>assistant
```

(The "Llama 3.2 native template vs ChatML" question remains a separate, parked task — ADR-0009 explicitly says not to conflate them.)

## What is explicitly NOT changed

- **Routing / PolicyEngine / Router**: still evaluate on the current query alone — history is not a routing signal (ADR-0009 §4).
- **Privacy (ADR-0008 R3 / Step 4.5)**: local path remains network-incapable. History is local data; nothing crosses the network boundary.
- **Retrieval (LocalRetriever / DeepSearch)**: chunks are still retrieved on the current query only — history is generation-only.
- **Chat template format**: ChatML stays. Only ADDING prior turns in the same format.
- **No new persistence**: reuses `DocumentManager.qaHistory` (the same data the History tab and Clear History already operate on, PR #89).

## Build status

| Scheme              | Destination                                     | Result            |
| ------------------- | ----------------------------------------------- | ----------------- |
| `NoesisNoema`       | `platform=macOS,arch=arm64`                     | ✅ BUILD SUCCEEDED |
| `NoesisNoemaMobile` | `platform=iOS Simulator,name=iPhone 17 Pro` (`ARCHS=arm64`) | ✅ BUILD SUCCEEDED |

No new warnings introduced.

## Tests

`NoesisNoemaTests/Runtime/SessionMemoryTests.swift` — source-level, covering:

- 5 turns spanning >45 min ⇒ exactly the 3 most-recent **in-window** turns, oldest→newest.
- All 5 turns in-window ⇒ capped to 3 most recent.
- Empty input ⇒ empty history (single-turn behaviour preserved).
- Undated turns are excluded (conservative).
- `NoemaRequest(query:)` / `(query:sessionId:)` still compile and default `history` to `[]` (ADR-0006-safe).
- `buildPrompt`: empty history ⇒ exactly one user + one assistant marker; 2 prior turns ⇒ 3 user + 3 assistant markers; historical turns appear verbatim **before** the current question; Context attaches to the **current** turn only; one system prompt.

**Caveat:** the `NoesisNoemaTests` Xcode target isn't wired to a run scheme (this matches the rest of `NoesisNoemaTests/Runtime/`). These are source-level guards that will run wherever the target is wired in.

## Test plan

- [x] macOS build (arm64) — green
- [x] iOS Simulator build (arm64) — green
- [ ] On-device verification: Taka's UAT — confirm the WW2 follow-up now produces a contextual answer instead of "This conversation just started…"
- [ ] Verify the History tab and Clear History still behave identically (no changes there; sanity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)