### PR TITLE
feat(rag): real semantic embedder foundation — ADR-0011 PR-A

### DIFF
--- a/NoesisNoemaTests/EmbeddingModelSmokeTests.swift
+++ b/NoesisNoemaTests/EmbeddingModelSmokeTests.swift
@@ -1,0 +1,49 @@
+//
+//  EmbeddingModelSmokeTests.swift
+//  NoesisNoemaTests
+//
+//  ADR-0011 PR-A: smoke test for the real semantic EmbeddingModel.
+//
+//  NOTE ON RUNNING: this test needs the embedder GGUF
+//  (nomic-embed-text-v1.5.Q5_K_M.gguf) reachable via Bundle.main. When the
+//  NoesisNoemaTests target is hosted by the NoesisNoema app (which bundles the
+//  git-ignored GGUF), the test runs end-to-end. If the GGUF is NOT in the test
+//  host bundle, `EmbeddingModel(name:)` loads no context (dimension == 0) and the
+//  body self-skips with a recorded note rather than failing — document the manual
+//  run in the PR. (See memory: the NoesisNoemaTests target wiring is incomplete;
+//  Taka runs these manually on his Mac.)
+//
+
+import Testing
+import Foundation
+@testable import NoesisNoema
+
+@Suite struct EmbeddingModelSmokeTests {
+
+    @Test func embedProducesNormalized768Vector() throws {
+        let model = EmbeddingModel(name: "default")
+
+        // Self-skip if the embedder GGUF isn't reachable in this runner's bundle.
+        guard model.dimension > 0 else {
+            Issue.record("Embedder GGUF not reachable via Bundle.main in this test host; skipping. Run manually with the GGUF bundled.")
+            return
+        }
+
+        let v1 = model.embed(text: "hello world")
+
+        // 3. 768 dimensions.
+        #expect(v1.count == 768)
+
+        // 4. L2 norm within 0.001 of 1.0.
+        let norm = sqrt(v1.reduce(Float(0)) { $0 + $1 * $1 })
+        #expect(abs(norm - 1.0) < 0.001)
+
+        // 5. Cache-hit determinism: same input → identical vector.
+        let v1again = model.embed(text: "hello world")
+        #expect(v1 == v1again)
+
+        // 6. Different text → different vector (basic semantic check).
+        let v2 = model.embed(text: "entirely different text")
+        #expect(v1 != v2)
+    }
+}

