### PR TITLE
feat(macos): restore full UI via NavigationSplitView (ADR-0010)

### DIFF
--- a/Apps/macOS/NoesisNoema/Views/DesktopChatView.swift
+++ b/Apps/macOS/NoesisNoema/Views/DesktopChatView.swift
@@ -1,0 +1,356 @@
+//
+//  DesktopChatView.swift
+//  NoesisNoema (macOS)
+//
+//  ADR-0010 Chat section. A model/preset header, an inline conversation
+//  transcript, and a bottom-pinned question input. The transcript renders the
+//  shared `DocumentManager.qaHistory` as a conversation so an answer appears
+//  HERE immediately after asking; the browsable archive lives in the History
+//  section.
+//
+//  Inference is routed through `executionCoordinator.execute(request:)`
+//  (ADR-0010 §3 / ADR-0008 R2) — NOT `ModelManager.generateAsync*`. Session
+//  memory is wired identically to iOS (PR #87 / ADR-0009): the UI pre-applies
+//  the 3-turn AND 45-minute caps via `SessionMemory.history(from:)` and carries
+//  exactly that in the request. Citations propagate on the response
+//  (`NoemaResponse.sources`) and are stashed in `QAContextStore` for History.
+//
+//  Mirrors `MobileHomeView` for STRUCTURE only; written fresh for macOS
+//  (semantic NSColor backgrounds, `SafeTextInput` for IME-safe entry).
+//
+
+#if os(macOS)
+import SwiftUI
+
+struct DesktopChatView: View {
+    /// Shared QA/document store, injected by `DesktopRootView` so Chat, History,
+    /// and Settings all observe the same instance.
+    @ObservedObject var documentManager: DocumentManager
+
+    @State private var question: String = ""
+    @State private var isLoading: Bool = false
+    @State private var errorMessage: String?
+
+    @State private var selectedLLMPreset: String = ModelManager.shared.currentLLMPreset
+    @State private var selectedLLMModel: String = ModelManager.shared.currentLLMModel.name
+
+    @State private var isAutotuningModel: Bool = false
+    @State private var recommendedReady: Bool = false
+    @State private var autotuneWarning: String? = nil
+
+    /// Hybrid runtime entry point. In the app this is the single coordinator
+    /// threaded from `@main`; the default exists only for `#Preview`/tests.
+    private let executionCoordinator: ExecutionCoordinating
+
+    /// Auto-scroll anchor for the in-flight "Generating…" indicator.
+    private static let loadingIndicatorID = "transcript.loading.indicator"
+
+    init(
+        documentManager: DocumentManager,
+        executionCoordinator: ExecutionCoordinating = HybridExecutionCoordinator()
+    ) {
+        self.documentManager = documentManager
+        self.executionCoordinator = executionCoordinator
+    }
+
+    private var availableLLMModels: [String] { ModelManager.shared.availableLLMModels }
+    private var availableLLMPresets: [String] { ModelManager.shared.availableLLMPresets }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+                .padding(.horizontal, 16)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
+
+            Divider()
+
+            transcript
+
+            Divider()
+
+            inputBar
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(NSColor.windowBackgroundColor))
+        .navigationTitle("Chat")
+        .alert(
+            "Couldn’t generate an answer",
+            isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { presented in if !presented { errorMessage = nil } }
+            ),
+            presenting: errorMessage
+        ) { _ in
+            Button("OK", role: .cancel) { }
+        } message: { message in
+            Text(message)
+        }
+    }
+
+    // MARK: - Header (model / preset)
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Current Model")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                HStack(spacing: 8) {
+                    Text(selectedLLMModel)
+                        .font(.headline)
+                    if isAutotuningModel {
+                        ProgressView().scaleEffect(0.7)
+                    } else if recommendedReady {
+                        DesktopBadge(text: "Recommended", color: .green)
+                    }
+                }
+            }
+
+            Spacer()
+
+            HStack(spacing: 8) {
+                Text("Preset")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Picker("Preset", selection: $selectedLLMPreset) {
+                    ForEach(availableLLMPresets, id: \.self) { preset in
+                        Text(preset).tag(preset)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .frame(maxWidth: 140)
+                .onChange(of: selectedLLMPreset) { _, newValue in
+                    ModelManager.shared.setLLMPreset(name: newValue)
+                }
+                .disabled(isLoading)
+            }
+        }
+        .overlay(alignment: .bottomLeading) {
+            if let warning = autotuneWarning {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.yellow)
+                    Text(warning)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .offset(y: 22)
+            }
+        }
+        .onAppear {
+            selectedLLMModel = ModelManager.shared.currentLLMModel.name
+            selectedLLMPreset = ModelManager.shared.currentLLMPreset
+        }
+    }
+
+    // MARK: - Transcript
+
+    private var transcript: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                if documentManager.qaHistory.isEmpty && !isLoading {
+                    emptyState
+                } else {
+                    LazyVStack(alignment: .leading, spacing: 16) {
+                        ForEach(documentManager.qaHistory) { qa in
+                            DesktopChatTurn(qa: qa)
+                                .id(qa.id)
+                        }
+                        if isLoading {
+                            generatingIndicator
+                                .id(Self.loadingIndicatorID)
+                        }
+                    }
+                    .padding(16)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .onChange(of: documentManager.qaHistory.count) { _, _ in
+                scrollToLatest(proxy)
+            }
+            .onChange(of: isLoading) { _, _ in
+                scrollToLatest(proxy)
+            }
+        }
+    }
+
+    private func scrollToLatest(_ proxy: ScrollViewProxy) {
+        withAnimation(.easeOut(duration: 0.25)) {
+            if isLoading {
+                proxy.scrollTo(Self.loadingIndicatorID, anchor: .bottom)
+            } else if let last = documentManager.qaHistory.last {
+                proxy.scrollTo(last.id, anchor: .bottom)
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "bubble.left.and.bubble.right")
+                .font(.system(size: 44))
+                .foregroundStyle(.secondary)
+            Text("Ask me anything.")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 80)
+    }
+
+    private var generatingIndicator: some View {
+        HStack(spacing: 8) {
+            ProgressView().scaleEffect(0.7)
+            Text("Generating…")
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+        }
+    }
+
+    // MARK: - Input bar
+
+    private var inputBar: some View {
+        HStack(alignment: .bottom, spacing: 10) {
+            SafeTextInput(
+                text: $question,
+                placeholder: "Type your question…",
+                onSubmit: startAsk,
+                isEnabled: !isLoading
+            )
+            .frame(minHeight: 38, maxHeight: 96)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.secondary.opacity(0.25), lineWidth: 1)
+            )
+
+            Button(action: startAsk) {
+                if isLoading {
+                    ProgressView().scaleEffect(0.7).frame(width: 22, height: 22)
+                } else {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 26))
+                }
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.return, modifiers: [.command])
+            .disabled(isLoading || question.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .accessibilityLabel("Submit question")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Color(NSColor.controlBackgroundColor))
+    }
+
+    // MARK: - Ask
+
+    private func startAsk() {
+        let trimmed = question.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        guard !isLoading else { return }
+
+        question = trimmed
+        isLoading = true
+
+        // ADR-0009 / ADR-0010 §3: session memory is the visible transcript only.
+        // The UI is the source of truth, so it pre-applies BOTH caps (3 turns AND
+        // the 45-minute window) via the shared helper before building the
+        // request — the executor sees exactly what the user sees.
+        let history = SessionMemory.history(from: documentManager.qaHistory)
+
+        Task { @MainActor in
+            do {
+                // ADR-0010 §3 / ADR-0008 R2: route through the coordinator; the
+                // heavy RAG + llama work runs off-main inside the executor.
+                let response = try await executionCoordinator.execute(
+                    request: NoemaRequest(query: trimmed, history: history)
+                )
+
+                let newPair = documentManager.addQAPair(
+                    question: trimmed,
+                    answer: response.text
+                )
+
+                // Citations arrive on the response (ExecutionResult.sources →
+                // NoemaResponse.sources). Stash per-QA context so the History
+                // section can render citations and feedback can cache.
+                QAContextStore.shared.put(
+                    qaId: newPair.id,
+                    question: newPair.question,
+                    answer: newPair.answer,
+                    sources: response.sources,
+                    embedder: ModelManager.shared.currentEmbeddingModel
+                )
+                question = ""
+            } catch {
+                // ADR-0000: no silent fallback. Surface the failure; do NOT fall
+                // back to a stub or to ModelManager as a backup.
+                errorMessage = error.localizedDescription
+            }
+            isLoading = false
+        }
+    }
+}
+
+// MARK: - Supporting views
+
+/// One conversation turn — question as a trailing bubble, answer below it.
+/// macOS semantic colours so it adapts to light/dark appearance.
+private struct DesktopChatTurn: View {
+    let qa: QAPair
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Spacer(minLength: 60)
+                Text(qa.question)
+                    .font(.system(size: 14))
+                    .textSelection(.enabled)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(Color.accentColor.opacity(0.15))
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+
+            HStack {
+                Text(qa.answer)
+                    .font(.system(size: 14))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(Color(NSColor.controlBackgroundColor))
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                Spacer(minLength: 60)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+/// Small pill badge (Recommended / Custom). macOS-local to avoid colliding with
+/// the iOS `Badge` (which lives in the iOS-only view layer).
+struct DesktopBadge: View {
+    let text: String
+    let color: Color
+
+    var body: some View {
+        Text(text)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundStyle(color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(color.opacity(0.15))
+            .clipShape(Capsule())
+    }
+}
+
+#Preview {
+    DesktopChatView(documentManager: DocumentManager())
+        .environmentObject(AppSettings.shared)
+        .frame(width: 600, height: 500)
+}
+#endif

--- a/Apps/macOS/NoesisNoema/Views/DesktopHistoryView.swift
+++ b/Apps/macOS/NoesisNoema/Views/DesktopHistoryView.swift
@@ -1,0 +1,322 @@
+//
+//  DesktopHistoryView.swift
+//  NoesisNoema (macOS)
+//
+//  ADR-0010 History section. A two-pane browser: the Q&A archive list (left)
+//  and a detail pane (right) showing the question, answer, retrieved citations,
+//  and 👍/👎 feedback. Feedback is wired to `FeedbackStore.save(...)` and
+//  `RewardBus.publish(...)`, identical to the iOS HistoryDetailSheet flow
+//  (PR #87) — written fresh for macOS (HSplitView, NSColor backgrounds, a
+//  native reason Menu instead of a sheet).
+//
+//  Citations come from `QAContextStore` (populated by DesktopChatView at ask
+//  time from `NoemaResponse.sources`) — the same per-QA context the feedback
+//  cache uses.
+//
+
+#if os(macOS)
+import SwiftUI
+
+struct DesktopHistoryView: View {
+    @ObservedObject var documentManager: DocumentManager
+    @ObservedObject private var modelManager = ModelManager.shared
+
+    @State private var selectedID: UUID?
+
+    private var selectedQA: QAPair? {
+        guard let id = selectedID else { return nil }
+        return documentManager.qaHistory.first { $0.id == id }
+    }
+
+    var body: some View {
+        HSplitView {
+            historyList
+                .frame(minWidth: 240, idealWidth: 280, maxWidth: 380)
+
+            Group {
+                if let qa = selectedQA {
+                    DesktopQADetail(qa: qa, modelName: modelManager.currentLLMModel.name)
+                } else {
+                    detailPlaceholder
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(NSColor.windowBackgroundColor))
+        .navigationTitle("History")
+    }
+
+    // MARK: - List
+
+    @ViewBuilder
+    private var historyList: some View {
+        if documentManager.qaHistory.isEmpty {
+            VStack(spacing: 12) {
+                Image(systemName: "clock")
+                    .font(.system(size: 40))
+                    .foregroundStyle(.secondary)
+                Text("No History Yet")
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+                Text("Your Q&A history will appear here.")
+                    .font(.subheadline)
+                    .foregroundStyle(.tertiary)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding()
+            .background(Color(NSColor.windowBackgroundColor))
+        } else {
+            List(selection: $selectedID) {
+                ForEach(documentManager.qaHistory) { qa in
+                    DesktopHistoryRow(qa: qa, modelName: modelManager.currentLLMModel.name)
+                        .tag(qa.id)
+                }
+            }
+            .listStyle(.inset)
+        }
+    }
+
+    private var detailPlaceholder: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "text.bubble")
+                .font(.system(size: 40))
+                .foregroundStyle(.secondary)
+            Text("Select a question to see its answer and citations.")
+                .font(.system(size: 14))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+}
+
+// MARK: - Row
+
+private struct DesktopHistoryRow: View {
+    let qa: QAPair
+    let modelName: String
+
+    private var formattedDate: String {
+        guard let date = qa.date else { return "Unknown time" }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(qa.question)
+                .font(.system(size: 14, weight: .medium))
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 8) {
+                Text(formattedDate)
+                Text("•")
+                Text(modelName).lineLimit(1)
+            }
+            .font(.system(size: 12))
+            .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Detail
+
+private struct DesktopQADetail: View {
+    let qa: QAPair
+    let modelName: String
+
+    @State private var showSubmittedToast: Bool = false
+
+    private let negativeReasonTags: [String] = [
+        "Not factual", "Hallucination", "Out of scope", "Poor retrieval",
+        "Formatting", "Toxicity", "Off topic", "Other"
+    ]
+
+    /// Citations recorded for this Q&A at ask time (from NoemaResponse.sources).
+    private var sources: [Chunk] {
+        QAContextStore.shared.get(qa.id)?.sources ?? []
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                section(title: "Question") {
+                    Text(qa.question)
+                        .font(.system(size: 15, weight: .medium))
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Divider()
+
+                section(title: "Answer") {
+                    Text(qa.answer)
+                        .font(.system(size: 14))
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Divider()
+
+                citationsSection
+
+                Divider()
+
+                feedbackSection
+
+                if let date = qa.date {
+                    Text("Answered \(date.formatted(.dateTime)) · \(modelName)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 4)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(20)
+        }
+        .overlay(alignment: .top) { submittedToast }
+        .background(Color(NSColor.windowBackgroundColor))
+    }
+
+    @ViewBuilder
+    private func section<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title.uppercased())
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+            content()
+        }
+    }
+
+    @ViewBuilder
+    private var citationsSection: some View {
+        section(title: "Citations") {
+            if sources.isEmpty {
+                Text("No citations recorded for this answer.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(Array(sources.enumerated()), id: \.offset) { index, chunk in
+                        DesktopCitationRow(index: index + 1, chunk: chunk)
+                    }
+                }
+            }
+        }
+    }
+
+    private var feedbackSection: some View {
+        section(title: "Feedback") {
+            HStack(spacing: 12) {
+                Button {
+                    submitFeedback(verdict: .up, tags: [])
+                } label: {
+                    Label("Good", systemImage: "hand.thumbsup.fill")
+                }
+                .buttonStyle(.bordered)
+                .tint(.green)
+
+                Menu {
+                    ForEach(negativeReasonTags, id: \.self) { tag in
+                        Button(tag) { submitFeedback(verdict: .down, tags: [tag]) }
+                    }
+                    Divider()
+                    Button("Bad (no reason)") { submitFeedback(verdict: .down, tags: []) }
+                } label: {
+                    Label("Bad", systemImage: "hand.thumbsdown.fill")
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .tint(.red)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var submittedToast: some View {
+        if showSubmittedToast {
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                Text("Feedback submitted")
+                    .font(.system(size: 13))
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(.regularMaterial, in: Capsule())
+            .padding(.top, 12)
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
+    }
+
+    private func submitFeedback(verdict: FeedbackVerdict, tags: [String]) {
+        let record = FeedbackRecord(
+            id: UUID(),
+            qaId: qa.id,
+            question: qa.question,
+            verdict: verdict,
+            tags: tags,
+            timestamp: Date()
+        )
+        FeedbackStore.shared.save(record)
+        RewardBus.shared.publish(qaId: qa.id, verdict: verdict, tags: tags)
+
+        withAnimation { showSubmittedToast = true }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            withAnimation { showSubmittedToast = false }
+        }
+    }
+}
+
+// MARK: - Citation row
+
+private struct DesktopCitationRow: View {
+    let index: Int
+    let chunk: Chunk
+
+    private var title: String {
+        chunk.sourceTitle ?? chunk.sourcePath ?? "Source \(index)"
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text("[\(index)]")
+                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(title)
+                        .font(.system(size: 13, weight: .medium))
+                        .lineLimit(1)
+                    if let page = chunk.page {
+                        Text("p.\(page)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Text(chunk.content)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+                    .textSelection(.enabled)
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(NSColor.controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+#Preview {
+    DesktopHistoryView(documentManager: DocumentManager())
+        .frame(width: 720, height: 500)
+}
+#endif

--- a/Apps/macOS/NoesisNoema/Views/DesktopRootView.swift
+++ b/Apps/macOS/NoesisNoema/Views/DesktopRootView.swift
@@ -1,0 +1,107 @@
+//
+//  DesktopRootView.swift
+//  NoesisNoema (macOS)
+//
+//  ADR-0010: macOS UI Restoration — Native NavigationSplitView Architecture.
+//
+//  The macOS render path. A `NavigationSplitView` shell with a sidebar
+//  (Chat / History / Settings) and a detail pane. This replaces the
+//  `MinimalClientView`-only render path at `@main` (Shared/NoesisNoemaApp.swift)
+//  and the retired `Shared/ContentView.swift` v0.22 UI.
+//
+//  Mirrors the iOS Phase 1 (PR #87) architecture for PATTERNS only — the macOS
+//  view layer is duplicated by design (ADR-0010 §5): iOS view files use
+//  iOS-only `Color(.systemBackground)` and a bottom-tab layout, so this layer
+//  is written fresh with macOS-appropriate semantic colours and a split-view
+//  shell. The whole file is `#if os(macOS)`-guarded because the enclosing
+//  folder (`Apps/macOS/NoesisNoema`) is also synchronized into the iOS target
+//  (NoesisNoemaMobile); the guard keeps it out of the iOS compile, the same
+//  convention `Shared/ContentView.swift` uses.
+//
+
+#if os(macOS)
+import SwiftUI
+
+struct DesktopRootView: View {
+    /// App-level hybrid runtime entry point, threaded from `@main`. ALL
+    /// inference flows through this coordinator (ADR-0010 §3 / ADR-0008 R2);
+    /// no view news-up a coordinator or calls `ModelManager.generateAsync*`.
+    let executionCoordinator: ExecutionCoordinating
+
+    /// The single shared QA/document store. Owned here so the Chat, History,
+    /// and Settings sections all observe the SAME instance — questions asked in
+    /// Chat appear in History, and Settings clears the same store. The iOS
+    /// Phase 1 PR #87 had to fix exactly this (one shared store via injection);
+    /// owning it once at the root and passing it down preserves that fix.
+    @StateObject private var documentManager = DocumentManager()
+
+    /// Sidebar selection. Optional to satisfy `List(selection:)`; the detail
+    /// pane falls back to `.chat` when nothing is selected.
+    @State private var section: DesktopSection? = .chat
+
+    var body: some View {
+        NavigationSplitView {
+            List(selection: $section) {
+                ForEach(DesktopSection.allCases) { item in
+                    Label(item.title, systemImage: item.systemImage)
+                        .tag(item)
+                }
+            }
+            .listStyle(.sidebar)
+            .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 280)
+            .navigationTitle("Noesis Noema")
+        } detail: {
+            detailPane
+                .frame(minWidth: 480, minHeight: 420)
+        }
+        // SafeTextInput (the macOS IME-safe input used by DesktopChatView) reads
+        // AppSettings from the environment, and the offline indicator binds to
+        // it. Inject the shared instance once at the root.
+        .environmentObject(AppSettings.shared)
+    }
+
+    @ViewBuilder
+    private var detailPane: some View {
+        switch section ?? .chat {
+        case .chat:
+            DesktopChatView(
+                documentManager: documentManager,
+                executionCoordinator: executionCoordinator
+            )
+        case .history:
+            DesktopHistoryView(documentManager: documentManager)
+        case .settings:
+            DesktopSettingsView(documentManager: documentManager)
+        }
+    }
+}
+
+/// The three macOS sidebar sections. No bottom tab bar (ADR-0010 §2).
+enum DesktopSection: String, CaseIterable, Identifiable, Hashable {
+    case chat
+    case history
+    case settings
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .chat: return "Chat"
+        case .history: return "History"
+        case .settings: return "Settings"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .chat: return "bubble.left.and.bubble.right"
+        case .history: return "clock"
+        case .settings: return "gearshape"
+        }
+    }
+}
+
+#Preview {
+    DesktopRootView(executionCoordinator: HybridExecutionCoordinator())
+}
+#endif

--- a/Apps/macOS/NoesisNoema/Views/DesktopSettingsView.swift
+++ b/Apps/macOS/NoesisNoema/Views/DesktopSettingsView.swift
@@ -1,0 +1,377 @@
+//
+//  DesktopSettingsView.swift
+//  NoesisNoema (macOS)
+//
+//  ADR-0010 Settings section. Consolidates the v0.22 macOS controls and the iOS
+//  parity controls into one native macOS Form:
+//   • DeepSearch toggle (@AppStorage, shared key with iOS PR #87)
+//   • Embedding model picker      → switchEmbeddingModel
+//   • LLM model picker + autotune → autotuneCurrentModelAsync
+//   • LLM preset picker           → setLLMPreset
+//   • Runtime mode picker         → getLLMRuntimeMode / setLLMRuntimeMode
+//     ( + Reset to recommended    → resetToRecommended )
+//   • Offline indicator (display-only: appSettings.offline && isFullyLocal())
+//   • RAGpack manager             → sheet over DocumentManager
+//   • Clear History               → clears the same four stores as iOS Settings
+//   • #if DEBUG "Open Minimal Client" debug entry (mirrors iOS PR #87)
+//
+//  Written fresh for macOS; no `ModelManager.generateAsync*` here — Settings is
+//  pure configuration. The Runtime picker binds to the actual `LLMRuntimeMode`
+//  cases (`.auto` / `.cpuOnly`); ADR-0010 §Scope: do not invent enum cases.
+//
+
+#if os(macOS)
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct DesktopSettingsView: View {
+    @ObservedObject var documentManager: DocumentManager
+    @ObservedObject private var modelManager = ModelManager.shared
+    @ObservedObject private var appSettings = AppSettings.shared
+
+    @State private var selectedEmbeddingModel: String = ModelManager.shared.currentEmbeddingModel.name
+    @State private var selectedLLMModel: String = ModelManager.shared.currentLLMModel.name
+    @State private var selectedLLMPreset: String = ModelManager.shared.currentLLMPreset
+    @State private var runtimeMode: LLMRuntimeMode = ModelManager.shared.getLLMRuntimeMode()
+
+    @State private var isAutotuningModel: Bool = false
+    @State private var recommendedReady: Bool = false
+    @State private var autotuneWarning: String? = nil
+
+    // Retrieval: Deep Search opt-in. Persisted in UserDefaults and read by
+    // LocalExecutor (off by default — heavier multi-round retrieval). Same
+    // defaults key as iOS PR #87. Fully on-device.
+    @AppStorage(LocalExecutor.deepSearchDefaultsKey) private var deepSearchEnabled: Bool = false
+
+    @State private var showRAGpackManager: Bool = false
+    @State private var showClearConfirm: Bool = false
+
+    #if DEBUG
+    @State private var showMinimalClient: Bool = false
+    #endif
+
+    private var availableEmbeddingModels: [String] { ModelManager.shared.availableEmbeddingModels }
+    private var availableLLMModels: [String] { ModelManager.shared.availableLLMModels }
+    private var availableLLMPresets: [String] { ModelManager.shared.availableLLMPresets }
+
+    var body: some View {
+        Form {
+            modelSection
+            presetSection
+            embeddingSection
+            runtimeSection
+            retrievalSection
+            connectivitySection
+            dataSection
+            #if DEBUG
+            debugSection
+            #endif
+        }
+        .formStyle(.grouped)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(NSColor.windowBackgroundColor))
+        .navigationTitle("Settings")
+        .onAppear {
+            selectedEmbeddingModel = ModelManager.shared.currentEmbeddingModel.name
+            selectedLLMModel = ModelManager.shared.currentLLMModel.name
+            selectedLLMPreset = ModelManager.shared.currentLLMPreset
+            runtimeMode = ModelManager.shared.getLLMRuntimeMode()
+        }
+        .sheet(isPresented: $showRAGpackManager) {
+            DesktopRAGpackManagerView(documentManager: documentManager)
+        }
+        #if DEBUG
+        .sheet(isPresented: $showMinimalClient) {
+            // EPIC1 vertical-slice debug screen. A fresh coordinator is fine —
+            // HybridExecutionCoordinator is stateless. Debug builds only.
+            VStack(spacing: 0) {
+                HStack {
+                    Spacer()
+                    Button("Done") { showMinimalClient = false }
+                }
+                .padding(12)
+                MinimalClientView(executionCoordinator: HybridExecutionCoordinator())
+            }
+            .frame(minWidth: 480, minHeight: 420)
+        }
+        #endif
+    }
+
+    // MARK: - Model
+
+    private var modelSection: some View {
+        Section("Model") {
+            HStack {
+                Picker("LLM Model", selection: $selectedLLMModel) {
+                    ForEach(availableLLMModels, id: \.self) { model in
+                        Text(model).tag(model)
+                    }
+                }
+                .onChange(of: selectedLLMModel) { _, newValue in
+                    handleLLMModelChange(newValue)
+                }
+
+                if isAutotuningModel {
+                    ProgressView().scaleEffect(0.7)
+                } else if runtimeMode == .cpuOnly {
+                    DesktopBadge(text: "Custom", color: .orange)
+                } else if recommendedReady {
+                    DesktopBadge(text: "Recommended", color: .green)
+                }
+            }
+
+            if let warning = autotuneWarning {
+                Label(warning, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Preset
+
+    private var presetSection: some View {
+        Section("Preset") {
+            Picker("LLM Preset", selection: $selectedLLMPreset) {
+                ForEach(availableLLMPresets, id: \.self) { preset in
+                    Text(preset).tag(preset)
+                }
+            }
+            .onChange(of: selectedLLMPreset) { _, newValue in
+                ModelManager.shared.setLLMPreset(name: newValue)
+            }
+            Text("Auto adjusts parameters for your model. Balanced / Creative / Precise pick specific behaviours.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Embedding
+
+    private var embeddingSection: some View {
+        Section("Embedding") {
+            Picker("Embedding Model", selection: $selectedEmbeddingModel) {
+                ForEach(availableEmbeddingModels, id: \.self) { model in
+                    Text(model).tag(model)
+                }
+            }
+            .onChange(of: selectedEmbeddingModel) { _, newValue in
+                ModelManager.shared.switchEmbeddingModel(name: newValue)
+            }
+        }
+    }
+
+    // MARK: - Runtime
+
+    private var runtimeSection: some View {
+        Section("Runtime") {
+            Picker("Runtime Mode", selection: $runtimeMode) {
+                Text("Auto (GPU when available)").tag(LLMRuntimeMode.auto)
+                Text("CPU only").tag(LLMRuntimeMode.cpuOnly)
+            }
+            .pickerStyle(.radioGroup)
+            .onChange(of: runtimeMode) { _, newValue in
+                ModelManager.shared.setLLMRuntimeMode(newValue)
+            }
+
+            Button("Reset to Recommended") {
+                ModelManager.shared.resetToRecommended()
+                runtimeMode = ModelManager.shared.getLLMRuntimeMode()
+                selectedLLMPreset = ModelManager.shared.currentLLMPreset
+                recommendedReady = true
+                autotuneWarning = nil
+            }
+            .disabled(runtimeMode == .auto)
+
+            Text("Auto lets the runtime use the GPU when the device supports it. CPU only forces CPU execution.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Retrieval
+
+    private var retrievalSection: some View {
+        Section("Retrieval") {
+            Toggle("Deep Search", isOn: $deepSearchEnabled)
+            Text("Multi-round local query expansion for broader retrieval. Runs fully on-device. Slower than standard retrieval — off by default.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Connectivity (offline indicator)
+
+    private var connectivitySection: some View {
+        Section("Connectivity") {
+            HStack {
+                Toggle("Offline", isOn: $appSettings.offline)
+                    .toggleStyle(.switch)
+                Spacer()
+                if appSettings.offline && modelManager.isFullyLocal() {
+                    DesktopBadge(text: "Local Only", color: .green)
+                }
+            }
+            Toggle("Disable macOS IME", isOn: $appSettings.disableMacOSIME)
+                .toggleStyle(.switch)
+            Text("Offline blocks all outbound network calls. Local Only confirms every component is on-device.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Data
+
+    private var dataSection: some View {
+        Section("Data") {
+            Button {
+                showRAGpackManager = true
+            } label: {
+                Label("Manage RAGpacks", systemImage: "shippingbox")
+            }
+
+            Button(role: .destructive) {
+                showClearConfirm = true
+            } label: {
+                Label("Clear History", systemImage: "trash")
+            }
+            .confirmationDialog(
+                "Delete all Q&A history?",
+                isPresented: $showClearConfirm,
+                titleVisibility: .visible
+            ) {
+                Button("Delete All", role: .destructive) { clearAllHistory() }
+                Button("Cancel", role: .cancel) { }
+            } message: {
+                Text("This permanently removes your Q&A history, cached answers, and feedback from this device. It cannot be undone.")
+            }
+
+            Text("Import RAGpacks for retrieval, or wipe all saved Q&A history, cached answers, and feedback.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Debug
+
+    #if DEBUG
+    private var debugSection: some View {
+        Section("Advanced") {
+            Button {
+                showMinimalClient = true
+            } label: {
+                Label("Open Minimal Client", systemImage: "ladybug")
+            }
+            Text("EPIC1 vertical-slice debug screen (prompt → coordinator → response). Debug builds only; not shipped in Release.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+    #endif
+
+    // MARK: - Helpers
+
+    private func handleLLMModelChange(_ newValue: String) {
+        recommendedReady = false
+        autotuneWarning = nil
+        isAutotuningModel = true
+
+        ModelManager.shared.switchLLMModel(name: newValue)
+        runtimeMode = ModelManager.shared.getLLMRuntimeMode()
+        selectedLLMPreset = "auto"
+        ModelManager.shared.setLLMPreset(name: "auto")
+
+        ModelManager.shared.autotuneCurrentModelAsync(trace: false, timeoutSeconds: 3.0) { warningMessage in
+            isAutotuningModel = false
+            recommendedReady = true
+            if !warningMessage.isEmpty {
+                autotuneWarning = warningMessage
+            }
+        }
+    }
+
+    /// Clears every store that backs user Q&A data. Invoked only after the
+    /// explicit confirmation dialog — there is no auto-wipe. Same four stores as
+    /// the iOS Settings "Clear History" action (PR #87).
+    private func clearAllHistory() {
+        documentManager.clearQAHistroy()        // qaHistory + selection + persisted file (typo is real)
+        QAContextStore.shared.removeAll()       // in-memory per-QA citation context
+        FeedbackStore.shared.clearAll()         // encrypted feedback file
+        SemanticAnswerCache.shared.clearCache() // cached semantic answers
+    }
+}
+
+// MARK: - RAGpack manager
+
+/// macOS RAGpack manager. Lists imported packs (name + chunk count), supports
+/// delete and import. macOS-local (`Desktop`-prefixed) to avoid colliding with
+/// the retired `RAGpackManagerView` in `Shared/ContentView.swift`, which is
+/// still compiled into the macOS target.
+private struct DesktopRAGpackManagerView: View {
+    @ObservedObject var documentManager: DocumentManager
+    @Environment(\.dismiss) private var dismiss
+    @State private var showImporter = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Manage RAGpacks").font(.headline)
+                Spacer()
+                Button {
+                    showImporter = true
+                } label: {
+                    Label("Import .zip", systemImage: "plus")
+                }
+                Button("Done") { dismiss() }
+            }
+            .padding(12)
+
+            Divider()
+
+            if documentManager.ragpackChunks.isEmpty {
+                VStack(spacing: 10) {
+                    Image(systemName: "shippingbox")
+                        .font(.system(size: 36))
+                        .foregroundStyle(.secondary)
+                    Text("No RAGpacks imported yet.")
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List {
+                    ForEach(documentManager.ragpackChunks.keys.sorted(), id: \.self) { key in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(key).font(.system(size: 14, weight: .medium))
+                                Text("Chunks: \(documentManager.ragpackChunks[key]?.count ?? 0)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Button(role: .destructive) {
+                                documentManager.deleteRAGpack(named: key)
+                            } label: {
+                                Image(systemName: "trash")
+                            }
+                            .buttonStyle(.borderless)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+            }
+        }
+        .frame(minWidth: 460, minHeight: 360)
+        .fileImporter(isPresented: $showImporter, allowedContentTypes: [UTType.zip]) { result in
+            if case let .success(url) = result {
+                documentManager.importDocument(file: url)
+            }
+        }
+    }
+}
+
+#Preview {
+    DesktopSettingsView(documentManager: DocumentManager())
+        .environmentObject(AppSettings.shared)
+        .frame(width: 600, height: 700)
+}
+#endif

--- a/Shared/NoesisNoemaApp.swift
+++ b/Shared/NoesisNoemaApp.swift
@@ -20,7 +20,13 @@ struct NoesisNoemaApp: App {
 
     var body: some Scene {
         WindowGroup {
-            MinimalClientView(executionCoordinator: executionCoordinator)
+            // ADR-0010: the macOS render path is the full NavigationSplitView UI
+            // (Chat / History / Settings). The app-level coordinator created
+            // above is threaded down; DesktopRootView owns the single shared
+            // DocumentManager. MinimalClientView remains reachable from
+            // Settings ▸ Advanced under #if DEBUG, and the retired
+            // Shared/ContentView.swift is no longer referenced.
+            DesktopRootView(executionCoordinator: executionCoordinator)
         }
     }
 }


### PR DESCRIPTION
## Summary

Restores the full macOS UI per **ADR-0010 (macOS UI Restoration — Native NavigationSplitView Architecture)**. The macOS app previously rendered only `MinimalClientView` (the EPIC1 vertical slice). This brings macOS to iOS Phase 1 (PR #87) parity **plus the v0.22 macOS-only features**, built entirely on the v0.4 hybrid-runtime architecture — **all inference flows through `HybridExecutionCoordinator`**, never the legacy direct-`ModelManager` path.

`@main` now renders `DesktopRootView`. `Shared/ContentView.swift` is retired from the render path but **kept as a functional reference** (ADR-0010 §6, "retired, not deleted"). **No iOS view files were touched.**

## File placement

New macOS view layer at **`Apps/macOS/NoesisNoema/Views/`**. This is the macOS app target's synchronized source folder (the ADR's provisional `Apps/macOS/NoesisNoemaDesktop/` does not exist). That folder is synchronized into **both** the macOS (`NoesisNoema`) and iOS (`NoesisNoemaMobile`) targets, so every new file is wrapped in `#if os(macOS)` — the same convention `Shared/ContentView.swift` uses — keeping macOS-only AppKit code (`NSColor`, `NSOpenPanel`/`fileImporter`) out of the iOS compile. No `project.pbxproj` edits were needed (Xcode 15+ synchronized groups auto-include the files).

## Coordinator threading & shared store

`@main` (`Shared/NoesisNoemaApp.swift`) creates the `executionCoordinator` and passes it to `DesktopRootView`. `DesktopRootView` owns the **single** `DocumentManager` as `@StateObject` and injects it into each section via `@ObservedObject` — so Chat, History, and Settings all observe the **same** instance (this is the exact bug iOS PR #87 had to fix; it is not reintroduced).

```
@main → executionCoordinator ─┐
                              ├─→ DesktopRootView (owns 1× DocumentManager @StateObject)
                              │      ├─ DesktopChatView(documentManager, executionCoordinator)
                              │      ├─ DesktopHistoryView(documentManager)
                              │      └─ DesktopSettingsView(documentManager)
```

## Per-section feature coverage

### Chat (`DesktopChatView`)
- Inline conversation transcript over the shared `qaHistory`, auto-scroll, "Generating…" indicator.
- **Coordinator-routed inference**: `executionCoordinator.execute(request: NoemaRequest(query:history:))`.
- **Session memory wired identically to iOS** (ADR-0009): UI pre-applies the 3-turn AND 45-minute caps via `SessionMemory.history(from: documentManager.qaHistory)`.
- Citations propagate on `NoemaResponse.sources` and are stashed in `QAContextStore` for History.
- IME-safe input via `SafeTextInput`. ADR-0000: errors surfaced via alert, no silent fallback.
- **Model/Preset display**: a header on the Chat view shows the current model (Llama 3.2 3B) + autotune badge and a Preset menu; full pickers live in Settings.

### History (`DesktopHistoryView`)
- `HSplitView`: archive **list** (left) + **detail** (right).
- Detail shows question, answer, **citations** (from `QAContextStore`), and **👍/👎 feedback** → `FeedbackStore.shared.save(...)` + `RewardBus.shared.publish(...)` (👎 uses a native reason Menu).

### Settings (`DesktopSettingsView`) — native macOS `Form`
- **DeepSearch toggle** (`@AppStorage(LocalExecutor.deepSearchDefaultsKey)`, shared key with iOS).
- **Embedding model picker** → `switchEmbeddingModel`.
- **LLM model picker + autotune** → `autotuneCurrentModelAsync(trace: false, timeoutSeconds: 3.0)`, surfacing `autotuneWarning` / `recommendedReady`.
- **LLM preset picker** → `setLLMPreset`.
- **Runtime mode picker** bound to the actual `LLMRuntimeMode` cases **`.auto` / `.cpuOnly`** (no invented cases) via `getLLMRuntimeMode`/`setLLMRuntimeMode`, with **Reset to recommended** → `resetToRecommended`.
- **Offline indicator** (display-only): `appSettings.offline && ModelManager.shared.isFullyLocal()` → "Local Only" badge.
- **RAGpack manager** sheet (list / import / delete).
- **Clear History** (confirmation dialog) clears the same four stores as iOS: `DocumentManager.clearQAHistroy()`, `QAContextStore.removeAll()`, `FeedbackStore.clearAll()`, `SemanticAnswerCache.clearCache()`.
- **`#if DEBUG` "Open Minimal Client"** entry (mirrors iOS PR #87).

## Compliance (ADR-0000 / ADR-0010)

- **No coordinator bypass.** `grep -rn "generateAsync" Apps/macOS/NoesisNoema/Views/` returns only comment lines stating the rule — the only inference call is `executionCoordinator.execute` in `DesktopChatView`.
- Pure Swift, no new dependencies. No new compiler warnings from the new files.
- Runtime/Shared contracts unchanged — the new views consume existing types only.

## Build matrix (all green ✅)

| Target | Config | Result |
|---|---|---|
| NoesisNoema (macOS) | Debug | ✅ BUILD SUCCEEDED |
| NoesisNoema (macOS) | Release | ✅ BUILD SUCCEEDED |
| NoesisNoemaMobile (iOS Sim arm64) | Debug | ✅ BUILD SUCCEEDED |
| NoesisNoemaMobile (iOS Sim arm64) | Release | ✅ BUILD SUCCEEDED |

> iOS Simulator Release must be built **arm64-only** (`ARCHS=arm64`): the `llama.xcframework` simulator slice has no x86_64, so the default Release `ARCHS_STANDARD` (which adds x86_64) fails at link. This is a pre-existing project constraint, independent of this change.

## Not in scope / follow-up
- On-device UAT is Taka's step (run the macOS app; verify Chat ↔ History flow, multi-turn memory, citations, Settings pickers, Clear History).
- An unrelated 1-line `project.pbxproj` working-tree change (LlamaBridgeTest model exception) was deliberately left **out** of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)