### PR TITLE
chore(debug): gate session-memory diagnostic logs under #if DEBUG

### DIFF
--- a/Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift
+++ b/Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift
@@ -312,13 +312,17 @@ struct MobileHomeView: View {
         // owns "what's visible" so the request carries exactly that. We
         // pre-apply BOTH caps (3 turns AND 45-minute window) here via the
         // shared helper so the executor doesn't need to know them.
+        #if DEBUG
         print("🧠 [SESSION-MEM/UI] qaHistory.count=\(documentManager.qaHistory.count); identity=\(ObjectIdentifier(documentManager))")
+        #endif
         let history = SessionMemory.history(from: documentManager.qaHistory)
+        #if DEBUG
         print("🧠 [SESSION-MEM/UI] derived history.count=\(history.count)")
         for (i, t) in history.enumerated() {
             let qPreview = String(t.question.prefix(30))
             print("🧠 [SESSION-MEM/UI]   turn[\(i)] date=\(t.date) q='\(qPreview)'")
         }
+        #endif
 
         Task { @MainActor in
             do {
@@ -330,7 +334,9 @@ struct MobileHomeView: View {
                     question: trimmed,
                     answer: response.text
                 )
+                #if DEBUG
                 print("🧠 [SESSION-MEM/UI] addQAPair on documentManager identity=\(ObjectIdentifier(documentManager)); qaHistory.count(post)=\(documentManager.qaHistory.count)")
+                #endif
 
                 // Citations now arrive on the response (ExecutionResult.sources
                 // → NoemaResponse.sources) instead of via ModelManager's mutable

--- a/Shared/Llama/LlamaState.swift
+++ b/Shared/Llama/LlamaState.swift
@@ -401,8 +401,8 @@ class LlamaState: ObservableObject {
         let GENERATION_TIMEOUT_S: Double = 20.0
         let genStartNS = DispatchTime.now().uptimeNanoseconds
 
-        #if DEBUG
         var tokenCount = 0
+        #if DEBUG
         var loopCount = 0
         var firstTokenReceivedAt: UInt64? = nil
         #endif
@@ -467,8 +467,8 @@ class LlamaState: ObservableObject {
 
             if chunk.isEmpty { continue }
 
-            #if DEBUG
             tokenCount += 1
+            #if DEBUG
             if tokenCount == 1 {
                 firstTokenReceivedAt = DispatchTime.now().uptimeNanoseconds
                 let firstTokenTime = Double(firstTokenReceivedAt! - genStartNS) / 1_000_000_000.0

--- a/Shared/Llama/NoesisCompletionPipeline.swift
+++ b/Shared/Llama/NoesisCompletionPipeline.swift
@@ -214,7 +214,9 @@ func buildPrompt(
     context: String?,
     history: [ConversationTurn] = []
 ) -> String {
+    #if DEBUG
     print("🧠 [SESSION-MEM/PROMPT] buildPrompt entered; history.count=\(history.count)")
+    #endif
     let sys = """
     You are Noesis/Noema on-device RAG assistant.
     Answer questions using the provided context.
@@ -249,8 +251,10 @@ func buildPrompt(
     <|im_end|>
     <|im_start|>assistant
     """
+    #if DEBUG
     print("🧠 [SESSION-MEM/PROMPT] final prompt length=\(prompt.count) chars")
     print("🧠 [SESSION-MEM/PROMPT] prompt full (first 1500 chars):\n\(String(prompt.prefix(1500)))")
+    #endif
     return prompt
 }
 

--- a/Shared/Runtime/Execution/HybridExecutionCoordinator.swift
+++ b/Shared/Runtime/Execution/HybridExecutionCoordinator.swift
@@ -73,7 +73,9 @@ final class HybridExecutionCoordinator: ExecutionCoordinating {
         request: NoemaRequest,
         overrideMode: HumanOverrideMode = .none
     ) async throws -> NoemaResponse {
+        #if DEBUG
         print("🧠 [SESSION-MEM/COORD] request.history.count=\(request.history.count)")
+        #endif
         let traceId = UUID()
         let executionStart = Date()
 
@@ -191,7 +193,9 @@ final class HybridExecutionCoordinator: ExecutionCoordinating {
         var executionError: String? = nil
         let result: ExecutionResult
         do {
+            #if DEBUG
             print("🧠 [SESSION-MEM/COORD] dispatching to executor; passing history.count=\(request.history.count)")
+            #endif
             result = try await executor.execute(
                 query: request.query,
                 sessionId: request.sessionId,

--- a/Shared/Runtime/Executors/LocalExecutor.swift
+++ b/Shared/Runtime/Executors/LocalExecutor.swift
@@ -52,7 +52,9 @@ final class LocalExecutor: Executor {
         query: String,
         sessionId: UUID
     ) async throws -> ExecutionResult {
+        #if DEBUG
         print("🧠 [SESSION-MEM/EXEC] LocalExecutor.execute(stateless) entered — delegating with []")
+        #endif
         return try await execute(query: query, sessionId: sessionId, history: [])
     }
 
@@ -70,7 +72,9 @@ final class LocalExecutor: Executor {
         sessionId: UUID,
         history: [ConversationTurn]
     ) async throws -> ExecutionResult {
+        #if DEBUG
         print("🧠 [SESSION-MEM/EXEC] LocalExecutor.execute(history-aware) entered; history.count=\(history.count)")
+        #endif
 
         let traceId = UUID()
 
@@ -102,7 +106,9 @@ final class LocalExecutor: Executor {
 
         let answer: String
         do {
+            #if DEBUG
             print("🧠 [SESSION-MEM/EXEC] calling generateAsync with history.count=\(history.count)")
+            #endif
             answer = try await model.generateAsync(
                 prompt: query,
                 context: context.isEmpty ? nil : context,


### PR DESCRIPTION
## Summary

Follow-up to #91 (squash-merged). Gap 1 (multi-turn session memory) is **verified fixed on-device** per ADR-0009 — the four `🧠 [SESSION-MEM/...]` diagnostic logging points from #91 served their purpose. The decision: keep them (useful for future on-device diagnosis) but compile them out of Release builds.

## What's in this PR

**1. Debug-gating of the 4 session-memory logging sites** (9 print statements total, content and prefixes unchanged):

| File | Sites |
|---|---|
| `Apps/iOS/NoesisNoemaMobile/Views/MobileHomeView.swift` | 3: pre/post `SessionMemory.history(...)` and post-`addQAPair`. The per-turn diagnostic loop is wrapped as a single `#if DEBUG` block so its local `qPreview` is not an unused-variable warning in Release. |
| `Shared/Runtime/Execution/HybridExecutionCoordinator.swift` | 2: request entry; just before dispatching to the executor |
| `Shared/Runtime/Executors/LocalExecutor.swift` | 3: stateless overload entry, history-aware overload entry, pre-`generateAsync` |
| `Shared/Llama/NoesisCompletionPipeline.swift` | 2: `buildPrompt` entry; final-prompt length + 1500-char dump (gated as a single block) |

No logic changes, no overload reordering, no filter tweaks, no prompt-template changes, no new dependencies. Gated blocks become empty in Release — no orphan locals.

**2. Minimum-correct fix to a pre-existing Release-config bug in `Shared/Llama/LlamaState.swift`**

Surfaced (not caused) while verifying Release × {macOS, iOS Sim} for this PR. Proven pre-existing by reproducing identically on baseline with the gating commit stashed out. `LlamaState.swift` last changed at `9d49a14`, which predates this branch and #91.

- `var tokenCount = 0` was declared inside `#if DEBUG` at line 405 but referenced **outside** `#if DEBUG` at line 561 (`SystemLog.logEvent` — production telemetry) and line 564 (empty-output guard). Declaration moved out.
- `tokenCount += 1` was also inside `#if DEBUG` at line 471, so even after moving the declaration, Release would always log "0 tokens" and the empty-output guard would always fire. Increment moved out too. First-token / mod-10 prints stay inside `#if DEBUG`.
- `loopCount` and `firstTokenReceivedAt` are only referenced inside `#if DEBUG`; their declarations stay where they were.

This was bundled into this PR (instead of a separate fix PR) at the user's direction — the move is 2 lines and was forced by the new "Release must succeed" verification requirement.

## Build verification (all four green)

| Target | Config | Result |
|---|---|---|
| `NoesisNoema` (macOS) | Debug | ✓ BUILD SUCCEEDED |
| `NoesisNoema` (macOS) | Release | ✓ BUILD SUCCEEDED |
| `NoesisNoemaMobile` (iOS Simulator, `ARCHS=arm64 ONLY_ACTIVE_ARCH=NO`) | Debug | ✓ BUILD SUCCEEDED |
| `NoesisNoemaMobile` (iOS Simulator, `ARCHS=arm64 ONLY_ACTIVE_ARCH=NO`) | Release | ✓ BUILD SUCCEEDED |

iOS Simulator is arm64-only per llama.xcframework slice availability.

## Test plan
- [x] Gap 1 verified fixed on-device per ADR-0009 (2-turn UAT: "Who is Einstein?" → "Who is his wife?")
- [x] Debug build retains all 9 `🧠 [SESSION-MEM/...]` prints
- [x] Release build compiles cleanly with all logs stripped (no orphan variables)
- [x] Both targets, both configurations, all green
- [ ] Merge

References: ADR-0009 (session memory), #90 (initial ADR-0009 implementation), #91 (diagnostic logging, this PR's predecessor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)