### PR TITLE
fix(macos): RAGpack import EPERM — call startAccessingSecurityScopedResource on macOS

### DIFF
--- a/Shared/DocumentManager.swift
+++ b/Shared/DocumentManager.swift
@@ -127,9 +127,12 @@ class DocumentManager: ObservableObject {
     }
 
     private func processRAGpackImport(fileURL: URL) async {
-        // iOSのFiles/iCloud経由で選択されたURLに対しては、セキュリティスコープを開始する
+        // Sandboxed iOS AND macOS both require explicit security-scoped access for
+        // user-picked URLs returned by .fileImporter / NSOpenPanel. The previous macOS
+        // branch (claiming the entitlement alone was sufficient) was incorrect and caused
+        // EPERM ("Operation not permitted") on RAGpack ZIP imports.
         var didStartAccessing = false
-        #if os(iOS)
+        #if os(iOS) || os(macOS)
         didStartAccessing = fileURL.startAccessingSecurityScopedResource()
         if !didStartAccessing {
             print("Warning: Could not start accessing security-scoped resource for \(fileURL)")
@@ -137,8 +140,6 @@ class DocumentManager: ObservableObject {
         defer {
             if didStartAccessing { fileURL.stopAccessingSecurityScopedResource() }
         }
-        #elseif os(macOS)
-        // NSOpenPanel + user-selected-file entitlement is sufficient; no scoped access required
         #endif
         let fileManager = FileManager.default
         let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)


### PR DESCRIPTION
## Summary

Fixes macOS RAGpack ZIP import failing under the App Sandbox. Settings ▸ Manage RAGpacks ▸ Import .zip threw EPERM because `processRAGpackImport(fileURL:)` only started security-scoped access on iOS. Sandboxed macOS needs it too.

## Error reproduced on UAT

```
Error: Could not open ZIP archive.
Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted"
UserInfo={NSFilePath=/Users/raskolnikoff/Downloads/2015.263056.Ethics_text.zip}
```

`EPERM` (POSIX code 1) on a `~/Downloads` file is the textbook signature of the macOS App Sandbox denying file access.

## Root cause — why the prior macOS branch comment was wrong

The macOS target **is** sandboxed (`Apps/macOS/NoesisNoema/NoesisNoema.macOS.entitlements`):

```xml
<key>com.apple.security.app-sandbox</key>                     <true/>
<key>com.apple.security.files.user-selected.read-only</key>  <true/>
```

Under the sandbox, URLs returned by `NSOpenPanel` / SwiftUI `.fileImporter` are **security-scoped**. The `files.user-selected.read-only` entitlement grants the *right* to access them, but the process must still **claim** that access with `startAccessingSecurityScopedResource()` before reading. The old code skipped this on macOS:

```swift
#if os(iOS)
didStartAccessing = fileURL.startAccessingSecurityScopedResource()
...
#elseif os(macOS)
// NSOpenPanel + user-selected-file entitlement is sufficient; no scoped access required  ← WRONG
#endif
```

So `Archive(url: fileURL, accessMode: .read)` hit the file before access was claimed → EPERM. This matches Apple's sandbox documentation: the entitlement authorizes access; `start/stopAccessingSecurityScopedResource()` activates it.

## The fix (single file, single hunk)

`Shared/DocumentManager.swift`, in `processRAGpackImport(fileURL:)`:

```diff
     private func processRAGpackImport(fileURL: URL) async {
-        // iOSのFiles/iCloud経由で選択されたURLに対しては、セキュリティスコープを開始する
+        // Sandboxed iOS AND macOS both require explicit security-scoped access for
+        // user-picked URLs returned by .fileImporter / NSOpenPanel. The previous macOS
+        // branch (claiming the entitlement alone was sufficient) was incorrect and caused
+        // EPERM ("Operation not permitted") on RAGpack ZIP imports.
         var didStartAccessing = false
-        #if os(iOS)
+        #if os(iOS) || os(macOS)
         didStartAccessing = fileURL.startAccessingSecurityScopedResource()
         if !didStartAccessing {
             print("Warning: Could not start accessing security-scoped resource for \(fileURL)")
         }
         defer {
             if didStartAccessing { fileURL.stopAccessingSecurityScopedResource() }
         }
-        #elseif os(macOS)
-        // NSOpenPanel + user-selected-file entitlement is sufficient; no scoped access required
         #endif
```

**Kept the `#if os(iOS) || os(macOS)` guard** (rather than deleting it): both shipping platforms are sandboxed and need the call, but the guard documents intent and keeps the no-op behaviour for any future non-sandboxed platform where claiming scoped access on a non-scoped URL would be needless. `grep` confirms `startAccessingSecurityScopedResource` is now compiled on macOS (no surviving iOS-only guard).

## Other user-URL sites (NOT fixed here — scope discipline)

All actual ZIP-import entry points funnel through `importDocument(file:)` → `processRAGpackImport(fileURL:)`, so they are **all covered by this one fix**:
- `Shared/ContentView.swift:301` — macOS `NSOpenPanel` (retired view) → `importDocument`
- `Apps/iOS/NoesisNoemaMobile/Views/SettingsView.swift:235` — `.fileImporter` → `importDocument`
- (`Apps/macOS/.../DesktopSettingsView.swift` on the PR #93 branch) — `.fileImporter` → `importDocument`

No independent user-URL-open site bypasses the fixed path. `ModelRegistry.swift:373` is only a comment. **Nothing further to fix.**

## Build matrix (all green ✅)

| Target | Config | Result |
|---|---|---|
| NoesisNoema (macOS) | Debug | ✅ BUILD SUCCEEDED |
| NoesisNoema (macOS) | Release | ✅ BUILD SUCCEEDED |
| NoesisNoemaMobile (iOS Sim arm64) | Debug | ✅ BUILD SUCCEEDED |
| NoesisNoemaMobile (iOS Sim arm64, `ARCHS=arm64`) | Release | ✅ BUILD SUCCEEDED |

No new warnings (the only DocumentManager warning is the pre-existing ZIPFoundation library-evolution note on the `import` line). iOS Simulator Release built arm64-only (`ARCHS=arm64`) per the project's known xcframework constraint (no x86_64 simulator slice).

## Independence

This fix is **independent of PR #93** (macOS UI restoration) and branched off `main`, not off #93. It can land **before or after** #93. (PR #93's `DesktopSettingsView` import path also routes through `processRAGpackImport`, so it benefits from this fix automatically once both merge.)

## On-device UAT (Taka's step after merge)
Re-run macOS app → Settings ▸ Manage RAGpacks ▸ Import .zip → pick `~/Downloads/...Ethics_text.zip` → verify it imports without EPERM and chunks appear in the retrieval path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)