### PR TITLE
fix(rag): tolerant decode for informational manifest blocks (indexer/chunker)

### DIFF
--- a/Shared/RAG/RAGpackManifest.swift
+++ b/Shared/RAG/RAGpackManifest.swift
@@ -16,7 +16,7 @@ struct RAGpackManifest: Codable {
     let createdAt: String
     let chunker: ChunkerInfo
     let embedder: EmbedderInfo
-    let indexer: IndexerInfo
+    let indexer: IndexerInfo?      // informational — tolerate absence (ADR-0011 strict-only-on-identity)
     let files: FilesInfo
     let stats: StatsInfo?
 
@@ -31,10 +31,12 @@ struct RAGpackManifest: Codable {
         case stats
     }
 
+    /// Informational chunker metadata. ALL fields optional: a chunker block must
+    /// never be the reason a pack is rejected (ADR-0011 — strict only on identity).
     struct ChunkerInfo: Codable {
-        let method: String
-        let chunkSize: Int
-        let overlap: Int
+        let method: String?
+        let chunkSize: Int?
+        let overlap: Int?
         let tokenizerName: String?
         let preserveSentences: Bool?
         let configHash: String?
@@ -69,9 +71,24 @@ struct RAGpackManifest: Codable {
         }
     }
 
+    /// Informational indexer metadata. ALL fields optional, covering BOTH known
+    /// shapes: the original PR-B prompt's `{method, dimension}` (forward-compat) and
+    /// the de-facto pipeline shape `{document_count, chunk_count, timestamp}`. An
+    /// informational block must never fail decode (ADR-0011 — strict only on identity).
     struct IndexerInfo: Codable {
-        let method: String
-        let dimension: Int
+        let method: String?
+        let dimension: Int?
+        let documentCount: Int?
+        let chunkCount: Int?
+        let timestamp: String?
+
+        enum CodingKeys: String, CodingKey {
+            case method
+            case dimension
+            case documentCount = "document_count"
+            case chunkCount = "chunk_count"
+            case timestamp
+        }
     }
 
     struct FilesInfo: Codable {
@@ -120,3 +137,45 @@ extension RAGpackManifest {
         }
     }
 }
+
+#if DEBUG
+extension RAGpackManifest {
+    /// The REAL manifest.json from the first failing v1.2 pack (Spinoza Ethica,
+    /// 406 chunks) — its `indexer` block uses the de-facto pipeline shape
+    /// (`document_count`/`chunk_count`/`timestamp`), NOT the original PR-B
+    /// `{method, dimension}` shape. Kept verbatim as a regression fixture.
+    static let spinozaFixtureJSON = """
+    {
+      "pack_version": "1.2",
+      "pack_id": "pack-9edb42ffa01d5da2c388d03f42562c70",
+      "created_at": "2026-06-11T06:18:52Z",
+      "chunker": { "method": "token_based", "chunk_size": 512, "overlap": 50, "tokenizer_name": "gpt2", "preserve_sentences": false, "config_hash": "a02e1eef8320ac74aae10efdfaaa0d703e2af4fccea685f355ea85f7918542ba" },
+      "embedder": { "embedding_model": "nomic-embed-text-v1.5.Q5_K_M.gguf", "embedding_version": "0.3.28", "embedding_dimension": 768, "model_hash": "0c7930f6c4f6f29b7da5046e3a2c0832aa3f602db3de5760a95f0582dbd3d6e6", "dtype": "float32", "pooling": "mean", "l2_normalized": true, "name": "nomic-embed-text-v1.5.Q5_K_M.gguf", "version": "0.3.28", "dimensions": 768, "runtime": "llama.cpp" },
+      "indexer": { "document_count": 1, "chunk_count": 406, "timestamp": "2026-06-11T06:18:52Z" },
+      "files": { "chunks": "chunks.json", "embeddings": "embeddings.npy", "citations": "citations.jsonl", "metadata": { "embeddings_csv": "embeddings.csv", "manifest": "manifest.json" } },
+      "source_documents": [ { "doc_id": "2015.263056.Ethics_text.txt", "title": "2015.263056.Ethics_text", "path": "/content/input/2015.263056.Ethics_text.txt", "source_hash": "c66d146a7faaa5bdf203aa5a6a2f38494bd4ca58063071cfc5e38847b34a9ed2", "char_count": 566764 } ]
+    }
+    """
+
+    /// Manual decode smoke for the Spinoza fixture: asserts the manifest decodes
+    /// (no throw) and that the strictly-required identity fields survived. Callable
+    /// from a debugger or a scratch call site while the XCTest target is unwired.
+    /// Returns the decoded manifest so a caller holding the live embedder can also
+    /// run `validate(againstCurrentEmbedder:)` to exercise the §3 fingerprint check.
+    @discardableResult
+    static func runDecodeSmoke() -> RAGpackManifest {
+        let m = try! JSONDecoder().decode(RAGpackManifest.self,
+                                          from: Data(spinozaFixtureJSON.utf8))
+        assert(m.packVersion == "1.2", "pack_version must decode strictly")
+        assert(m.embedder.modelHash == "0c7930f6c4f6f29b7da5046e3a2c0832aa3f602db3de5760a95f0582dbd3d6e6")
+        assert(m.embedder.embeddingDimension == 768 && m.embedder.dtype == "float32")
+        assert(m.files.chunks == "chunks.json" && m.files.embeddings == "embeddings.npy")
+        // Informational pipeline-shape indexer block decodes tolerantly.
+        assert(m.indexer?.chunkCount == 406 && m.indexer?.documentCount == 1)
+        assert(m.indexer?.method == nil && m.indexer?.dimension == nil)
+        print("[RAGpackManifest] decode smoke PASSED — Spinoza v1.2 manifest decoded; "
+              + "indexer.chunk_count=\(m.indexer?.chunkCount ?? -1)")
+        return m
+    }
+}
+#endif

