### PR TITLE
feat(rag): RAGpack v1.2 reader + import error UI — ADR-0011 PR-B

### DIFF
--- a/Apps/iOS/NoesisNoemaMobile/Views/SettingsView.swift
+++ b/Apps/iOS/NoesisNoemaMobile/Views/SettingsView.swift
@@ -238,6 +238,19 @@ struct SettingsView: View {
                     lastImportedPath = url.lastPathComponent
                 }
             }
+            // ADR-0011 §4: surface RAGpack import failures instead of failing silently.
+            .alert(
+                "RAGpack Import Failed",
+                isPresented: Binding(
+                    get: { documentManager.lastImportError != nil },
+                    set: { if !$0 { documentManager.lastImportError = nil } }
+                ),
+                presenting: documentManager.lastImportError
+            ) { _ in
+                Button("OK", role: .cancel) { documentManager.lastImportError = nil }
+            } message: { error in
+                Text(error.errorDescription ?? "The RAGpack could not be imported.")
+            }
 
             if let path = lastImportedPath {
                 VStack(alignment: .leading, spacing: 4) {

--- a/Apps/macOS/NoesisNoema/Views/DesktopSettingsView.swift
+++ b/Apps/macOS/NoesisNoema/Views/DesktopSettingsView.swift
@@ -366,6 +366,19 @@ private struct DesktopRAGpackManagerView: View {
                 documentManager.importDocument(file: url)
             }
         }
+        // ADR-0011 §4: surface RAGpack import failures instead of failing silently.
+        .alert(
+            "RAGpack Import Failed",
+            isPresented: Binding(
+                get: { documentManager.lastImportError != nil },
+                set: { if !$0 { documentManager.lastImportError = nil } }
+            ),
+            presenting: documentManager.lastImportError
+        ) { _ in
+            Button("OK", role: .cancel) { documentManager.lastImportError = nil }
+        } message: { error in
+            Text(error.errorDescription ?? "The RAGpack could not be imported.")
+        }
     }
 }
 

--- a/Shared/DocumentManager.swift
+++ b/Shared/DocumentManager.swift
@@ -44,6 +44,16 @@ class DocumentManager: ObservableObject {
     /// POTENTIAL LARGE PAYLOAD: RAGpack chunks with embeddings (can be MBs per pack)
     @Published var ragpackChunks: [String: [Chunk]] = [:]
 
+    /// ADR-0011 §4 (no silent fallback): the last RAGpack import failure, surfaced
+    /// to the user via a SwiftUI alert in the Settings views. Set on a failed
+    /// import; cleared on a successful one (and when the user dismisses the alert).
+    @Published var lastImportError: RAGpackImportError? = nil
+
+    /// The app's current query/pack embedder — reused from the shared VectorStore
+    /// so we don't reload the GGUF. Drives the v1.2 manifest fingerprint/dimension
+    /// validation (ADR-0011 §3).
+    private var embedder: EmbeddingModel { VectorStore.shared.embeddingModel }
+
     // DEPRECATED: Old UserDefaults keys (migrated to file storage)
     // let historyKey = "RAGpackUploadHistory" // SMALL - but moved for consistency
     // let ragpackChunksKey = "RAGpackChunks"  // LARGE PAYLOAD - MOVED to file
@@ -120,24 +130,31 @@ class DocumentManager: ObservableObject {
             return
         }
 
-        // Run heavy processing on background thread
+        // Clear any prior failure before starting a fresh import.
+        self.lastImportError = nil
+
+        // Run heavy processing off the main thread; route any failure to
+        // `lastImportError` so the Settings views can present it (ADR-0011 §4).
         Task.detached {
-            await self.processRAGpackImport(fileURL: fileURL)
+            do {
+                try await self.processRAGpackImport(fileURL: fileURL)
+                await MainActor.run { self.lastImportError = nil }
+            } catch {
+                let importError = (error as? RAGpackImportError)
+                    ?? .manifestMalformed(underlying: String(describing: error))
+                print("[RAGpack import] failed: \(importError.errorDescription ?? "\(importError)")")
+                await MainActor.run { self.lastImportError = importError }
+            }
         }
     }
 
