### PR TITLE
debug: instrument session-memory data flow for Gap 1 diagnosis

### DIFF
--- a/Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift
+++ b/Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift
@@ -312,7 +312,13 @@ struct MobileHomeView: View {
         // owns "what's visible" so the request carries exactly that. We
         // pre-apply BOTH caps (3 turns AND 45-minute window) here via the
         // shared helper so the executor doesn't need to know them.
+        print("🧠 [SESSION-MEM/UI] qaHistory.count=\(documentManager.qaHistory.count); identity=\(ObjectIdentifier(documentManager))")
         let history = SessionMemory.history(from: documentManager.qaHistory)
+        print("🧠 [SESSION-MEM/UI] derived history.count=\(history.count)")
+        for (i, t) in history.enumerated() {
+            let qPreview = String(t.question.prefix(30))
+            print("🧠 [SESSION-MEM/UI]   turn[\(i)] date=\(t.date) q='\(qPreview)'")
+        }
 
         Task { @MainActor in
             do {
@@ -324,6 +330,7 @@ struct MobileHomeView: View {
                     question: trimmed,
                     answer: response.text
                 )
+                print("🧠 [SESSION-MEM/UI] addQAPair on documentManager identity=\(ObjectIdentifier(documentManager)); qaHistory.count(post)=\(documentManager.qaHistory.count)")
 
                 // Citations now arrive on the response (ExecutionResult.sources
                 // → NoemaResponse.sources) instead of via ModelManager's mutable

--- a/Shared/Llama/NoesisCompletionPipeline.swift
+++ b/Shared/Llama/NoesisCompletionPipeline.swift
@@ -214,6 +214,7 @@ func buildPrompt(
     context: String?,
     history: [ConversationTurn] = []
 ) -> String {
+    print("🧠 [SESSION-MEM/PROMPT] buildPrompt entered; history.count=\(history.count)")
     let sys = """
     You are Noesis/Noema on-device RAG assistant.
     Answer questions using the provided context.
@@ -239,7 +240,7 @@ func buildPrompt(
         """
     }
 
-    return """
+    let prompt = """
     <|im_start|>system
     \(sys)
     <|im_end|>
@@ -248,6 +249,9 @@ func buildPrompt(
     <|im_end|>
     <|im_start|>assistant
     """
+    print("🧠 [SESSION-MEM/PROMPT] final prompt length=\(prompt.count) chars")
+    print("🧠 [SESSION-MEM/PROMPT] prompt full (first 1500 chars):\n\(String(prompt.prefix(1500)))")
+    return prompt
 }
 
 private func cleanOutput(_ s: String) -> String {

--- a/Shared/Runtime/Execution/HybridExecutionCoordinator.swift
+++ b/Shared/Runtime/Execution/HybridExecutionCoordinator.swift
@@ -73,6 +73,7 @@ final class HybridExecutionCoordinator: ExecutionCoordinating {
         request: NoemaRequest,
         overrideMode: HumanOverrideMode = .none
     ) async throws -> NoemaResponse {
+        print("🧠 [SESSION-MEM/COORD] request.history.count=\(request.history.count)")
         let traceId = UUID()
         let executionStart = Date()
 
@@ -190,6 +191,7 @@ final class HybridExecutionCoordinator: ExecutionCoordinating {
         var executionError: String? = nil
         let result: ExecutionResult
         do {
+            print("🧠 [SESSION-MEM/COORD] dispatching to executor; passing history.count=\(request.history.count)")
             result = try await executor.execute(
                 query: request.query,
                 sessionId: request.sessionId,

--- a/Shared/Runtime/Executors/LocalExecutor.swift
+++ b/Shared/Runtime/Executors/LocalExecutor.swift
@@ -52,7 +52,8 @@ final class LocalExecutor: Executor {
         query: String,
         sessionId: UUID
     ) async throws -> ExecutionResult {
-        try await execute(query: query, sessionId: sessionId, history: [])
+        print("🧠 [SESSION-MEM/EXEC] LocalExecutor.execute(stateless) entered — delegating with []")
+        return try await execute(query: query, sessionId: sessionId, history: [])
     }
 
     /// Execute query using the local LLM + RAG pipeline.
@@ -69,6 +70,7 @@ final class LocalExecutor: Executor {
         sessionId: UUID,
         history: [ConversationTurn]
     ) async throws -> ExecutionResult {
+        print("🧠 [SESSION-MEM/EXEC] LocalExecutor.execute(history-aware) entered; history.count=\(history.count)")
 
         let traceId = UUID()
 
@@ -100,6 +102,7 @@ final class LocalExecutor: Executor {
 
         let answer: String
         do {
+            print("🧠 [SESSION-MEM/EXEC] calling generateAsync with history.count=\(history.count)")
             answer = try await model.generateAsync(
                 prompt: query,
                 context: context.isEmpty ? nil : context,


### PR DESCRIPTION
## Summary

PR #90 / ADR-0009 shipped session memory (multi-turn conversation context).
On-device UAT (iPhone, PR #90 binary) confirms the feature does **not** work:
asking "Who is his wife?" after a full Einstein answer returns "I don't have
enough context… Who is he?". The code path looks correct end-to-end, so before
we patch anything we need ground-truth telemetry that pinpoints where history
is lost.

This PR adds **logging only** — no logic, overload order, filter, or prompt
template change. Intended workflow: Taka rebuilds on iPhone, runs a 2-turn
UAT, and pastes the filtered log (`grep SESSION-MEM`) for diagnosis. **Do not
merge.**

## Logging points (4)

All lines emit with prefix `🧠 [SESSION-MEM/<layer>]` for clean grep. Question
previews are truncated to 30 chars; answers are never logged.

| # | File | Layer | Hypothesis discriminated |
|---|------|-------|--------------------------|
| 1 | `Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift` (startAsk, ~line 315 + after addQAPair) | `UI` | H1: `documentManager.qaHistory` empty / wrong `DocumentManager` instance between Chat and appendQA sites · H2: `SessionMemory.history(from:)` filters the prior turn out (date out-of-window) |
| 2 | `Shared/Runtime/Execution/HybridExecutionCoordinator.swift` (top of `execute(request:overrideMode:)` + before executor dispatch) | `COORD` | H3: request crosses coordinator boundary with history but coordinator drops it before executor |
| 3 | `Shared/Runtime/Executors/LocalExecutor.swift` (both overloads + before `generateAsync`) | `EXEC` | H3 / H4: stateless overload wins over history-aware path, or executor drops history before generateAsync |
| 4 | `Shared/Llama/NoesisCompletionPipeline.swift` (top of `buildPrompt` + before return) | `PROMPT` | H4: buildPrompt called without history · H5: history reaches buildPrompt but isn't rendered into ChatML |

The buildPrompt log dumps the first 1500 chars of the rendered prompt — the
smoking gun: if `<|im_start|>user` appears more than once after the second
turn, history made it to the model; if only once, the upstream logs pinpoint
the drop.

## What this PR does not do
- No fix.
- No `SessionMemory` filter / cutoff tweaks.
- No prompt template changes.
- No overload-resolution reordering.
- No new dependencies; pure `print` statements (consistent with existing
  diagnostic lines in the same files).

## Build verification
- `xcodebuild -scheme NoesisNoema -configuration Debug -destination 'platform=macOS' build` → **BUILD SUCCEEDED**
- `xcodebuild -scheme NoesisNoemaMobile -configuration Debug -destination 'generic/platform=iOS Simulator' ARCHS=arm64 ONLY_ACTIVE_ARCH=NO build` → **BUILD SUCCEEDED**
  (arm64-only per llama.xcframework slice availability)

## Test plan
- [ ] Taka rebuilds Debug on iPhone from this branch
- [ ] Run 2-turn UAT: "Who is Einstein?" → wait for full answer → "Who is his wife?"
- [ ] Capture Console.app log filtered by `SESSION-MEM`
- [ ] Paste the filtered log in this PR for diagnosis
- [ ] Decide next steps (fix, not this PR) based on which `[SESSION-MEM/*]` line first shows count=0 or wrong overload

🤖 Generated with [Claude Code](https://claude.com/claude-code)