--- a/Tests/RAG/RAGpackManifestDecodeTests.swift
+++ b/Tests/RAG/RAGpackManifestDecodeTests.swift
@@ -1,0 +1,101 @@
+// Project: NoesisNoema
+// File: RAGpackManifestDecodeTests.swift
+// Description: Regression test for the v1.2 manifest contract fix — the app's
+//   IndexerInfo originally required `{method, dimension}` (PR-B prompt shape), but
+//   real pipeline packs ship `{document_count, chunk_count, timestamp}`. The first
+//   real v1.2 import (Spinoza Ethica, 406 chunks) failed at decode with:
+//     DecodingError.keyNotFound: Key 'method' not found ... Path: indexer.
+//   ADR-0011 policy: strict only on identity/correctness (pack_version + embedder
+//   block + files.chunks/embeddings); informational blocks decode tolerantly.
+//
+//   NOTE: the NoesisNoemaTests Xcode target is currently unwired (see PR-A note), so
+//   this XCTest is committed for when the target is wired but is NOT exercised by
+//   `xcodebuild test` today. A runnable `#if DEBUG` smoke
+//   (`RAGpackManifest.runDecodeSmoke()`) lives in RAGpackManifest.swift for now.
+// License: MIT License
+
+import XCTest
+@testable import NoesisNoema
+
+final class RAGpackManifestDecodeTests: XCTestCase {
+
+    /// The REAL manifest.json from the failing Spinoza pack — verbatim.
+    private let spinozaManifestJSON = """
+    {
+      "pack_version": "1.2",
+      "pack_id": "pack-9edb42ffa01d5da2c388d03f42562c70",
+      "created_at": "2026-06-11T06:18:52Z",
+      "chunker": { "method": "token_based", "chunk_size": 512, "overlap": 50, "tokenizer_name": "gpt2", "preserve_sentences": false, "config_hash": "a02e1eef8320ac74aae10efdfaaa0d703e2af4fccea685f355ea85f7918542ba" },
+      "embedder": { "embedding_model": "nomic-embed-text-v1.5.Q5_K_M.gguf", "embedding_version": "0.3.28", "embedding_dimension": 768, "model_hash": "0c7930f6c4f6f29b7da5046e3a2c0832aa3f602db3de5760a95f0582dbd3d6e6", "dtype": "float32", "pooling": "mean", "l2_normalized": true, "name": "nomic-embed-text-v1.5.Q5_K_M.gguf", "version": "0.3.28", "dimensions": 768, "runtime": "llama.cpp" },
+      "indexer": { "document_count": 1, "chunk_count": 406, "timestamp": "2026-06-11T06:18:52Z" },
+      "files": { "chunks": "chunks.json", "embeddings": "embeddings.npy", "citations": "citations.jsonl", "metadata": { "embeddings_csv": "embeddings.csv", "manifest": "manifest.json" } },
+      "source_documents": [ { "doc_id": "2015.263056.Ethics_text.txt", "title": "2015.263056.Ethics_text", "path": "/content/input/2015.263056.Ethics_text.txt", "source_hash": "c66d146a7faaa5bdf203aa5a6a2f38494bd4ca58063071cfc5e38847b34a9ed2", "char_count": 566764 } ]
+    }
+    """
+
+    private func decode(_ json: String) throws -> RAGpackManifest {
+        try JSONDecoder().decode(RAGpackManifest.self, from: Data(json.utf8))
+    }
+
+    /// The pipeline-shape `indexer` block must decode without throwing, and the
+    /// strictly-required identity fields must survive intact.
+    func testDecodesRealSpinozaManifest() throws {
+        let m = try decode(spinozaManifestJSON)
+
+        // Strict identity fields — unchanged by this fix.
+        XCTAssertEqual(m.packVersion, "1.2")
+        XCTAssertEqual(m.embedder.modelHash,
+                       "0c7930f6c4f6f29b7da5046e3a2c0832aa3f602db3de5760a95f0582dbd3d6e6")
+        XCTAssertEqual(m.embedder.embeddingDimension, 768)
+        XCTAssertEqual(m.embedder.dtype, "float32")
+        XCTAssertEqual(m.embedder.pooling, "mean")
+        XCTAssertTrue(m.embedder.l2Normalized)
+        XCTAssertEqual(m.files.chunks, "chunks.json")
+        XCTAssertEqual(m.files.embeddings, "embeddings.npy")
+
+        // Informational pipeline-shape indexer block decodes tolerantly.
+        XCTAssertEqual(m.indexer?.documentCount, 1)
+        XCTAssertEqual(m.indexer?.chunkCount, 406)
+        XCTAssertEqual(m.indexer?.timestamp, "2026-06-11T06:18:52Z")
+        XCTAssertNil(m.indexer?.method)      // PR-B-shape fields simply absent
+        XCTAssertNil(m.indexer?.dimension)
+
+        // Informational chunker block also tolerated.
+        XCTAssertEqual(m.chunker.method, "token_based")
+        XCTAssertEqual(m.chunker.chunkSize, 512)
+    }
+
+    /// The original PR-B `{method, dimension}` indexer shape must STILL decode
+    /// (forward-compat) — both shapes are accepted.
+    func testDecodesOriginalPRBIndexerShape() throws {
+        let json = spinozaManifestJSON.replacingOccurrences(
+            of: "\"indexer\": { \"document_count\": 1, \"chunk_count\": 406, \"timestamp\": \"2026-06-11T06:18:52Z\" },",
+            with: "\"indexer\": { \"method\": \"flat\", \"dimension\": 768 },")
+        let m = try decode(json)
+        XCTAssertEqual(m.indexer?.method, "flat")
+        XCTAssertEqual(m.indexer?.dimension, 768)
+        XCTAssertNil(m.indexer?.chunkCount)
+    }
+
+    /// An omitted `indexer` block (future producer) must not fail decode.
+    func testDecodesWithIndexerOmitted() throws {
+        let json = spinozaManifestJSON.replacingOccurrences(
+            of: "\"indexer\": { \"document_count\": 1, \"chunk_count\": 406, \"timestamp\": \"2026-06-11T06:18:52Z\" },",
+            with: "")
+        let m = try decode(json)
+        XCTAssertNil(m.indexer)
+    }
+
+    /// Full validate path incl. the §3 fingerprint check — requires the live
+    /// embedder (git-ignored GGUF must be bundled). Skipped when unavailable so
+    /// the suite stays green on CI without the model.
+    func testValidatesAgainstCurrentEmbedderWhenAvailable() throws {
+        guard let embedder = try? EmbeddingModel.defaultInstance() else {
+            throw XCTSkip("Embedder GGUF unavailable; skipping fingerprint validation.")
+        }
+        let m = try decode(spinozaManifestJSON)
+        // Asserts the fixture's model_hash matches the current embedder fingerprint.
+        XCTAssertNoThrow(try m.validate(againstCurrentEmbedder: embedder),
+                         "Spinoza pack fingerprint must match the current embedder.")
+    }
+}