-    private func processRAGpackImport(fileURL: URL) async {
-        // NOTE (ADR-0011, PR-A foundation merged; PR-B reader pending):
-        // This function still expects the legacy v0.x pack shape and will NOT work with
-        // pipeline-produced v1.1 packs (no embeddings.csv → silent return). PR-B replaces
-        // this entire function with a v1.2 RAGpackReader (chunks.json + embeddings.npy +
-        // manifest.json + citations.jsonl) and surfaces failures via UI alert. Do not ship
-        // without PR-B.
-        //
+    /// Imports a RAGpack v1.2 archive (ADR-0011 §3-§7). Unzips, reads via
+    /// `RAGpackReader` (which validates the manifest against the current embedder),
+    /// and adds the chunks to the VectorStore. Throws `RAGpackImportError` on every
+    /// malformation — no silent return, no v0.x CSV fallback.
+    private func processRAGpackImport(fileURL: URL) async throws {
         // Sandboxed iOS AND macOS both require explicit security-scoped access for
-        // user-picked URLs returned by .fileImporter / NSOpenPanel. The previous macOS
-        // branch (claiming the entitlement alone was sufficient) was incorrect and caused
-        // EPERM ("Operation not permitted") on RAGpack ZIP imports.
+        // user-picked URLs returned by .fileImporter / NSOpenPanel (PR #94 EPERM fix).
         var didStartAccessing = false
         #if os(iOS) || os(macOS)
         didStartAccessing = fileURL.startAccessingSecurityScopedResource()
@@ -148,106 +165,61 @@ class DocumentManager: ObservableObject {
             if didStartAccessing { fileURL.stopAccessingSecurityScopedResource() }
         }
         #endif
+
         let fileManager = FileManager.default
         let tempDir = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? fileManager.removeItem(at: tempDir) }
+
+        // 1. Unzip into a temp dir. A zip that cannot be opened/extracted is not a
+        //    readable v1.2 pack → surface as a missing-manifest failure.
         do {
             try fileManager.createDirectory(at: tempDir, withIntermediateDirectories: true, attributes: nil)
-            let archive: Archive
-            do {
-                archive = try Archive(url: fileURL, accessMode: .read)
-            } catch {
-                print("Error: Could not open ZIP archive. \(error)")
-                try? fileManager.removeItem(at: tempDir)
-                return
-            }
+            let archive = try Archive(url: fileURL, accessMode: .read)
             for entry in archive {
                 let destinationURL = tempDir.appendingPathComponent(entry.path)
-                do {
-                    switch entry.type {
-                    case .directory:
-                        try fileManager.createDirectory(at: destinationURL, withIntermediateDirectories: true, attributes: nil)
-                        continue
-                    default:
-                        try fileManager.createDirectory(at: destinationURL.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
-                        _ = try archive.extract(entry, to: destinationURL)
-                    }
-                } catch {
-                    print("Error extracting entry \(entry.path): \(error)")
+                switch entry.type {
+                case .directory:
+                    try fileManager.createDirectory(at: destinationURL, withIntermediateDirectories: true, attributes: nil)
+                default:
+                    try fileManager.createDirectory(at: destinationURL.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
+                    _ = try archive.extract(entry, to: destinationURL)
                 }
             }
         } catch {
-            print("Error: Failed to create temporary directory or extract ZIP. \(error)")
-            return
+            throw RAGpackImportError.manifestMissing
         }
-        // Locate required files in the extracted directory
-        let chunksURL = tempDir.appendingPathComponent("chunks.json")
-        let embeddingsURL = tempDir.appendingPathComponent("embeddings.csv")
-        let metadataURL = tempDir.appendingPathComponent("metadata.json")
-        guard fileManager.fileExists(atPath: chunksURL.path),
-              fileManager.fileExists(atPath: embeddingsURL.path) else {
-            print("Error: Missing required file(s) in RAGpack (.zip): chunks.json and/or embeddings.csv.")
-            try? fileManager.removeItem(at: tempDir)
-            return
-        }
-        do {
-            let chunksData = try Data(contentsOf: chunksURL)
-            let chunkStrings = try JSONDecoder().decode([String].self, from: chunksData)
-            // Inline legacy v0.x CSV parse (formerly EmbeddingModel's CSV loader,
-            // removed in PR-A — the embedder no longer ships a CSV loader). Behavior is
-            // byte-for-byte identical to the old helper; this whole branch is superseded
-            // by the v1.2 RAGpackReader in PR-B (see the NOTE at the top of this function).
-            let embeddings: [[Float]] = {
-                guard let csvString = try? String(contentsOf: embeddingsURL, encoding: .utf8) else { return [] }
-                return csvString.split(separator: "\n").map { row in
-                    row.split(separator: ",").compactMap { Float($0.trimmingCharacters(in: .whitespaces)) }
-                }
-            }()
-            if chunkStrings.count != embeddings.count {
-                print("Error: chunks.jsonとembeddings.csvの数が一致しません")
-                try? fileManager.removeItem(at: tempDir)
-                return
-            }
-            let chunks = zip(chunkStrings, embeddings).map { Chunk(content: $0.0, embedding: $0.1, sourceTitle: nil, sourcePath: nil, page: nil) }
-            // After building chunks, attach a default title so UI can show citations
-            let baseName = fileURL.deletingPathExtension().lastPathComponent
-            let timestamp = Date()
-            let docName = "\(baseName)_\(Int(timestamp.timeIntervalSince1970))"
-            let titledChunks = chunks.map { ch -> Chunk in
-                var c = ch
-                c.sourceTitle = docName
-                return c
-            }
-            var metadata: [String: Any] = [:]
-            if fileManager.fileExists(atPath: metadataURL.path) {
-                let metadataData = try Data(contentsOf: metadataURL)
-                if let meta = try JSONSerialization.jsonObject(with: metadataData, options: []) as? [String: Any] {
-                    metadata = meta
-                }
-            }
-            let ragFile = LLMRagFile(filename: docName, metadata: metadata, chunks: titledChunks)
 
-            // Filter unique chunks
-            let uniqueChunks = titledChunks.filter { chunk in
-                !VectorStore.shared.chunks.contains(where: { $0.content == chunk.content && $0.embedding == chunk.embedding })
-            }
+        // 2. Read + validate the v1.2 pack. Throws RAGpackImportError; let it propagate.
+        let (chunks, _) = try RAGpackReader.readPack(at: tempDir, embedder: self.embedder)
 
-            // Update UI on main thread
-            await MainActor.run {
-                self.llmragFiles.append(ragFile)
-                print("Imported RAGpack document: \(docName)")
-                VectorStore.shared.chunks.append(contentsOf: uniqueChunks)
-                print("RAGpack unique chunks added to VectorStore.shared (RAG検索対象拡張)")
-                self.ragpackChunks[docName] = uniqueChunks
-                self.uploadHistory.append(UploadHistory(filename: docName, timestamp: timestamp, chunkCount: uniqueChunks.count))
-                self.saveHistory()
-                self.saveRAGpackChunks()
-            }
-        } catch {
-            print("Error: Failed to load chunks or embeddings. \(error)")
-            try? fileManager.removeItem(at: tempDir)
-            return
+        // 3. Title the chunks and add the unique ones to the VectorStore.
+        let baseName = fileURL.deletingPathExtension().lastPathComponent
+        let timestamp = Date()
+        let docName = "\(baseName)_\(Int(timestamp.timeIntervalSince1970))"
+        let titledChunks = chunks.map { ch -> Chunk in
+            var c = ch
+            if c.sourceTitle == nil { c.sourceTitle = docName }
+            return c
         }
-        try? fileManager.removeItem(at: tempDir)
+        let metadata: [String: Any] = [
+            "pack_version": "1.2",
+            "doc_name": docName
+        ]
+        let ragFile = LLMRagFile(filename: docName, metadata: metadata, chunks: titledChunks)
+
+        let uniqueChunks = titledChunks.filter { chunk in
+            !VectorStore.shared.chunks.contains(where: { $0.content == chunk.content && $0.embedding == chunk.embedding })
+        }
+
+        await MainActor.run {
+            self.llmragFiles.append(ragFile)
+            VectorStore.shared.chunks.append(contentsOf: uniqueChunks)
+            self.ragpackChunks[docName] = uniqueChunks
+            self.uploadHistory.append(UploadHistory(filename: docName, timestamp: timestamp, chunkCount: uniqueChunks.count))
+            self.saveHistory()
+            self.saveRAGpackChunks()
+            print("Imported RAGpack v1.2 document: \(docName) (\(uniqueChunks.count) unique chunks)")
+        }
     }
 
     /**
@@ -278,58 +250,6 @@ class DocumentManager: ObservableObject {
      */
     func importModelResource(file: Any) {
         // TODO: implement model resource import for RAGpack-based architecture.
-    }
-
-    /// モデルファイル探索＋LlamaStateでロード＋推論
-    func inferWithLlama(prompt: String, fileName: String = "llama3-8b.gguf", completion: @escaping (String) -> Void) {
-        // プレ・プロンプト（独白/CoT抑止）
-        func buildPlainPrompt(question: String, context: String? = nil) -> String {
-            let sys = """
-            You are a helpful, concise assistant.
-            Answer with the final answer only. Do not include analysis, chain-of-thought, self-talk, internal monologue, or meta commentary.
-            Never output tags like <think>...</think>. If tempted, stop and give only the final answer.
-            """
-            var txt = sys + "\n\n"
-            if let ctx = context, !ctx.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                txt += "Context:\n\(ctx)\n\n"
-            }
-            txt += "Question: \(question)\n\nAnswer:"
-            return txt
-        }
-        let fm = FileManager.default
-        let cwd = fm.currentDirectoryPath
-        var checkedPaths: [String] = []
-        let pathCWD = "\(cwd)/\(fileName)"
-        checkedPaths.append(pathCWD)
-        let exePath = CommandLine.arguments[0]
-        let exeDir = URL(fileURLWithPath: exePath).deletingLastPathComponent().path
-        let pathExeDir = "\(exeDir)/\(fileName)"
-        if pathExeDir != pathCWD { checkedPaths.append(pathExeDir) }
-        if let bundleResourceURL = Bundle.main.resourceURL {
-            let pathBundle = bundleResourceURL.appendingPathComponent(fileName).path
-            if pathBundle != pathCWD && pathBundle != pathExeDir { checkedPaths.append(pathBundle) }
-        }
-        for path in checkedPaths {
-            if fm.fileExists(atPath: path) {
-                print("[Llama] FOUND: \(path)")
-                Task {
-                    let llama = await LlamaState()
-                    do {
-                        try await llama.loadModel(modelUrl: URL(fileURLWithPath: path))
-                        // プレ・プロンプト適用
-                        let wrapped = buildPlainPrompt(question: prompt)
-                        let response: String = await llama.complete(text: wrapped)
-                        completion(response)
-                    } catch {
-                        print("[Llama] Error running inference: \(error)")
-                        completion("[Llama Error] \(error)")
-                    }
-                }
-                return
-            }
-        }
-        print("[Llama] NOT FOUND in any attempted path!")
-        completion("[Llama] Model file not found.")
     }
 
     // MARK: - QA History Management

--- a/Shared/RAG/Chunk.swift
+++ b/Shared/RAG/Chunk.swift
@@ -18,4 +18,55 @@ struct Chunk: Codable, Equatable {
     var sourceTitle: String?
     var sourcePath: String?
     var page: Int?
+
+    // ADR-0011 PR-B: optional citation metadata sourced from a v1.2 RAGpack's
+    // citations.jsonl. All optional and defaulted — purely additive, so every
+    // existing constructor (`Chunk(content:embedding:)` etc.) keeps compiling and
+    // existing encoded chunks keep decoding.
+    var docId: String?
+    var charStart: Int?
+    var charEnd: Int?
+    var paragraphBoundaries: [Int]?
+
+    enum CodingKeys: String, CodingKey {
+        case content, embedding, sourceTitle, sourcePath, page
+        case docId, charStart, charEnd, paragraphBoundaries
+    }
+
+    init(content: String,
+         embedding: [Float],
+         sourceTitle: String? = nil,
+         sourcePath: String? = nil,
+         page: Int? = nil,
+         docId: String? = nil,
+         charStart: Int? = nil,
+         charEnd: Int? = nil,
+         paragraphBoundaries: [Int]? = nil) {
+        self.content = content
+        self.embedding = embedding
+        self.sourceTitle = sourceTitle
+        self.sourcePath = sourcePath
+        self.page = page
+        self.docId = docId
+        self.charStart = charStart
+        self.charEnd = charEnd
+        self.paragraphBoundaries = paragraphBoundaries
+    }
+
+    // Custom decoder so a v1.2 chunks.json that carries content (+ optional
+    // metadata) but NO embedding still decodes — the embedding is filled from
+    // embeddings.npy by RAGpackReader. Previously-encoded chunks (embedding
+    // present) continue to decode unchanged. Encoding stays synthesized.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.content = try c.decode(String.self, forKey: .content)
+        self.embedding = try c.decodeIfPresent([Float].self, forKey: .embedding) ?? []
+        self.sourceTitle = try c.decodeIfPresent(String.self, forKey: .sourceTitle)
+        self.sourcePath = try c.decodeIfPresent(String.self, forKey: .sourcePath)
+        self.page = try c.decodeIfPresent(Int.self, forKey: .page)
+        self.docId = try c.decodeIfPresent(String.self, forKey: .docId)
+        self.charStart = try c.decodeIfPresent(Int.self, forKey: .charStart)
+        self.charEnd = try c.decodeIfPresent(Int.self, forKey: .charEnd)
+        self.paragraphBoundaries = try c.decodeIfPresent([Int].self, forKey: .paragraphBoundaries)
+    }
 }

--- a/Shared/RAG/NumpyReader.swift
+++ b/Shared/RAG/NumpyReader.swift
@@ -1,0 +1,176 @@
+// Project: NoesisNoema
+// File: NumpyReader.swift
+// Description: Minimal NumPy .npy reader for little-endian float32 arrays.
+//   ADR-0011 PR-B (§3-§7): RAGpack v1.2 stores embeddings as embeddings.npy.
+//   This is the import-side parser. Pure Foundation, no third-party deps.
+// License: MIT License
+
+import Foundation
+
+/// Parses a NumPy `.npy` file (v1.0 / v2.0) holding a little-endian float32
+/// (`'<f4'`), C-contiguous array. Throws on every malformation — there is no
+/// silent fallback (ADR-0011 §4).
+struct NumpyReader {
+
+    /// Reads a float32 `.npy` file.
+    /// - Returns: the parsed `shape` (arbitrary rank) and a flat `data` buffer of
+    ///   `prod(shape)` floats in C (row-major) order. The caller reshapes.
+    static func readFloat32(from url: URL) throws -> (shape: [Int], data: [Float]) {
+        let bytes = try Data(contentsOf: url)
+
+        // Header preamble: 6 magic + 2 version + (2 or 4) header-length bytes.
+        guard bytes.count >= 10 else { throw NumpyReadError.fileTooSmall }
+
+        // Magic string: \x93 N U M P Y
+        let magic: [UInt8] = [0x93, 0x4E, 0x55, 0x4D, 0x50, 0x59]
+        guard Array(bytes.prefix(6)) == magic else { throw NumpyReadError.badMagic }
+
+        let major = bytes[bytes.startIndex + 6]
+        // bytes[startIndex + 7] is the minor version; we only branch on major.
+
+        // Header length is uint16 (v1.x) or uint32 (v2.x), little-endian. The
+        // header dict begins right after the length field.
+        let headerLenSize: Int
+        switch major {
+        case 1:
+            headerLenSize = 2
+        case 2:
+            headerLenSize = 4
+        default:
+            throw NumpyReadError.unsupportedVersion
+        }
+
+        let lenStart = bytes.startIndex + 8
+        guard bytes.count >= 8 + headerLenSize else { throw NumpyReadError.fileTooSmall }
+
+        var headerLen = 0
+        for i in 0..<headerLenSize {
+            // Little-endian: least-significant byte first.
+            headerLen |= Int(bytes[lenStart + i]) << (8 * i)
+        }
+
+        let headerStart = lenStart + headerLenSize
+        let headerEnd = headerStart + headerLen
+        guard bytes.count >= headerEnd else { throw NumpyReadError.fileTooSmall }
+
+        guard let header = String(data: bytes[headerStart..<headerEnd], encoding: .ascii) else {
+            throw NumpyReadError.headerMalformed("header is not valid ASCII")
+        }
+
+        // Parse the three fields we care about out of the Python dict literal.
+        let descr = try parseStringField("descr", in: header)
+        guard descr == "<f4" else { throw NumpyReadError.unsupportedDtype(descr) }
+
+        let fortran = try parseBoolField("fortran_order", in: header)
+        guard fortran == false else {
+            throw NumpyReadError.headerMalformed("fortran_order: True is not supported")
+        }
+
+        let shape = try parseShapeField(in: header)
+
+        // Data payload: prod(shape) little-endian float32 values.
+        let expectedCount = shape.reduce(1, *)
+        let expectedBytes = expectedCount * 4
+        let payload = bytes[headerEnd...]
+        guard payload.count == expectedBytes else {
+            throw NumpyReadError.dataLengthMismatch(expected: expectedBytes, actual: payload.count)
+        }
+
+        // Single-pass copy into [Float]. We re-base the payload into a contiguous
+        // Data so the unsafe load offsets are well-defined regardless of the
+        // original slice's startIndex. The on-disk bytes are little-endian, which
+        // matches every Apple platform we ship, so a raw reinterpret is correct.
+        var out = [Float](repeating: 0, count: expectedCount)
+        if expectedCount > 0 {
+            let contiguous = Data(payload)
+            contiguous.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+                for i in 0..<expectedCount {
+                    out[i] = raw.loadUnaligned(fromByteOffset: i * 4, as: Float.self)
+                }
+            }
+        }
+
+        return (shape, out)
+    }
+
+    // MARK: - Header field parsing (hand-written; no regex framework)
+
+    /// Extracts `'<key>': '<value>'` and returns `<value>`.
+    private static func parseStringField(_ key: String, in header: String) throws -> String {
+        guard let keyRange = header.range(of: "'\(key)'") else {
+            throw NumpyReadError.headerMalformed("missing '\(key)'")
+        }
+        let after = header[keyRange.upperBound...]
+        guard let colon = after.firstIndex(of: ":") else {
+            throw NumpyReadError.headerMalformed("malformed '\(key)' (no colon)")
+        }
+        let rest = after[after.index(after: colon)...]
+        guard let openQuote = rest.firstIndex(of: "'") else {
+            throw NumpyReadError.headerMalformed("malformed '\(key)' (no opening quote)")
+        }
+        let valueStart = rest.index(after: openQuote)
+        guard let closeQuote = rest[valueStart...].firstIndex(of: "'") else {
+            throw NumpyReadError.headerMalformed("malformed '\(key)' (no closing quote)")
+        }
+        return String(rest[valueStart..<closeQuote])
+    }
+
+    /// Extracts `'<key>': True|False`.
+    private static func parseBoolField(_ key: String, in header: String) throws -> Bool {
+        guard let keyRange = header.range(of: "'\(key)'") else {
+            throw NumpyReadError.headerMalformed("missing '\(key)'")
+        }
+        let after = header[keyRange.upperBound...]
+        guard let colon = after.firstIndex(of: ":") else {
+            throw NumpyReadError.headerMalformed("malformed '\(key)' (no colon)")
+        }
+        // The value is the token between the colon and the next comma, e.g.
+        // "fortran_order': False, 'shape'..." → "False".
+        let afterColon = after[after.index(after: colon)...]
+        let valueToken = afterColon.prefix { $0 != "," }
+            .trimmingCharacters(in: .whitespaces)
+        switch valueToken {
+        case "True": return true
+        case "False": return false
+        default:
+            throw NumpyReadError.headerMalformed("malformed '\(key)' (expected True/False, got '\(valueToken)')")
+        }
+    }
+
+    /// Extracts `'shape': (a, b, ...)` into `[a, b, ...]`. Accepts arbitrary rank,
+    /// including the 1-tuple form `(N,)` and the 0-d form `()`.
+    private static func parseShapeField(in header: String) throws -> [Int] {
+        guard let keyRange = header.range(of: "'shape'") else {
+            throw NumpyReadError.shapeMalformed("missing 'shape'")
+        }
+        let after = header[keyRange.upperBound...]
+        guard let open = after.firstIndex(of: "(") else {
+            throw NumpyReadError.shapeMalformed("no opening paren")
+        }
+        guard let close = after[open...].firstIndex(of: ")") else {
+            throw NumpyReadError.shapeMalformed("no closing paren")
+        }
+        let inner = after[after.index(after: open)..<close]
+        let dims = inner.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        var shape: [Int] = []
+        for d in dims {
+            guard let n = Int(d), n >= 0 else {
+                throw NumpyReadError.shapeMalformed("non-integer dimension '\(d)'")
+            }
+            shape.append(n)
+        }
+        return shape
+    }
+}
+
+enum NumpyReadError: Error {
+    case fileTooSmall
+    case badMagic                  // not "\x93NUMPY"
+    case unsupportedVersion        // we accept 1.0 and 2.0; reject others
+    case headerMalformed(String)
+    case unsupportedDtype(String)  // we accept only "<f4" (little-endian float32)
+    case shapeMalformed(String)
+    case dataLengthMismatch(expected: Int, actual: Int)
+}

--- a/Shared/RAG/RAGpackManifest.swift
+++ b/Shared/RAG/RAGpackManifest.swift
@@ -1,0 +1,122 @@
+// Project: NoesisNoema
+// File: RAGpackManifest.swift
+// Description: RAGpack v1.2 manifest model + validator (ADR-0011 §3-§7).
+//   Mirrors the v1.2 manifest schema this app commits to (derived from
+//   noesisnoema-pipeline's manifest_v1_1.json, lifted to the llama.cpp embedder
+//   identity). Embedder identity is by fingerprint (model_hash), not name (§3).
+// License: MIT License
+
+import Foundation
+
+/// Decoded `manifest.json` from a RAGpack v1.2 archive. Snake_case JSON keys map
+/// to camelCase Swift via `CodingKeys`.
+struct RAGpackManifest: Codable {
+    let packVersion: String      // must equal "1.2"
+    let packId: String
+    let createdAt: String
+    let chunker: ChunkerInfo
+    let embedder: EmbedderInfo
+    let indexer: IndexerInfo
+    let files: FilesInfo
+    let stats: StatsInfo?
+
+    enum CodingKeys: String, CodingKey {
+        case packVersion = "pack_version"
+        case packId = "pack_id"
+        case createdAt = "created_at"
+        case chunker
+        case embedder
+        case indexer
+        case files
+        case stats
+    }
+
+    struct ChunkerInfo: Codable {
+        let method: String
+        let chunkSize: Int
+        let overlap: Int
+        let tokenizerName: String?
+        let preserveSentences: Bool?
+        let configHash: String?
+
+        enum CodingKeys: String, CodingKey {
+            case method
+            case chunkSize = "chunk_size"
+            case overlap
+            case tokenizerName = "tokenizer_name"
+            case preserveSentences = "preserve_sentences"
+            case configHash = "config_hash"
+        }
+    }
+
+    struct EmbedderInfo: Codable {
+        let embeddingModel: String      // human-readable name (NOT the identity)
+        let embeddingDimension: Int
+        let modelHash: String           // <-- the fingerprint (GGUF SHA-256), REQUIRED
+        let dtype: String
+        let pooling: String
+        let l2Normalized: Bool
+        let runtime: String?
+
+        enum CodingKeys: String, CodingKey {
+            case embeddingModel = "embedding_model"
+            case embeddingDimension = "embedding_dimension"
+            case modelHash = "model_hash"
+            case dtype
+            case pooling
+            case l2Normalized = "l2_normalized"
+            case runtime
+        }
+    }
+
+    struct IndexerInfo: Codable {
+        let method: String
+        let dimension: Int
+    }
+
+    struct FilesInfo: Codable {
+        let chunks: String
+        let embeddings: String
+        let citations: String?          // optional in v1.2
+    }
+
+    struct StatsInfo: Codable {
+        let chunkCount: Int?
+        let totalTokens: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case chunkCount = "chunk_count"
+            case totalTokens = "total_tokens"
+        }
+    }
+}
+
+extension RAGpackManifest {
+    /// Validates this manifest against the v1.2 spec AND against the app's
+    /// currently-loaded embedder. Throws a specific `RAGpackImportError` on every
+    /// violation — there is no silent fallback (ADR-0011 §4). The central §3 check
+    /// is the fingerprint (`model_hash`) comparison.
+    func validate(againstCurrentEmbedder current: EmbeddingModel) throws {
+        guard packVersion == "1.2" else {
+            throw RAGpackImportError.unsupportedPackVersion(found: packVersion)
+        }
+        guard embedder.dtype == "float32" else {
+            throw RAGpackImportError.unsupportedEmbedderDtype(found: embedder.dtype)
+        }
+        guard embedder.pooling == "mean" else {
+            throw RAGpackImportError.unsupportedEmbedderPooling(found: embedder.pooling)
+        }
+        guard embedder.l2Normalized else {
+            throw RAGpackImportError.embedderNotL2Normalized
+        }
+        guard embedder.embeddingDimension == current.dimension else {
+            throw RAGpackImportError.embedderDimensionMismatch(expected: current.dimension,
+                                                               found: embedder.embeddingDimension)
+        }
+        // §3: identity is by fingerprint, not name. Case-insensitive hex compare.
+        guard embedder.modelHash.lowercased() == current.modelFingerprint.lowercased() else {
+            throw RAGpackImportError.embedderFingerprintMismatch(expected: current.modelFingerprint,
+                                                                 found: embedder.modelHash)
+        }
+    }
+}

