### PR TITLE
chore(models): registry cleanup — Llama 3.2 3B as sole declared model

### DIFF
--- a/Apps/CLI/LlamaBridgeTest/main.swift
+++ b/Apps/CLI/LlamaBridgeTest/main.swift
@@ -7,7 +7,7 @@
 //  minimal runtime defaults (threads/ngl placeholders), and output cleanup for <think> tags.
 //
 //  Usage examples:
-//    LlamaBridgeTest -m /path/to/Jan-v1-4B-Q4_K_M.gguf -p "Say hello."
+//    LlamaBridgeTest -m /path/to/llama-3.2-3b-instruct-q4_k_m.gguf -p "Say hello."
 //    LlamaBridgeTest -p "What is RAG?"   // model auto-lookup
 //
 //  Note:
@@ -183,7 +183,7 @@ func autoPresetAdjust(_ cli: inout CLI, modelPath: String, prompt: String) {
 }
 
 // MARK: - Paths
-let defaultModelFileName = "Jan-v1-4B-Q4_K_M.gguf" // development default
+let defaultModelFileName = "llama-3.2-3b-instruct-q4_k_m.gguf" // development default
 
 /// Search for a model file, supporting both flat and nested directory structures
 /// (llama.cpp v0.2.0+ expects Models/<modelName>/*.gguf)