### PR DESCRIPTION
## Bug (UAT blocker)

The first real v1.2 pack import (Spinoza Ethica, 406 chunks) failed at decode:

> **RAGpack Import Failed**
> The RAGpack manifest.json could not be read: DecodingError.keyNotFound:
> Key 'method' not found in keyed decoding container. Path: indexer.

The pipeline's real v1.2 `indexer` block is `{ "document_count": 1, "chunk_count": 406, "timestamp": "…" }`, but the app's `RAGpackManifest.IndexerInfo` (PR #98) required `method` (and `dimension`).

**Root cause — contract inconsistency between two implementation prompts:** the app-side PR-B prompt specified `indexer: {method, dimension}`; the pipeline prompt said "lift the v1.1 schema" whose indexer shape is `document_count`/`chunk_count`/`timestamp`. Both CLIs followed their prompts faithfully — the prompts disagreed. The pipeline's shape is the de-facto v1.2 (it's what real packs ship); **the app adapts.**

## Fix policy (ADR-0011 strict-vs-tolerant)

Stay strict ONLY where identity/correctness lives. **Unchanged & still strictly validated:** `pack_version` and the entire `embedder` block (`embedding_model`, `embedding_dimension`, `model_hash`, `dtype`, `pooling`, `l2_normalized`) plus `files.chunks` + `files.embeddings`. Everything *informational* now decodes tolerantly. **`validate(againstCurrentEmbedder:)` semantics are untouched** — the §3 fingerprint (`model_hash`) check remains the central gate.