--- a/Shared/RAG/RAGpackReader.swift
+++ b/Shared/RAG/RAGpackReader.swift
@@ -1,0 +1,218 @@
+// Project: NoesisNoema
+// File: RAGpackReader.swift
+// Description: RAGpack v1.2 reader (ADR-0011 §3-§7). Reads an unzipped pack
+//   (manifest.json + chunks.json + embeddings.npy + optional citations.jsonl),
+//   validates the manifest against the current embedder, and returns parsed
+//   chunks with embeddings. Throws a structured error on every malformation —
+//   no silent fallback (§4), no v0.x CSV path (anti-goal).
+// License: MIT License
+
+import Foundation
+
+struct RAGpackReader {
+
+    /// Reads a v1.2 RAGpack from an already-unzipped directory.
+    /// - Parameters:
+    ///   - unzippedDir: directory containing manifest.json, chunks.json,
+    ///     embeddings.npy, and optionally citations.jsonl.
+    ///   - embedder: the app's current `EmbeddingModel` — used to validate the
+    ///     embedder fingerprint and dimension (ADR-0011 §3).
+    /// - Returns: `chunks` (each carrying its embedding and any citation metadata)
+    ///   and the parallel `embeddings` matrix.
+    static func readPack(at unzippedDir: URL,
+                         embedder: EmbeddingModel) throws -> (chunks: [Chunk],
+                                                              embeddings: [[Float]]) {
+        let fm = FileManager.default
+
+        // 1. manifest.json → RAGpackManifest
+        let manifestURL = unzippedDir.appendingPathComponent("manifest.json")
+        guard fm.fileExists(atPath: manifestURL.path) else {
+            throw RAGpackImportError.manifestMissing
+        }
+        let manifest: RAGpackManifest
+        do {
+            let data = try Data(contentsOf: manifestURL)
+            manifest = try JSONDecoder().decode(RAGpackManifest.self, from: data)
+        } catch let e as RAGpackImportError {
+            throw e
+        } catch {
+            throw RAGpackImportError.manifestMalformed(underlying: String(describing: error))
+        }
+
+        // 2. Validate schema + embedder identity (throws on every violation).
+        try manifest.validate(againstCurrentEmbedder: embedder)
+
+        // 3. chunks.json → [Chunk] (embeddings filled from the .npy in step 5).
+        let chunksURL = unzippedDir.appendingPathComponent(manifest.files.chunks)
+        guard fm.fileExists(atPath: chunksURL.path) else {
+            throw RAGpackImportError.chunksMissing
+        }
+        var chunks: [Chunk]
+        do {
+            let data = try Data(contentsOf: chunksURL)
+            chunks = try JSONDecoder().decode([Chunk].self, from: data)
+        } catch {
+            throw RAGpackImportError.chunksMalformed(underlying: String(describing: error))
+        }
+
+        // 4. embeddings.npy → (shape, flat)
+        let embeddingsURL = unzippedDir.appendingPathComponent(manifest.files.embeddings)
+        guard fm.fileExists(atPath: embeddingsURL.path) else {
+            throw RAGpackImportError.embeddingsMissing
+        }
+        let shape: [Int]
+        let flat: [Float]
+        do {
+            (shape, flat) = try NumpyReader.readFloat32(from: embeddingsURL)
+        } catch {
+            throw RAGpackImportError.embeddingsMalformed(underlying: String(describing: error))
+        }
+        guard shape.count == 2, shape[1] == embedder.dimension else {
+            throw RAGpackImportError.embeddingShapeUnexpected(shape: shape)
+        }
+
+        // 5. Reshape flat → [[Float]] of length shape[0], each row shape[1].
+        let rowCount = shape[0]
+        let dim = shape[1]
+        var embeddings: [[Float]] = []
+        embeddings.reserveCapacity(rowCount)
+        for r in 0..<rowCount {
+            let start = r * dim
+            embeddings.append(Array(flat[start..<(start + dim)]))
+        }
+
+        // 6. Cross-check chunk / embedding counts.
+        guard chunks.count == embeddings.count else {
+            throw RAGpackImportError.chunksEmbeddingsCountMismatch(chunks: chunks.count,
+                                                                  embeddings: embeddings.count)
+        }
+
+        // Attach each embedding row to its chunk so the returned chunks are fully
+        // formed for the VectorStore (which keys/searches on Chunk.embedding).
+        for i in chunks.indices {
+            chunks[i].embedding = embeddings[i]
+        }
+
+        // 7. citations.jsonl — optional. If present, attach per-chunk metadata by index.
+        if let citationsName = manifest.files.citations {
+            let citationsURL = unzippedDir.appendingPathComponent(citationsName)
+            if fm.fileExists(atPath: citationsURL.path) {
+                try attachCitations(from: citationsURL, to: &chunks)
+            }
+        }
+
+        // 8. Done.
+        return (chunks, embeddings)
+    }
+
+    /// Parses citations.jsonl (one JSON object per line) and attaches the citation
+    /// fields to the matching chunk by `chunk_index`. Errors → `.citationsMalformed`.
+    private static func attachCitations(from url: URL, to chunks: inout [Chunk]) throws {
+        let raw: String
+        do {
+            raw = try String(contentsOf: url, encoding: .utf8)
+        } catch {
+            throw RAGpackImportError.citationsMalformed(underlying: String(describing: error))
+        }
+        let lines = raw.split(whereSeparator: { $0 == "\n" || $0 == "\r\n" })
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty { continue }
+            guard let lineData = trimmed.data(using: .utf8) else {
+                throw RAGpackImportError.citationsMalformed(underlying: "line is not valid UTF-8")
+            }
+            let record: CitationRecord
+            do {
+                record = try JSONDecoder().decode(CitationRecord.self, from: lineData)
+            } catch {
+                throw RAGpackImportError.citationsMalformed(underlying: String(describing: error))
+            }
+            let idx = record.chunkIndex
+            guard idx >= 0 && idx < chunks.count else {
+                throw RAGpackImportError.citationsMalformed(
+                    underlying: "chunk_index \(idx) out of range (0..<\(chunks.count))")
+            }
+            if let docId = record.docId { chunks[idx].docId = docId }
+            if let page = record.page { chunks[idx].page = page }
+            if let s = record.charStart { chunks[idx].charStart = s }
+            if let e = record.charEnd { chunks[idx].charEnd = e }
+            if let pb = record.paragraphBoundaries { chunks[idx].paragraphBoundaries = pb }
+        }
+    }
+
+    /// One line of citations.jsonl. Derived from noesisnoema-pipeline's
+    /// `chunk_text_with_offsets` output.
+    private struct CitationRecord: Decodable {
+        let chunkIndex: Int
+        let docId: String?
+        let page: Int?
+        let charStart: Int?
+        let charEnd: Int?
+        let paragraphBoundaries: [Int]?
+
+        enum CodingKeys: String, CodingKey {
+            case chunkIndex = "chunk_index"
+            case docId = "doc_id"
+            case page
+            case charStart = "char_start"
+            case charEnd = "char_end"
+            case paragraphBoundaries = "paragraph_boundaries"
+        }
+    }
+}
+
+enum RAGpackImportError: Error, LocalizedError, Identifiable {
+    case manifestMissing
+    case manifestMalformed(underlying: String)
+    case chunksMissing
+    case chunksMalformed(underlying: String)
+    case embeddingsMissing
+    case embeddingsMalformed(underlying: String)
+    case citationsMalformed(underlying: String)
+    case unsupportedPackVersion(found: String)
+    case unsupportedEmbedderDtype(found: String)
+    case unsupportedEmbedderPooling(found: String)
+    case embedderNotL2Normalized
+    case embedderDimensionMismatch(expected: Int, found: Int)
+    case embedderFingerprintMismatch(expected: String, found: String)
+    case chunksEmbeddingsCountMismatch(chunks: Int, embeddings: Int)
+    case embeddingShapeUnexpected(shape: [Int])
+
+    /// Stable identity so SwiftUI `.alert(item:)` can present the error.
+    var id: String { errorDescription ?? "ragpack-import-error" }
+
+    var errorDescription: String? {
+        switch self {
+        case .manifestMissing:
+            return "This RAGpack is missing manifest.json. It is not a valid v1.2 pack."
+        case .manifestMalformed(let underlying):
+            return "The RAGpack manifest.json could not be read: \(underlying)"
+        case .chunksMissing:
+            return "This RAGpack is missing its chunks.json file."
+        case .chunksMalformed(let underlying):
+            return "The RAGpack chunks.json could not be read: \(underlying)"
+        case .embeddingsMissing:
+            return "This RAGpack is missing its embeddings.npy file."
+        case .embeddingsMalformed(let underlying):
+            return "The RAGpack embeddings.npy could not be read: \(underlying)"
+        case .citationsMalformed(let underlying):
+            return "The RAGpack citations.jsonl could not be read: \(underlying)"
+        case .unsupportedPackVersion(let found):
+            return "Unsupported RAGpack version “\(found)”. This app requires v1.2."
+        case .unsupportedEmbedderDtype(let found):
+            return "Unsupported embedding dtype “\(found)”. Only float32 is supported."
+        case .unsupportedEmbedderPooling(let found):
+            return "Unsupported embedding pooling “\(found)”. Only mean pooling is supported."
+        case .embedderNotL2Normalized:
+            return "This RAGpack's embeddings are not L2-normalized, which this app requires."
+        case .embedderDimensionMismatch(let expected, let found):
+            return "Embedding dimension mismatch: this pack has \(found)-dim vectors, but the app's embedder produces \(expected)-dim."
+        case .embedderFingerprintMismatch(let expected, let found):
+            return "This RAGpack was built with a different embedding model than the app uses, so retrieval would be wrong. Re-generate the pack with the current embedder.\n\nExpected fingerprint: \(expected.prefix(16))…\nPack fingerprint: \(found.prefix(16))…"
+        case .chunksEmbeddingsCountMismatch(let chunks, let embeddings):
+            return "Corrupt RAGpack: \(chunks) chunks but \(embeddings) embeddings."
+        case .embeddingShapeUnexpected(let shape):
+            return "Unexpected embeddings shape \(shape); expected a 2-D (N, dimension) array."
+        }
+    }
+}


