### PR TITLE
fix(macos): raise llama n_ctx to 4096 (Deep Search KV cache overflow)

### DIFF
--- a/Shared/Llama/LibLlama.swift
+++ b/Shared/Llama/LibLlama.swift
@@ -125,7 +125,7 @@ actor LlamaContext {
         #if os(iOS)
         ctx_params.n_ctx = 1024 // Lightweight for iOS
         #else
-        ctx_params.n_ctx = 2048
+        ctx_params.n_ctx = 4096 // macOS: room for Deep Search + history + retrieved chunks
         #endif
         ctx_params.n_threads       = Int32(n_threads)
         ctx_params.n_threads_batch = Int32(n_threads)


### PR DESCRIPTION
## Summary

Raises the macOS runtime `n_ctx` for the llama context from **2048 → 4096** in `Shared/Llama/LibLlama.swift`. One-line value change (+ comment). iOS is left at 1024.

## The UAT path that hit it

macOS UAT after PR #93/#94 merge:
1. Enabled **Deep Search**
2. Imported the **Spinoza Ethica PDF** as a RAGpack
3. Asked **"What is the main theme of Spinoza's Ethic?"**

→ App crashed with **SIGABRT** in `LibLlama.swift:232` at `if llama_decode(context, batch) != 0`.

Console:
```
error: n_kv_req > n_ctx, the required KV cache size is not big enough
needed  = 2369
n_ctx   = 2048
n_kv_req = 512
```

## Root cause

The runtime `n_ctx` was 2048 on macOS, but Deep Search over a dense philosophical text retrieved enough chunks that the assembled prompt (system + history + retrieved chunks + question) needed **2369** tokens of KV cache. The underlying Llama 3.2 3B model supports `n_ctx_train = 131072` — the model is fine; only the runtime ctx allocation was the bottleneck.

## The fix

```diff
 #if os(iOS)
 ctx_params.n_ctx = 1024 // Lightweight for iOS
 #else
-ctx_params.n_ctx = 2048
+ctx_params.n_ctx = 4096 // macOS: room for Deep Search + history + retrieved chunks
 #endif
```

### Why 4096 and not 8192

- Today's UAT needed **2369** → 4096 gives ~1700 tokens of headroom, comfortable for typical Deep Search runs on a 3B model.
- 4096 is the **smallest power-of-two that clears the actual observed need**.
- KV cache scales linearly with `n_ctx`. The iOS value of 1024 ≈ 224 MiB KV cache in earlier logs, so macOS at 4096 is ~4× ≈ 900 MiB — fine on a Mac (M1 Max trivially handles this for a 3B Q4 model). 8192 is defensible but uses more memory for no benefit on the failing case.
- iOS stays at 1024 — phones are tighter on memory and the iOS UAT hasn't hit overflow.

## Out of scope (intentional — follow-ups, NOT in this PR)

- **L2** — pre-overflow warning / auto-truncate of retrieved chunks or history when the assembled prompt approaches `n_ctx`.
- **L3** — change `llama_decode != 0` at `LibLlama.swift:232` to **throw** a structured error instead of letting the process abort with SIGABRT, so the executor can surface a user-facing alert.

Both belong to a single later PR ("robust context-window handling").

## Build matrix (all green; iOS builds run serially)

| Configuration | Result |
|---|---|
| macOS Debug | ✅ BUILD SUCCEEDED |
| macOS Release | ✅ BUILD SUCCEEDED |
| iOS Simulator arm64 Debug | ✅ BUILD SUCCEEDED |
| iOS Simulator arm64 Release | ✅ BUILD SUCCEEDED |

iOS builds use `ARCHS=arm64 ONLY_ACTIVE_ARCH=NO` and were run **serially** to avoid the DerivedData lock. No new warnings from this change (the pre-existing "duplicate build file" warning on `NoesisNoemaMobileApp.swift` is unrelated project-config noise).

## Verification (Taka)

Re-run the Spinoza Deep Search question and confirm the answer comes back without SIGABRT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)