--- a/Apps/macOS/NoesisNoema/ModelRegistry/CLI/ModelCLI.swift
+++ b/Apps/macOS/NoesisNoema/ModelRegistry/CLI/ModelCLI.swift
@@ -252,7 +252,7 @@ struct ModelCLI {
 
         print("\n🔧 CLI Usage Examples:")
         print("   nn model list                    # List available models")
-        print("   nn model info jan-v1-4b         # Show detailed model info")
+        print("   nn model info llama-3.2-3b       # Show detailed model info")
         print("   nn model scan /path/to/models    # Scan for GGUF files")
         print("   nn model test                    # Run functionality tests")
 
@@ -281,7 +281,7 @@ struct ModelCLI {
           --trace            Print decision rationale and timing during autotune
 
         Examples:
-          nn model info jan-v1-4b --dry-run
+          nn model info llama-3.2-3b --dry-run
           nn model list
           nn model list --all
           nn model scan
@@ -292,7 +292,7 @@ struct ModelCLI {
 
         Model ID Format:
           Model IDs are lowercase, with hyphens replaced by underscores.
-          Examples: jan_v1_4b, llama_3_8b, phi_3_mini
+          Examples: llama_3_2_3b
         """)
     }
 }

--- a/Apps/macOS/NoesisNoema/ModelRegistry/Core/ModelRegistry.swift
+++ b/Apps/macOS/NoesisNoema/ModelRegistry/Core/ModelRegistry.swift
@@ -19,11 +19,15 @@ actor ModelRegistry {
     private var scanningPaths: Set<String> = []
 
     /// Predefined model specifications (fallbacks)
+    ///
+    /// Only Llama 3.2 3B is declared — the single GGUF that actually ships on device.
+    /// Earlier ghost/retired LLM entries were removed in the registry cleanup ahead
+    /// of ADR-0011 (replaceable GGUF embedder).
     private let predefinedSpecs: [ModelSpec] = [
         ModelSpec(
             id: "llama-3.2-3b",
             name: "Llama 3.2 3B",
-            modelFile: "Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+            modelFile: "llama-3.2-3b-instruct-q4_k_m.gguf",
             version: "3B",
             metadata: GGUFMetadata(
                 architecture: "llama",
@@ -38,101 +42,6 @@ actor ModelRegistry {
             ),
             tags: ["llama", "small", "q4_k_m", "long-context", "instruct"],
             description: "Llama 3.2 3B Instruct, Q4_K_M quantization — default on-device model"
-        ),
-        ModelSpec(
-            id: "jan-v1-4b",
-            name: "Jan-V1-4B",
-            modelFile: "Jan-v1-4B-Q4_K_M.gguf",
-            version: "4B",
-            metadata: GGUFMetadata(
-                architecture: "qwen",
-                parameterCount: 4.0,
-                contextLength: 32768,
-                quantization: "Q4_K_M",
-                layerCount: 32,
-                embeddingDimension: 2048,
-                feedForwardDimension: 5504,
-                attentionHeads: 32,
-                supportsFlashAttention: true
-            ),
-            tags: ["qwen", "small", "q4_k_m", "long-context"],
-            description: "Jan V1 4B parameter model with Qwen architecture, Q4_K_M quantization"
-        ),
-        ModelSpec(
-            id: "llama-3-8b",
-            name: "Llama-3",
-            modelFile: "llama3-8b.gguf",
-            version: "8B",
-            metadata: GGUFMetadata(
-                architecture: "llama",
-                parameterCount: 8.0,
-                contextLength: 8192,
-                quantization: "Q4_K_M",
-                layerCount: 32,
-                embeddingDimension: 4096,
-                feedForwardDimension: 14336,
-                attentionHeads: 32,
-                supportsFlashAttention: true
-            ),
-            tags: ["llama", "medium", "q4_k_m", "medium-context"],
-            description: "LLaMA 3 8B parameter model with standard quantization"
-        ),
-        ModelSpec(
-            id: "phi-3-mini",
-            name: "Phi-3-mini",
-            modelFile: "phi-3-mini.gguf",
-            version: "mini",
-            metadata: GGUFMetadata(
-                architecture: "phi3",
-                parameterCount: 3.8,
-                contextLength: 4096,
-                quantization: "Q4_K_M",
-                layerCount: 32,
-                embeddingDimension: 3072,
-                feedForwardDimension: 8192,
-                attentionHeads: 32,
-                supportsFlashAttention: true
-            ),
-            tags: ["phi", "small", "q4_k_m", "medium-context"],
-            description: "Phi-3 Mini 3.8B parameter model optimized for efficiency"
-        ),
-        ModelSpec(
-            id: "gemma-2b",
-            name: "Gemma-2B",
-            modelFile: "gemma-2b.gguf",
-            version: "2B",
-            metadata: GGUFMetadata(
-                architecture: "gemma",
-                parameterCount: 2.0,
-                contextLength: 2048,
-                quantization: "Q4_K_M",
-                layerCount: 18,
-                embeddingDimension: 2048,
-                feedForwardDimension: 5632,
-                attentionHeads: 8,
-                supportsFlashAttention: false
-            ),
-            tags: ["gemma", "small", "q4_k_m", "short-context"],
-            description: "Gemma 2B parameter lightweight model"
-        ),
-        ModelSpec(
-            id: "gpt-oss-20b",
-            name: "GPT-OSS-20B",
-            modelFile: "gpt-oss-20b-Q4_K_S.gguf",
-            version: "20B",
-            metadata: GGUFMetadata(
-                architecture: "gpt",
-                parameterCount: 20.0,
-                contextLength: 4096,
-                quantization: "Q4_K_S",
-                layerCount: 44,
-                embeddingDimension: 6144,
-                feedForwardDimension: 24576,
-                attentionHeads: 48,
-                supportsFlashAttention: false
-            ),
-            tags: ["gpt", "large", "q4_k_s", "medium-context"],
-            description: "GPT-OSS 20B parameter large language model"
         )
     ]
 

--- a/Apps/macOS/NoesisNoema/ModelRegistry/Tests/TestRunner.swift
+++ b/Apps/macOS/NoesisNoema/ModelRegistry/Tests/TestRunner.swift
@@ -238,21 +238,14 @@ class TestRunner {
         }
 
         // Test finding specific model
-        let janModel = await registry.getModelSpec(id: "jan-v1-4b")
-        guard let jan = janModel else {
-            print("❌ Should find Jan model")
+        let llamaModel = await registry.getModelSpec(id: "llama-3.2-3b")
+        guard let llama = llamaModel else {
+            print("❌ Should find Llama 3.2 3B model")
             return false
         }
 
-        guard jan.name == "Jan-V1-4B" else {
-            print("❌ Jan model name mismatch: \(jan.name)")
-            return false
-        }
-
-        // Test finding by tag
-        let qwenModels = await registry.findModelSpecs(withTag: "qwen")
-        guard !qwenModels.isEmpty else {
-            print("❌ Should find models with qwen tag")
+        guard llama.name == "Llama 3.2 3B" else {
+            print("❌ Llama model name mismatch: \(llama.name)")
             return false
         }
 
@@ -265,7 +258,6 @@ class TestRunner {
 
         print("✅ Model registry functionality working")
         print("   Total models: \(allSpecs.count)")
-        print("   Qwen models: \(qwenModels.count)")
         print("   LLaMA models: \(llamaModels.count)")
         return true
     }
@@ -274,8 +266,8 @@ class TestRunner {
     private static func testCLIModelInfo() async -> Bool {
         let registry = ModelRegistry.shared
 
-        guard let modelInfo = await registry.getModelInfo(id: "jan-v1-4b") else {
-            print("❌ Should get model info for Jan model")
+        guard let modelInfo = await registry.getModelInfo(id: "llama-3.2-3b") else {
+            print("❌ Should get model info for Llama 3.2 3B model")
             return false
         }
 
@@ -363,16 +355,16 @@ class TestRunner {
         // Minimal valid
         let ok = "{" +
         "\"models\":[{" +
-        "\"id\":\"llama3-8b\"," +
-        "\"name\":\"Llama 3 8B\"," +
-        "\"model_file\":\"llama3-8b.Q4_K_M.gguf\"," +
-        "\"version\":\"8B\"," +
+        "\"id\":\"llama-3.2-3b\"," +
+        "\"name\":\"Llama 3.2 3B\"," +
+        "\"model_file\":\"llama-3.2-3b-instruct-q4_k_m.gguf\"," +
+        "\"version\":\"3B\"," +
         "\"quantization\":\"Q4_K_M\"" +
         "}]" +
         "}"
         do {
             let specs = try RegistryJSONLoader.load(from: ok)
-            guard specs.count == 1, specs[0].id == "llama3-8b" else {
+            guard specs.count == 1, specs[0].id == "llama-3.2-3b" else {
                 print("❌ Minimal valid registry did not parse as expected")
                 return false
             }
@@ -582,7 +574,7 @@ class TestRunner {
         await RegistryPersistence.shared.clearCache()
 
         // Prepare a model id and two distinct params
-        let modelId = "jan-v1-4b"
+        let modelId = "llama-3.2-3b"
         var recommended = RuntimeParams.oomSafeDefaults()
         recommended.nCtx = 4096
         var overrideP = recommended
@@ -619,7 +611,7 @@ class TestRunner {
         await RegistryPersistence.shared.wipe()
         await RegistryPersistence.shared.clearCache()
 
-        let modelId = "llama-3-8b"
+        let modelId = "llama-3.2-3b"
         var recommended = RuntimeParams.oomSafeDefaults()
         recommended.nCtx = 2048
         var overrideP = recommended

--- a/Apps/macOS/NoesisNoema/Tests/ModelRegistryTests/ModelCompatibilityTests.swift
+++ b/Apps/macOS/NoesisNoema/Tests/ModelRegistryTests/ModelCompatibilityTests.swift
@@ -25,11 +25,9 @@ class ModelCompatibilityTests: XCTestCase {
         let availableModels = await registry.getAvailableModelSpecs()
         XCTAssertGreaterThan(availableModels.count, 0, "No models discovered in Resources/Models")
 
-        // Verify new models are found
+        // Verify the shipping model is found
         let expectedModels = [
-            "Llama-3.3-70B-Instruct",
-            "gpt-oss-20b",
-            "Jan-v1-4B"
+            "llama-3.2-3b"
         ]
 
         for expected in expectedModels {

--- a/Apps/macOS/NoesisNoema/Tests/ModelRegistryTests/ModelRegistryTests.swift
+++ b/Apps/macOS/NoesisNoema/Tests/ModelRegistryTests/ModelRegistryTests.swift
@@ -93,13 +93,13 @@ class ModelRegistryTests {
         assert(!initialSpecs.isEmpty, "Registry should have predefined models")
 
         // Test finding by ID
-        let janModel = await registry.getModelSpec(id: "jan-v1-4b")
-        assert(janModel != nil, "Should find Jan model by ID")
-        assert(janModel?.name == "Jan-V1-4B", "Jan model name should match")
+        let llamaModel = await registry.getModelSpec(id: "llama-3.2-3b")
+        assert(llamaModel != nil, "Should find Llama 3.2 3B model by ID")
+        assert(llamaModel?.name == "Llama 3.2 3B", "Llama model name should match")
 
         // Test finding by tag
-        let qwenModels = await registry.findModelSpecs(withTag: "qwen")
-        assert(!qwenModels.isEmpty, "Should find models with qwen tag")
+        let instructModels = await registry.findModelSpecs(withTag: "instruct")
+        assert(!instructModels.isEmpty, "Should find models with instruct tag")
 
         // Test finding by architecture
         let llamaModels = await registry.findModelSpecs(withArchitecture: "llama")
@@ -107,7 +107,7 @@ class ModelRegistryTests {
 
         print("✅ ModelRegistry functionality working")
         print("   - Total models: \(initialSpecs.count)")
-        print("   - Qwen models: \(qwenModels.count)")
+        print("   - Instruct models: \(instructModels.count)")
         print("   - LLaMA models: \(llamaModels.count)")
     }
 

--- a/Shared/Llama/LlamaState.swift
+++ b/Shared/Llama/LlamaState.swift
@@ -44,14 +44,7 @@ class LlamaState: ObservableObject {
 
     private var llamaContext: LlamaContext?
     private var defaultModelUrl: URL? {
-        // プラットフォーム優先: iOSはJan、macOSはLlama3-8B
-        #if os(macOS)
-        let primaryFile = "llama3-8b.gguf"
-        let secondaryFile = "Jan-v1-4B-Q4_K_M.gguf"
-        #else
-        let primaryFile = "Llama-3.2-3B-Instruct-Q4_K_M.gguf"
-        let secondaryFile = "Jan-v1-4B-Q4_K_M.gguf"
-        #endif
+        let primaryFile = "llama-3.2-3b-instruct-q4_k_m.gguf"
         func findInBundle(_ file: String) -> URL? {
             let nameNoExt = (file as NSString).deletingPathExtension
             let ext = (file as NSString).pathExtension
@@ -63,10 +56,7 @@ class LlamaState: ObservableObject {
             }
             return nil
         }
-        if let url = findInBundle(primaryFile) { return url }
-        if let url = findInBundle(secondaryFile) { return url }
-        // 旧フォールバック
-        return Bundle.main.url(forResource: "ggml-model", withExtension: "gguf", subdirectory: "models")
+        return findInBundle(primaryFile)
     }
 
     struct SamplingConfig {
@@ -385,7 +375,7 @@ class LlamaState: ObservableObject {
             self.messageLog += "USER: \(text)\n"
         }
 
-        // First-token watchdog: strict deadline for Jan-v1-4B (8s), relaxed for larger models (15s)
+        // First-token watchdog: strict deadline for the on-device model (8s)
         let FIRST_TOKEN_DEADLINE_S: Double = 8.0
         let firstTokenDeadlineNS = DispatchTime.now().uptimeNanoseconds + UInt64(FIRST_TOKEN_DEADLINE_S * 1_000_000_000)
 


### PR DESCRIPTION
## Summary

Cleanup of the model layer ahead of ADR-0011 (replaceable GGUF embedder). The registry had accumulated drift: **6 LLMs declared, 4 physical GGUFs on disk, 3 pure ghosts, 2 retired** — but only **Llama 3.2 3B** is the chosen default and the one model that actually ships on device.

This PR removes the ghosts and the retired declarations, fixes the hard-coded `LlamaState` defaults, and fixes a latent GGUF filename case-sensitivity bug.

## Accumulated drift (before)

`predefinedSpecs` declared 6 LLMs:

| Declared model | `modelFile` | On disk? | Status |
|---|---|---|---|
| Llama 3.2 3B | `Llama-3.2-3B-Instruct-Q4_K_M.gguf` | ✅ (as lowercase) | **KEEP** |
| Jan-V1-4B | `Jan-v1-4B-Q4_K_M.gguf` | ✅ | retired |
| Llama-3 (8B) | `llama3-8b.gguf` | ❌ | ghost |
| Phi-3-mini | `phi-3-mini.gguf` | ❌ | ghost |
| Gemma 2B | `gemma-2b.gguf` | ❌ | ghost |
| gpt-oss-20b | `gpt-oss-20b-Q4_K_S.gguf` | ❌ (disk has F16) | ghost / retired |

Physical GGUFs on disk: `llama-3.2-3b-instruct-q4_k_m.gguf` (keep), `Jan-v1-4B-Q4_K_M.gguf`, `gpt-oss-20b-F16.gguf`, `Llama-3.3-70B-Instruct-UD-IQ1_S.gguf` (latter 3 to be retired).

## Changes

**`ModelRegistry.swift`** — `predefinedSpecs` reduced from 6 entries to 1 (Llama 3.2 3B only). Removed Jan-V1-4B, Llama-3 (8B), Phi-3-mini, Gemma 2B, gpt-oss-20b. Updated the kept entry's `modelFile` to the all-lowercase on-disk name.

**Case-sensitivity fix** — registry and `LlamaState` both pointed at `Llama-3.2-3B-Instruct-Q4_K_M.gguf`, but the physical file on disk is `llama-3.2-3b-instruct-q4_k_m.gguf` (lowercase). On case-sensitive iOS Simulator/device builds the mixed-case lookup would fail. Both now use the lowercase name matching the on-disk file (safer than renaming the file).

**`LlamaState` hard-coded-default removal** — `defaultModelUrl` hard-coded `let primaryFile = "llama3-8b.gguf"` for macOS (a file that never shipped, silently falling back to Jan-v1), plus a Jan-v1 `secondaryFile` and a legacy `ggml-model` fallback. Replaced both `#if os` branches with a single `let primaryFile = "llama-3.2-3b-instruct-q4_k_m.gguf"` and removed the secondary + legacy fallbacks — the file either resolves or we return nil, no silent fallback (ADR-0000). The line-388 watchdog comment naming Jan-v1-4B was reworded.

**Tests / CLI** — updated references to the removed model IDs in `TestRunner.swift`, `ModelRegistryTests.swift`, `ModelCompatibilityTests.swift`, `ModelCLI.swift` (help text), and `LlamaBridgeTest/main.swift` (dev default). Test cases that asserted ghost/retired models were retargeted to Llama 3.2 3B rather than expanding the test surface.

## Removed ghosts / retired

`Jan-V1-4B`, `Llama-3 (8B)`, `Phi-3-mini`, `Gemma 2B`, `gpt-oss-20b`.

## Grep self-check

```
$ grep -rn "Jan-v1\|Jan-V1\|jan-v1\|jan_v1\|llama3-8b\|llama-3-8b\|llama_3_8b\|phi-3-mini\|phi_3_mini\|gemma-2b\|gemma_2b\|gpt-oss\|gpt_oss\|Llama-3.3-70B\|Llama-3.3-70b" --include="*.swift" .
Shared/DocumentManager.swift:269:    func inferWithLlama(prompt: String, fileName: String = "llama3-8b.gguf", ...
```

One non-test match remains — see "Out of scope" below. Zero matches in all files within scope.

## Out of scope / noted for follow-up

- **`Shared/DocumentManager.swift:269`** — `inferWithLlama(prompt:fileName: "llama3-8b.gguf", ...)` carries a ghost default filename. Per the task scope DocumentManager was explicitly off-limits for this PR. The function is **defined but never called** anywhere in the codebase (dead code), so it has no runtime impact. Recommend removing/fixing it in a separate cleanup.

## Build matrix (all green, no new warnings)

| Build | Result |
|---|---|
| macOS Debug | ✅ BUILD SUCCEEDED |
| macOS Release | ✅ BUILD SUCCEEDED |
| iOS Simulator arm64 Debug | ✅ BUILD SUCCEEDED |
| iOS Simulator arm64 Release (`ARCHS=arm64 ONLY_ACTIVE_ARCH=NO`) | ✅ BUILD SUCCEEDED |

(Pre-existing warnings in `ModelFactory`, `ExecutionCoordinator`, ZIPFoundation, etc. are unchanged; none are in the edited regions.)

## Notes

- This prepares the ground for **ADR-0011** (replaceable GGUF embedder). The embedder GGUF arrives in a **subsequent PR** — this PR does **not** add it.
- **Taka** will manually delete the 3 retired GGUFs (`Jan-v1-4B-Q4_K_M.gguf`, `gpt-oss-20b-F16.gguf`, `Llama-3.3-70B-Instruct-UD-IQ1_S.gguf`) from `Apps/macOS/NoesisNoema/Resources/Models/` on disk after this PR lands. No `.gguf` files are tracked in git, so no repo change is needed for that.
- `project.pbxproj` is intentionally left untouched (the synced-folder convention handles file membership automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)