### PR DESCRIPTION
## ADR-0011 PR-B — RAGpack v1.2 reader + import error UI

This is **PR-B of two** for ADR-0011 (`c61a2ae` in `rag-fish/RAGfish`), §3-§7.
PR-A (#97) delivered the foundation: real semantic embedding via llama.cpp, the
new `EmbeddingModel` (768-dim output, SHA-256 `modelFingerprint`). **PR-B delivers
the import-side completion**: a RAGpack v1.2 reader (`.npy` parser + manifest
validator + fingerprint check), UI alert surfacing for import failures, and
incidental dead-code cleanup.

> ⚠️ **The pipeline must be updated to v1.2 (separate PR in `noesisnoema-pipeline`)
> before any new RAGpack can be imported successfully.** Existing v1.1 packs
> (MiniLM-based) are now **rejected** at import with `embedderFingerprintMismatch`
> — that is by design (ADR-0011 §6, accepted hard break). Re-UAT of Spinoza Ethica
> requires the pipeline-side v1.2 PR landed + a v1.2 pack regenerated.

### v1.2 manifest shape this PR commits to

```jsonc
{
  "pack_version": "1.2",
  "pack_id": "<uuid>",
  "created_at": "<ISO 8601>",
  "chunker":  { "method": "...", "chunk_size": 512, "overlap": 64,
                "tokenizer_name": "?", "preserve_sentences": true, "config_hash": "?" },
  "embedder": { "embedding_model": "nomic-embed-text-v1.5", "embedding_dimension": 768,
                "model_hash": "<sha256 of GGUF — the fingerprint>", "dtype": "float32",
                "pooling": "mean", "l2_normalized": true, "runtime": "llama.cpp" },
  "indexer":  { "method": "flat", "dimension": 768 },
  "files":    { "chunks": "chunks.json", "embeddings": "embeddings.npy",
                "citations": "citations.jsonl" },   // citations optional
  "stats":    { "chunk_count": 1234, "total_tokens": 543210 }  // optional
}
```

### B1 — `Shared/RAG/NumpyReader.swift` (new, 176 LOC)

Pure-Foundation NumPy `.npy` reader. `readFloat32(from:) -> (shape, data)`:
- Accepts v1.0 (uint16 header len) and v2.0 (uint32); rejects other versions.
- Validates magic `\x93NUMPY`; only `'descr': '<f4'` (little-endian f32); only
  `'fortran_order': False`. Hand-written dict-field + shape-tuple parser (no regex
  framework), arbitrary rank.
- Exact `data_size == prod(shape) * 4` check → `.dataLengthMismatch`.
- Single-pass copy into `[Float]` via `withUnsafeBytes` / `loadUnaligned`.
- `NumpyReadError`: `fileTooSmall`, `badMagic`, `unsupportedVersion`,
  `headerMalformed`, `unsupportedDtype`, `shapeMalformed`, `dataLengthMismatch`.

### B2 — `Shared/RAG/RAGpackManifest.swift` (new, 122 LOC)

`Codable` model of the v1.2 manifest (snake_case JSON ↔ camelCase Swift via
`CodingKeys`). `validate(againstCurrentEmbedder:)` enforces:

| check | error on failure |
|---|---|
| `pack_version == "1.2"` | `.unsupportedPackVersion(found:)` |
| `embedder.dtype == "float32"` | `.unsupportedEmbedderDtype(found:)` |
| `embedder.pooling == "mean"` | `.unsupportedEmbedderPooling(found:)` |
| `embedder.l2_normalized == true` | `.embedderNotL2Normalized` |
| `embedding_dimension == current.dimension` | `.embedderDimensionMismatch(expected:found:)` |
| `model_hash == current.modelFingerprint` (case-insensitive hex) | `.embedderFingerprintMismatch(expected:found:)` ← **§3 identity check** |

### B3 — `Shared/RAG/RAGpackReader.swift` (new, 218 LOC)

`readPack(at:embedder:) -> (chunks, embeddings)`. Read order: **manifest.json →
validate → chunks.json → embeddings.npy → reshape (N, dim) → count cross-check →
optional citations.jsonl** (one JSON object per line, attached to chunk by
`chunk_index`). Throws on every malformation; `embeddings.npy` must be 2-D with
`shape[1] == embedder.dimension`.

`RAGpackImportError: Error, LocalizedError, Identifiable` — full case list per
spec; `errorDescription` produces user-readable strings, e.g.:

- `unsupportedPackVersion("1.1")` → *"Unsupported RAGpack version “1.1”. This app requires v1.2."*
- `embedderFingerprintMismatch` → *"This RAGpack was built with a different embedding model than the app uses, so retrieval would be wrong. Re-generate the pack with the current embedder. Expected fingerprint: 0c7930f6c4f6f29b… / Pack fingerprint: <found>…"*
- `embedderDimensionMismatch(expected: 768, found: 384)` → *"Embedding dimension mismatch: this pack has 384-dim vectors, but the app's embedder produces 768-dim."*
- `chunksEmbeddingsCountMismatch(120, 119)` → *"Corrupt RAGpack: 120 chunks but 119 embeddings."*

`Chunk` gains **additive** optional citation fields (`docId`, `charStart`,
`charEnd`, `paragraphBoundaries`) + a tolerant decoder (embedding defaults to `[]`
when absent in chunks.json, filled from the `.npy`). **Additive only** — all
three existing constructors (`Chunk(content:embedding:)`, the 5-arg titled form,
`Preprocessor`'s) compile unchanged and previously-encoded chunks still decode.

### B4 — `Shared/DocumentManager.swift` (rewrite)

`processRAGpackImport` rewritten end-to-end, now `async throws`:

| before (v0.x) | after (v1.2) |
|---|---|
| `chunks.json` as `[String]` + `embeddings.csv` (inlined CSV parse) + `metadata.json` | unzip → `RAGpackReader.readPack(at:embedder:)` |
| missing files → `print` + silent `return` | every error throws `RAGpackImportError`, propagated |
| no fallback path, no v0.x CSV | n/a — v0.x path fully removed |

`importDocument` wraps the call in `do/catch` and routes failures to a new
`@Published var lastImportError: RAGpackImportError?` (cleared on success; a zip
that won't open maps to `.manifestMissing`). The PR-A NOTE block is removed.

### B5 — UI alert wiring (iOS + macOS, both confirmed)

`Apps/iOS/.../SettingsView.swift` and `Apps/macOS/.../DesktopSettingsView.swift`
both observe `documentManager.lastImportError` after their `.fileImporter` and
present a SwiftUI `.alert` (non-deprecated `isPresented`/`presenting` form) showing
`error.errorDescription`, with a single **OK** action that clears the error. No new
property wiring needed — both already hold `documentManager`.

### B6 — dead function removal

`inferWithLlama(…, fileName: "llama3-8b.gguf", …)` removed (zero callers, verified
in PR #96 report). Incidental — DocumentManager was already being rewritten.

### B7 — .gitignore

No change (`*.gguf` already present from PR-A). No new ignore rule needed.

### Grep self-checks (all ZERO in non-test Swift)

```
$ grep -rn "embeddings.csv"  --include="*.swift" .   → (none)
$ grep -rn "loadEmbeddingsCSV" --include="*.swift" . → (none)
$ grep -rn 'fileName:\s*"llama3-8b.gguf"' --include="*.swift" . → (none)
$ grep -rn "metadata.json"   --include="*.swift" .   → (none)
```

`manifest.json` appears **only** in the two new v1.2 files
(`RAGpackReader.swift`, `RAGpackManifest.swift`) — the expected v1.2 filename, and
the only `*.json` filename reference of its kind.

### Build matrix (all 4 green; iOS built serially)

| target | result |
|---|---|
| macOS Debug | ✅ BUILD SUCCEEDED |
| macOS Release | ✅ BUILD SUCCEEDED |
| iOS Simulator arm64 Debug | ✅ BUILD SUCCEEDED |
| iOS Simulator arm64 Release (`ARCHS=arm64 ONLY_ACTIVE_ARCH=NO`) | ✅ BUILD SUCCEEDED |

**No new warnings.** The two warnings present are pre-existing and unrelated to this
PR: ZIPFoundation library-evolution (the `import ZIPFoundation` at
`DocumentManager.swift:12` predates this PR) and a "duplicate build file
NoesisNoemaMobileApp.swift" project-config warning in the Mobile target.

### Scope / anti-goals honored

- New files auto-compile via the project's Xcode 16 synchronized folder groups —
  **`project.pbxproj` not touched** (a pre-existing unrelated working-tree change to
  it was deliberately left unstaged and is **not** part of this PR).
- `EmbeddingModel`, `VectorStore`, `BanditRetriever`, `Shared/Llama/*` untouched.
  The reader returns `(chunks, embeddings)`; DocumentManager uses the existing
  `VectorStore.shared.chunks` append path — no VectorStore change required.
- No v1.1 parallel support; no v0.x CSV fallback; no new dependencies.

### Orthogonal findings (noted, not fixed)

- `DocumentManager.embedder` reuses `VectorStore.shared.embeddingModel`. In a build
  where the embedder GGUF is absent (git-ignored), `dimension == 0` /
  `modelFingerprint == ""`, so **all** imports fail with a dimension/fingerprint
  mismatch. This is the intended §4 "visibly broken, not silently wrong" behavior,
  but worth noting for local dev without the GGUF bundled.
- The "duplicate build file `NoesisNoemaMobileApp.swift`" warning is a standing
  project-config issue, outside this PR's scope.

**Do not merge** — Taka merges after Spinoza Ethica re-UAT (needs the pipeline-side
v1.2 PR + a regenerated v1.2 pack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