### Per-field optional/required summary

**`IndexerInfo`** (property `indexer` now `IndexerInfo?` — informational, tolerate absence):

| field | JSON key | before | after |
|---|---|---|---|
| `method` | `method` | required | optional (forward-compat with PR-B shape) |
| `dimension` | `dimension` | required | optional (forward-compat with PR-B shape) |
| `documentCount` | `document_count` | — | **added**, optional |
| `chunkCount` | `chunk_count` | — | **added**, optional |
| `timestamp` | `timestamp` | — | **added**, optional |

**`ChunkerInfo`** (property `chunker` stays required; no required fields *inside*):

| field | JSON key | before | after |
|---|---|---|---|
| `method` | `method` | required | optional |
| `chunkSize` | `chunk_size` | required | optional |
| `overlap` | `overlap` | required | optional |
| `tokenizerName` | `tokenizer_name` | optional | optional |
| `preserveSentences` | `preserve_sentences` | optional | optional |
| `configHash` | `config_hash` | optional | optional |

`stats` was already optional (left as-is). `files.citations` stays optional. `files.metadata` (v1.1-residue nested dict) and top-level `source_documents` are ignored by Codable automatically — no action.

## Fixture (real Spinoza manifest, embedded verbatim)

```json
{
  "pack_version": "1.2",
  "pack_id": "pack-9edb42ffa01d5da2c388d03f42562c70",
  "created_at": "2026-06-11T06:18:52Z",
  "chunker": { "method": "token_based", "chunk_size": 512, "overlap": 50, "tokenizer_name": "gpt2", "preserve_sentences": false, "config_hash": "a02e1eef8320ac74aae10efdfaaa0d703e2af4fccea685f355ea85f7918542ba" },
  "embedder": { "embedding_model": "nomic-embed-text-v1.5.Q5_K_M.gguf", "embedding_version": "0.3.28", "embedding_dimension": 768, "model_hash": "0c7930f6c4f6f29b7da5046e3a2c0832aa3f602db3de5760a95f0582dbd3d6e6", "dtype": "float32", "pooling": "mean", "l2_normalized": true, "name": "nomic-embed-text-v1.5.Q5_K_M.gguf", "version": "0.3.28", "dimensions": 768, "runtime": "llama.cpp" },
  "indexer": { "document_count": 1, "chunk_count": 406, "timestamp": "2026-06-11T06:18:52Z" },
  "files": { "chunks": "chunks.json", "embeddings": "embeddings.npy", "citations": "citations.jsonl", "metadata": { "embeddings_csv": "embeddings.csv", "manifest": "manifest.json" } },
  "source_documents": [ { "doc_id": "2015.263056.Ethics_text.txt", "title": "2015.263056.Ethics_text", "path": "/content/input/2015.263056.Ethics_text.txt", "source_hash": "c66d146a7faaa5bdf203aa5a6a2f38494bd4ca58063071cfc5e38847b34a9ed2", "char_count": 566764 } ]
}
```