--- a/Shared/DocumentManager.swift
+++ b/Shared/DocumentManager.swift
@@ -127,6 +127,13 @@ class DocumentManager: ObservableObject {
     }
 
     private func processRAGpackImport(fileURL: URL) async {
+        // NOTE (ADR-0011, PR-A foundation merged; PR-B reader pending):
+        // This function still expects the legacy v0.x pack shape and will NOT work with
+        // pipeline-produced v1.1 packs (no embeddings.csv → silent return). PR-B replaces
+        // this entire function with a v1.2 RAGpackReader (chunks.json + embeddings.npy +
+        // manifest.json + citations.jsonl) and surfaces failures via UI alert. Do not ship
+        // without PR-B.
+        //
         // Sandboxed iOS AND macOS both require explicit security-scoped access for
         // user-picked URLs returned by .fileImporter / NSOpenPanel. The previous macOS
         // branch (claiming the entitlement alone was sufficient) was incorrect and caused
@@ -185,8 +192,16 @@ class DocumentManager: ObservableObject {
         do {
             let chunksData = try Data(contentsOf: chunksURL)
             let chunkStrings = try JSONDecoder().decode([String].self, from: chunksData)
-            let embeddingModel = EmbeddingModel(name: "import")
-            let embeddings = embeddingModel.loadEmbeddingsCSV(from: embeddingsURL)
+            // Inline legacy v0.x CSV parse (formerly EmbeddingModel's CSV loader,
+            // removed in PR-A — the embedder no longer ships a CSV loader). Behavior is
+            // byte-for-byte identical to the old helper; this whole branch is superseded
+            // by the v1.2 RAGpackReader in PR-B (see the NOTE at the top of this function).
+            let embeddings: [[Float]] = {
+                guard let csvString = try? String(contentsOf: embeddingsURL, encoding: .utf8) else { return [] }
+                return csvString.split(separator: "\n").map { row in
+                    row.split(separator: ",").compactMap { Float($0.trimmingCharacters(in: .whitespaces)) }
+                }
+            }()
             if chunkStrings.count != embeddings.count {
                 print("Error: chunks.jsonとembeddings.csvの数が一致しません")
                 try? fileManager.removeItem(at: tempDir)

--- a/Shared/Llama/LlamaEmbeddingContext.swift
+++ b/Shared/Llama/LlamaEmbeddingContext.swift
@@ -1,0 +1,202 @@
+// Project: NoesisNoema
+// File: LlamaEmbeddingContext.swift
+// Description: llama.cpp embedding-mode actor (ADR-0011, PR-A foundation).
+//   Parallel to `LlamaContext` (LibLlama.swift) but specialised for embedding
+//   inference: pooling enabled, no sampler chain, single pooled vector out.
+// License: MIT License
+//
+// EDIT POLICY (mirrors LibLlama.swift):
+// - Only update to adapt to upstream llama.cpp C API changes or add thin shims.
+// - Reuses the free helpers `llama_batch_clear` / `llama_batch_add` defined in
+//   LibLlama.swift (do not redefine them here).
+
+import Foundation
+import CryptoKit
+import llama
+
+/// Errors surfaced by the embedding path. ADR-0000 §4: no silent fallback —
+/// every failure throws a specific case; callers decide how to surface.
+enum EmbeddingError: Error {
+    case modelLoadFailed(path: String, underlying: String)
+    case contextInitFailed
+    case tokenizationFailed
+    case decodeFailed(rc: Int32)
+    case poolingUnavailable
+    case zeroNorm
+}
+
+/// A llama.cpp context loaded in embedding mode (mean-pooled, L2-normalized output).
+///
+/// The embedder GGUF is replaceable: nothing here hard-codes nomic-embed beyond
+/// the resource lookup in `EmbeddingModel`. Dimension is read from the model.
+actor LlamaEmbeddingContext {
+
+    // Isolated C handles — never touched off the actor.
+    private let model: OpaquePointer
+    private let context: OpaquePointer
+    private let vocab: OpaquePointer
+    private var batch: llama_batch
+
+    /// Embedding dimension as reported by the loaded model (`llama_model_n_embd`).
+    nonisolated let dimension: Int
+
+    /// SHA-256 hex digest of the GGUF file bytes, computed once at load.
+    /// PR-B uses this for manifest fingerprint validation.
+    nonisolated let modelFingerprint: String
+
+    private init(model: OpaquePointer,
+                 context: OpaquePointer,
+                 vocab: OpaquePointer,
+                 dimension: Int,
+                 fingerprint: String) {
+        self.model = model
+        self.context = context
+        self.vocab = vocab
+        self.dimension = dimension
+        self.modelFingerprint = fingerprint
+        // n_batch == n_ctx == 8192 so a full-length chunk fits in one decode.
+        self.batch = llama_batch_init(8192, 0, 1)
+    }
+
+    deinit {
+        llama_batch_free(batch)
+        llama_free(context)
+        llama_model_free(model)
+        // NOTE: intentionally NOT calling llama_backend_free() here — the backend
+        // is shared process-wide with LlamaContext (LibLlama.swift). Freeing it
+        // would tear down a live backend used by the generation path.
+    }
+
+    // MARK: - Load
+
+    static func load(modelPath: String) throws -> LlamaEmbeddingContext {
+        // Compute the fingerprint first (cheap, memory-mapped) so a failure here
+        // doesn't leak a loaded model/context.
+        let fingerprint = try computeFingerprint(path: modelPath)
+
+        #if os(iOS)
+        setenv("LLAMA_NO_METAL", "1", 1)
+        #endif
+        llama_backend_init()
+
+        var model_params = llama_model_default_params()
+        #if targetEnvironment(simulator)
+        model_params.n_gpu_layers = 0
+        #elseif os(iOS)
+        model_params.n_gpu_layers = 0
+        #else
+        model_params.n_gpu_layers = 999 // macOS: use Metal when available
+        #endif
+
+        guard let model = llama_model_load_from_file(modelPath, model_params) else {
+            throw EmbeddingError.modelLoadFailed(path: modelPath,
+                                                 underlying: "llama_model_load_from_file returned nil")
+        }
+
+        let n_embd = Int(llama_model_n_embd(model))
+
+        #if os(iOS)
+        let nThreads: Int32 = 4
+        #else
+        let nThreads = Int32(max(1, min(8, ProcessInfo.processInfo.processorCount - 2)))
+        #endif
+
+        var ctx_params = llama_context_default_params()
+        ctx_params.embeddings       = true                       // critical: embedding mode
+        ctx_params.n_ctx            = 8192                        // nomic-embed-text-v1.5 supports 8192
+        ctx_params.n_batch          = 8192                        // a long chunk fits in a single batch
+        ctx_params.n_ubatch         = 8192
+        ctx_params.pooling_type     = LLAMA_POOLING_TYPE_MEAN     // mean pooling → one vector per sequence
+        ctx_params.n_threads        = nThreads
+        ctx_params.n_threads_batch  = nThreads
+
+        guard let context = llama_init_from_model(model, ctx_params) else {
+            llama_model_free(model)
+            throw EmbeddingError.contextInitFailed
+        }
+
+        guard let vocab = llama_model_get_vocab(model) else {
+            llama_free(context)
+            llama_model_free(model)
+            throw EmbeddingError.contextInitFailed
+        }
+
+        return LlamaEmbeddingContext(model: model,
+                                     context: context,
+                                     vocab: vocab,
+                                     dimension: n_embd,
+                                     fingerprint: fingerprint)
+    }
+
+    private static func computeFingerprint(path: String) throws -> String {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe) else {
+            throw EmbeddingError.modelLoadFailed(path: path,
+                                                 underlying: "could not read GGUF bytes for fingerprint")
+        }
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - Embed
+
+    /// Returns the L2-normalized mean-pooled embedding for `text` as `dimension` float32s.
+    func embed(text: String) async throws -> [Float] {
+        var tokens = tokenize(text: text)
+        guard !tokens.isEmpty else { throw EmbeddingError.tokenizationFailed }
+
+        let nCtx = Int(llama_n_ctx(context))
+        if tokens.count > nCtx {
+            print("[LlamaEmbeddingContext] WARNING: input \(tokens.count) tokens > n_ctx \(nCtx); truncating")
+            tokens = Array(tokens.prefix(nCtx))
+        }
+
+        // Build a single-sequence batch with logits disabled at every position —
+        // we want pooled embeddings, not per-token logits.
+        llama_batch_clear(&batch)
+        for (i, tok) in tokens.enumerated() {
+            llama_batch_add(&batch, tok, Int32(i), [0], false)
+        }
+
+        // Ensure embedding mode (also set at context init; belt-and-suspenders).
+        llama_set_embeddings(context, true)
+
+        let rc = llama_decode(context, batch)
+        // ADR-0000 §4: do NOT print-and-continue. Throw on non-zero (mirrors the
+        // parked L3 issue from PR #95 explicitly for the embedding path).
+        if rc != 0 { throw EmbeddingError.decodeFailed(rc: rc) }
+
+        // Sequence-0 pooled output (valid because pooling_type == MEAN).
+        guard let ptr = llama_get_embeddings_seq(context, 0) else {
+            throw EmbeddingError.poolingUnavailable
+        }
+
+        var vec = [Float](repeating: 0, count: dimension)
+        for i in 0..<dimension { vec[i] = ptr[i] }
+
+        // L2-normalize.
+        var sumSq: Float = 0
+        for v in vec { sumSq += v * v }
+        let norm = sumSq.squareRoot()
+        guard norm > 0, norm.isFinite else { throw EmbeddingError.zeroNorm }
+        for i in 0..<dimension { vec[i] /= norm }
+
+        return vec
+    }
+
+    // MARK: - Tokenization (mirrors LibLlama.tokenize, add_bos = true)
+
+    private func tokenize(text: String) -> [llama_token] {
+        let utf8Count = text.utf8.count
+        let nMax = utf8Count + 2 // +BOS, +slack
+        let tokens = UnsafeMutablePointer<llama_token>.allocate(capacity: nMax)
+        defer { tokens.deallocate() }
+
+        let n = llama_tokenize(vocab, text, Int32(utf8Count), tokens, Int32(nMax), true, false)
+        guard n >= 0 else { return [] }
+
+        var out: [llama_token] = []
+        out.reserveCapacity(Int(n))
+        for i in 0..<Int(n) { out.append(tokens[i]) }
+        return out
+    }
+}

--- a/Shared/RAG/EmbeddingModel.swift
+++ b/Shared/RAG/EmbeddingModel.swift
@@ -1,74 +1,140 @@
 // Project: NoesisNoema
 // File: EmbeddingModel.swift
 // Created by Раскольников on 2025/07/20.
-// Description: Defines the EmbeddingModel class for handling text embeddings.
+// Description: Real semantic embedding model backed by llama.cpp (ADR-0011, PR-A).
+//   Replaces the former 10-dim pseudo-hash stub — the root cause of broken RAG.
 // License: MIT License
 
 import Foundation
 
+/// Query-side text embedder. Holds a `LlamaEmbeddingContext` and exposes a
+/// synchronous `embed(text:)` (preserved from the old stub so the many sync call
+/// sites compile unchanged) via a blocking bridge over the actor's async API.
+///
+/// nomic-embed-text-v1.5 requires task prefixes; PR-A only has query-side callers
+/// so it always applies `"search_query: "`. PR-B introduces `"search_document: "`
+/// for pack-side ingestion in the v1.2 RAGpackReader.
 class EmbeddingModel {
 
-    /**
-        * Represents an embedding model with its properties and methods.
-        * - Properties:
-        *   - name: The name of the embedding model.
-        * - Methods:
-        *   - embed(text: String) -> [Float]: Generates an embedding for the given text.
-        *     This method takes a string input and returns an array of floats representing the embedding vector
-        *     for the input text.
-        */
     var name: String
 
-    // PERFORMANCE: Cache embeddings to avoid recomputation
+    /// Embedder GGUF resource (git-ignored; bundled into the app target manually).
+    static let embedderResourceName = "nomic-embed-text-v1.5.Q5_K_M"
+    static let embedderResourceExt = "gguf"
+    private static let taskPrefix = "search_query: "
+
+    /// nil when the embedder GGUF could not be found/loaded — `embed` then logs
+    /// loudly and returns []. We deliberately do NOT fatalError at init so the app
+    /// still launches on a build missing the (git-ignored) GGUF; the empty vector
+    /// makes the failure visible downstream rather than silently wrong.
+    private let context: LlamaEmbeddingContext?
+
+    /// Forwarded from the loaded context (0 when not loaded). PR-B needs these.
+    let dimension: Int
+    let modelFingerprint: String
+
+    // PERFORMANCE: Cache embeddings to avoid recomputation. Keyed on the
+    // task-prefixed text (the exact string handed to the embedder).
     private var embeddingCache: [String: [Float]] = [:]
     private let cacheQueue = DispatchQueue(label: "com.noesis.embedding.cache", attributes: .concurrent)
     private let maxCacheSize = 500
 
     init(name: String) {
         self.name = name
+        if let path = EmbeddingModel.resolveEmbedderPath() {
+            do {
+                let ctx = try LlamaEmbeddingContext.load(modelPath: path)
+                self.context = ctx
+                self.dimension = ctx.dimension
+                self.modelFingerprint = ctx.modelFingerprint
+                print("[EmbeddingModel] Loaded embedder '\(name)' dim=\(ctx.dimension) fp=\(ctx.modelFingerprint.prefix(12))…")
+            } catch {
+                print("[EmbeddingModel] ERROR: failed to load embedder at \(path): \(error)")
+                self.context = nil
+                self.dimension = 0
+                self.modelFingerprint = ""
+            }
+        } else {
+            print("[EmbeddingModel] ERROR: embedder GGUF '\(EmbeddingModel.embedderResourceName).\(EmbeddingModel.embedderResourceExt)' not found in bundle")
+            self.context = nil
+            self.dimension = 0
+            self.modelFingerprint = ""
+        }
+    }
+
+    /// Strict factory: throws if the embedder could not be loaded. Useful for
+    /// PR-B and tests that must not run against a missing embedder.
+    static func defaultInstance() throws -> EmbeddingModel {
+        let model = EmbeddingModel(name: "default")
+        guard model.context != nil else {
+            throw EmbeddingError.modelLoadFailed(path: EmbeddingModel.resolveEmbedderPath() ?? "<not found>",
+                                                 underlying: "embedder GGUF unavailable")
+        }
+        return model
     }
 
     /// テキストを埋め込みベクトルに変換（キャッシュ付き）
     func embed(text: String) -> [Float] {
-        // Check cache first
-        let cached = cacheQueue.sync { embeddingCache[text] }
-        if let cached = cached {
+        let prefixed = EmbeddingModel.taskPrefix + text
+
+        // Check cache first (keyed on the prefixed string).
+        if let cached = cacheQueue.sync(execute: { embeddingCache[prefixed] }) {
             return cached
         }
 
-        // 1. テキストの文字コードの合計を計算
-        let hashValue = text.unicodeScalars.reduce(0) { $0 + UInt32($1.value) }
-        // 2. ダミーの埋め込みベクトルを生成（例: ハッシュ値を元に固定長のベクトルを作成）
-        let embedding = (0..<10).map { i in
-            Float((hashValue + UInt32(i * 31)) % 1000) / 1000.0
-        }
-
-        // Cache the result
-        cacheQueue.async(flags: .barrier) { [weak self] in
-            guard let self = self else { return }
-            if self.embeddingCache.count >= self.maxCacheSize {
-                let oldest = self.embeddingCache.keys.prefix(50)
-                oldest.forEach { self.embeddingCache.removeValue(forKey: $0) }
-            }
-            self.embeddingCache[text] = embedding
-        }
-
-        // 3. 埋め込みベクトルを返す
-        return embedding
-    }
-
-    /// embeddings.csvから[[Float]]としてロードする
-    func loadEmbeddingsCSV(from url: URL) -> [[Float]] {
-        do {
-            let csvString = try String(contentsOf: url, encoding: .utf8)
-            let rows = csvString.split(separator: "\n")
-            let embeddings: [[Float]] = rows.map { row in
-                row.split(separator: ",").compactMap { Float($0.trimmingCharacters(in: .whitespaces)) }
-            }
-            return embeddings
-        } catch {
-            print("[EmbeddingModel] CSV読み込み失敗: \(error)")
+        guard let context = context else {
+            print("[EmbeddingModel] ERROR: no embedding context loaded; returning empty vector")
             return []
         }
+
+        let result = blockingEmbed(context: context, text: prefixed)
+
+        // Only cache real results — never cache an empty (error) vector.
+        if !result.isEmpty {
+            cacheQueue.async(flags: .barrier) { [weak self] in
+                guard let self = self else { return }
+                if self.embeddingCache.count >= self.maxCacheSize {
+                    let oldest = self.embeddingCache.keys.prefix(50)
+                    oldest.forEach { self.embeddingCache.removeValue(forKey: $0) }
+                }
+                self.embeddingCache[prefixed] = result
+            }
+        }
+
+        return result
+    }
+
+    /// Blocking bridge from the synchronous public API to the async actor.
+    /// Callers are expected to run off the main actor (retrieval already does).
+    /// ADR-0000 §4: the actor throws on failure; the sync boundary can't rethrow,
+    /// so we log loudly and return [] — visibly broken, not silently wrong.
+    private func blockingEmbed(context: LlamaEmbeddingContext, text: String) -> [Float] {
+        let sem = DispatchSemaphore(value: 0)
+        var out: [Float] = []
+        var failure: Error?
+        Task.detached(priority: .userInitiated) {
+            do { out = try await context.embed(text: text) }
+            catch { failure = error }
+            sem.signal()
+        }
+        sem.wait()
+        if let failure = failure {
+            print("[EmbeddingModel] ERROR: embed failed: \(failure)")
+            return []
+        }
+        return out
+    }
+
+    /// Resolve the embedder GGUF in the app bundle (mirrors LlamaState.defaultModelUrl).
+    static func resolveEmbedderPath() -> String? {
+        let subs: [String?] = [nil, "Models", "Resources/Models", "Resources"]
+        for sub in subs {
+            if let url = Bundle.main.url(forResource: embedderResourceName,
+                                         withExtension: embedderResourceExt,
+                                         subdirectory: sub) {
+                return url.path
+            }
+        }
+        return nil
     }
 }


### PR DESCRIPTION
## ADR-0011 PR-A — real semantic embedder foundation

This is **PR-A of two** for ADR-0011. It delivers the foundation: a real
llama.cpp-backed embedding API and a new `EmbeddingModel`. **PR-A alone does NOT
enable RAGpack v1.2 import** — that ships in PR-B. PR-A intentionally leaves the
legacy v1.1/v0.x import path broken pending PR-B (documented in-code).

ADR-0011 decided: embedding runs in the existing llama.cpp xcframework (no CoreML),
the embedder GGUF is replaceable, and the old 10-dim pseudo-hash `EmbeddingModel`
(root cause of broken RAG) gets fully replaced.

### A1 — new `Shared/Llama/LlamaEmbeddingContext.swift` (Swift actor)
Parallel to `LlamaContext`, specialised for embedding inference.
- **Context flags:** `embeddings = true`, `n_ctx = 8192`, `n_batch = 8192`,
  `n_ubatch = 8192`, `pooling_type = LLAMA_POOLING_TYPE_MEAN`. `n_gpu_layers = 999`
  on macOS (Metal), `0` on iOS/simulator (mirrors LibLlama).
- **`embed(text:)`:** tokenize (add_bos, truncate to `n_ctx` with a warning) →
  single-seq batch, `logits = false` everywhere → `llama_decode` (**throws** on
  non-zero rc — ADR-0000 §4, no print-and-continue) → `llama_get_embeddings_seq(ctx, 0)`
  → copy `n_embd` floats → **L2-normalize** (throws `zeroNorm` on degenerate output).
- **`dimension`:** `nonisolated let`, from `llama_model_n_embd`.
- **`modelFingerprint`:** `nonisolated let`, SHA-256 hex of the GGUF bytes
  (`CryptoKit`, memory-mapped, computed once at load).
- **`enum EmbeddingError`:** `modelLoadFailed` / `contextInitFailed` /
  `tokenizationFailed` / `decodeFailed(rc:)` / `poolingUnavailable` / `zeroNorm`.
  No silent fallback anywhere in the file.
- Reuses LibLlama's `llama_batch_clear` / `llama_batch_add`; **does not modify**
  `LibLlama.swift`. `deinit` deliberately skips `llama_backend_free()` (backend is
  shared with the generation path).

### A2 — `Shared/RAG/EmbeddingModel.swift` rewrite
- **Public sync signature `embed(text:) -> [Float]` preserved.** Holds a
  `LlamaEmbeddingContext`; bridges async→sync via `DispatchSemaphore` + detached
  Task (pure Swift, no Combine).
- 500-entry concurrent cache kept; keyed on the prefixed string.
- Applies the **`"search_query: "`** task prefix before cache key + embedding.
  (`"search_document: "` is PR-B.)
- **Removed the dead `loadEmbeddingsCSV` loader.**
- Forwards `dimension` and `modelFingerprint` for PR-B.
- **`init(name:)` kept non-throwing** so all call sites compile and the app still
  launches if the git-ignored GGUF is absent (logs loudly, `embed` returns `[]` —
  visibly broken, not silently wrong). Added a strict `static defaultInstance() throws`
  factory for PR-B/tests. *(Chose this over a deprecated failable init to avoid a
  launch-time crash on builds missing the GGUF.)*

**Call sites verified unchanged (compile in all 4 green builds):**
`BanditRetriever.swift:30`, `MobileHomeView.swift:350`, `ChatView.swift:141`,
`DesktopChatView.swift:284`, `ModelManager.swift` (`currentEmbeddingModel` /
`switchEmbeddingModel`), plus `AnswerGenerator`, `Preprocessor`, `DeepSearch`,
`QAContextStore`, `SemanticAnswerCache`, `OnlineSGDReranker`, `LocalRetriever`,
`VectorStore`, `RagCLI`. None required changes.

### A3 — `.gitignore`
`*.gguf` already present at root (`.gitignore:355`, plus per-dir lines). **No change needed.**

### A4 — smoke test
`NoesisNoemaTests/EmbeddingModelSmokeTests.swift`: asserts 768-dim, unit L2 norm
(±0.001), cache-hit determinism, and semantic distinctness. **Compiles** (TEST BUILD
SUCCEEDED) but the `NoesisNoemaTests` target is **unwired** (pre-existing — `xcodebuild
test` discovers 0 cases), so it must be **run manually**. The test self-skips (via
`Issue.record`) when the GGUF isn't reachable through `Bundle.main`.
Manual run: open in Xcode, run the test on the macOS host (which bundles the GGUF).

### A5 — v1.1 import guard
Added the ADR-0011 NOTE block at the top of `DocumentManager.processRAGpackImport`
marking it PR-B-pending. Behavior unchanged. **Finding (see below):** the function
actually called the now-removed CSV loader, so the parse was inlined byte-for-byte.

### Build matrix — all green
| Config | Result |
|---|---|
| macOS Debug | ✅ |
| macOS Release | ✅ |
| iOS Simulator arm64 Debug | ✅ |
| iOS Simulator arm64 Release (`ARCHS=arm64 ONLY_ACTIVE_ARCH=NO`) | ✅ |

iOS builds run serially. No new warnings from the new files.

### modelFingerprint (for PR-B manifest validation)
```
0c7930f6c4f6f29b7da5046e3a2c0832aa3f602db3de5760a95f0582dbd3d6e6
```
(SHA-256 of `nomic-embed-text-v1.5.Q5_K_M.gguf`; matches `shasum -a 256`.)

### ⚠️ PR-A alone breaks RAGpack import until PR-B lands
This is **by design**. The legacy import path no longer works (and the v1.2 reader
doesn't exist yet). **Do not merge PR-A without intending to land PR-B immediately after.**

### Unexpected findings (noted, not fixed beyond what was required)
1. **`loadEmbeddingsCSV` was NOT dead** — `DocumentManager.swift:189` called it in the
   import path (the task's grep premise was inaccurate). To satisfy the mandated
   zero-match self-check *and* keep the build green, the CSV parse was inlined into
   DocumentManager (identical behavior). This is the only DocumentManager change beyond
   the A5 comment.
2. **`LlamaBridgeTest` / `NNTestCLI` target is pre-existing broken** — fails on
   `LibLlama.swift:7 import llama` (no llama link) on a clean `main` checkout too. Not
   caused by PR-A; not in the build matrix.
3. **`NoesisNoemaTests` target is unwired** (consistent with prior project memory) —
   tests compile but aren't discovered/executed by the runner.
4. Pre-existing uncommitted working-tree changes (`project.pbxproj`, the GGUF) were left
   untouched/uncommitted per scope (don't touch pbxproj; GGUF stays git-ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