## Test

- **`#if DEBUG` smoke** `RAGpackManifest.runDecodeSmoke()` (in `RAGpackManifest.swift`) — decodes the fixture verbatim, asserts no-throw + that the strict identity fields survived; callable manually while the test target is unwired.
- **XCTest** `Tests/RAG/RAGpackManifestDecodeTests.swift` — decodes the real manifest, both indexer shapes, indexer-omitted, and a `validate(againstCurrentEmbedder:)` path that asserts `model_hash` matches the live embedder (skips when the git-ignored GGUF is absent). Committed for when the `NoesisNoemaTests` target gets wired (it is **not** exercised by `xcodebuild test` today — per PR-A's note the target is unwired; per task scope I did NOT wire it).

The decode + validate path was verified now by compiling the **real** `RAGpackManifest.swift` (struct + `validate` extension) against minimal `EmbeddingModel`/`RAGpackImportError` stubs:

```
[RAGpackManifest] decode smoke PASSED — Spinoza v1.2 manifest decoded; indexer.chunk_count=406
VALIDATE OK via fixture string literal (model_hash matches current embedder)
```

Also verified: original PR-B `{method, dimension}` indexer shape still decodes, and a fully-omitted `indexer` decodes to `nil`.

## Build matrix (all green)

| Build | Result |
|---|---|
| macOS Debug | ✅ BUILD SUCCEEDED |
| macOS Release | ✅ BUILD SUCCEEDED |
| iOS Simulator arm64 Debug (`ARCHS=arm64 ONLY_ACTIVE_ARCH=NO`) | ✅ BUILD SUCCEEDED |
| iOS Simulator arm64 Release (`ARCHS=arm64 ONLY_ACTIVE_ARCH=NO`) | ✅ BUILD SUCCEEDED |

iOS builds run serially (DerivedData lock).

## Scope

- Touched ONLY `Shared/RAG/RAGpackManifest.swift` + new `Tests/RAG/RAGpackManifestDecodeTests.swift`.
- `RAGpackReader.swift`'s call to `validate(...)` keeps working unchanged. No embedder/UI/`project.pbxproj` changes. The pre-existing unstaged `project.pbxproj` modification (present at session start) was deliberately left out of this commit.

## Orthogonal findings (reported, NOT fixed)

The pipeline manifest carries **v1.1 residue**: `files.metadata.embeddings_csv` and duplicated embedder fields (`name`/`version`/`dimensions` alongside canonical `embedding_model`/`embedding_version`/`embedding_dimension`). Harmless to the app (Codable ignores unknown keys); flag for a later **pipeline cleanup PR**.

Also noted (pre-existing, unrelated): the iOS target build emits `warning: Skipping duplicate build file ... NoesisNoemaMobileApp.swift` — a duplicate entry in the Compile Sources phase. Not touched here.

## Do NOT merge
Taka merges, then re-imports the **existing** Spinoza zip (no re-embedding needed) and continues UAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
