### PR TITLE
fix(registry): exclude embedder GGUF from LLM selection (UAT blocker)

### DIFF
--- a/Apps/macOS/NoesisNoema/ModelRegistry/Core/ModelRegistry.swift
+++ b/Apps/macOS/NoesisNoema/ModelRegistry/Core/ModelRegistry.swift
@@ -57,6 +57,31 @@ actor ModelRegistry {
         modelSpecs[spec.id] = spec
     }
 
+    /// Decide whether a GGUF file is an embedding-only model that must never be
+    /// offered as a chat LLM. Embedders (nomic-bert, BGE, E5, Jina, …) have no
+    /// generation head; asked to generate they emit reserved-vocab `[unusedN]`
+    /// tokens. Pure + deterministic so it is trivially unit-testable.
+    ///
+    /// Detection (any single signal is sufficient):
+    ///   1. File-name marker — base name contains `embed`, `-bert`, or `jina-`.
+    ///   2. GGUF `architecture` metadata contains `bert` (nomic-bert, jina-bert,
+    ///      mpnet-bert, plain bert, …).
+    ///
+    /// NOTE: `GGUFMetadata` does not currently surface a pooling-type field; a
+    /// non-nil pooling marker would be an orthogonal third signal, but adding it
+    /// to `GGUFReader` is out of scope here — the two signals above cover every
+    /// embedder Nomic / Jina / BGE / E5 ships today.
+    static func looksLikeEmbedder(fileName: String, metadata: GGUFMetadata) -> Bool {
+        let lower = fileName.lowercased()
+        if lower.contains("embed") || lower.contains("-bert") || lower.contains("jina-") {
+            return true
+        }
+        if metadata.architecture.lowercased().contains("bert") {
+            return true
+        }
+        return false
+    }
+
     /// Update runtime params for a given model id (if exists)
     func updateRuntimeParams(for id: String, params: RuntimeParams) {
         guard var spec = modelSpecs[id] else { return }
@@ -103,7 +128,34 @@ actor ModelRegistry {
                 scanningPaths.remove(path)
             }
         }
+
+        #if DEBUG
+        assertNoEmbeddersRegistered()
+        #endif
     }
+
+    #if DEBUG
+    /// Startup smoke (matches the PR #99 / #100 manual-smoke pattern): after a full
+    /// scan, no registered spec's `modelFile` may look like an embedder. If one
+    /// slips through (a future embedder that dodges the file-name / architecture
+    /// heuristics), this logs loudly in DEBUG so it is caught before UAT — the LLM
+    /// picker driving an embedder is exactly the [unusedN]-garbage bug this guards.
+    private func assertNoEmbeddersRegistered() {
+        let offenders = getAvailableModelSpecs().filter {
+            $0.modelFile.lowercased().contains("embed")
+                || $0.modelFile.lowercased().contains("-bert")
+                || $0.metadata.architecture.lowercased().contains("bert")
+        }
+        if offenders.isEmpty {
+            print("[ModelRegistry] embedder-exclusion smoke PASSED — "
+                  + "\(getAvailableModelSpecs().count) available model(s), none look like embedders.")
+        } else {
+            let names = offenders.map { $0.modelFile }.joined(separator: ", ")
+            print("[ModelRegistry] embedder-exclusion smoke FAILED — embedder(s) registered as LLM: \(names)")
+            assertionFailure("Embedder GGUF leaked into availableModels: \(names)")
+        }
+    }
+    #endif
 
     /// Scan for GGUF files in a specific directory
     func scanDirectory(_ directoryPath: String) async {
@@ -135,6 +187,15 @@ actor ModelRegistry {
             let metadata = try await GGUFReader.readMetadata(from: filePath)
             let fileName = URL(fileURLWithPath: filePath).lastPathComponent
             let baseName = URL(fileURLWithPath: filePath).deletingPathExtension().lastPathComponent
+
+            // Embedding-only GGUFs (e.g. nomic-embed-text) live in the same
+            // Resources/Models dir as the generator since ADR-0011 PR-A. They must
+            // never be registered as selectable LLMs — drop them before they reach
+            // `modelSpecs` / `availableModels` / the model picker.
+            if Self.looksLikeEmbedder(fileName: fileName, metadata: metadata) {
+                print("[ModelRegistry] Skipping embedder GGUF (not a generator): \(fileName)")
+                return
+            }
 
             // Generate ID from filename
             let id = generateModelId(from: baseName)

--- a/Apps/macOS/NoesisNoema/ModelRegistry/Tests/EmbedderExclusionTests.swift
+++ b/Apps/macOS/NoesisNoema/ModelRegistry/Tests/EmbedderExclusionTests.swift
@@ -1,0 +1,74 @@
+#if !BRIDGE_TEST
+// Project: NoesisNoema
+// File: EmbedderExclusionTests.swift
+// Description: Unit smoke for ModelRegistry.looksLikeEmbedder — the registry-scan
+//   guard that keeps embedding-only GGUFs (nomic-embed-text, BGE, E5, Jina, …) out
+//   of the LLM picker. Regression cover for the UAT blocker where the Spinoza chat
+//   returned identical [unusedN] reserved-vocab garbage to every question because
+//   the embedder was selected as the chat LLM.
+// License: MIT License
+//
+// The NoesisNoemaTests Xcode target is unwired (see auto-memory), so — like
+// TestRunner.swift — this is a self-contained, dependency-free checker runnable
+// from a scratch call site or the debugger. `runAllTests()` returns true iff every
+// case passes; it does not depend on XCTest.
+
+import Foundation
+
+/// Pure unit cover for `ModelRegistry.looksLikeEmbedder`.
+enum EmbedderExclusionTests {
+
+    /// One table row: (fileName, architecture) → expected `looksLikeEmbedder`.
+    private struct Case {
+        let fileName: String
+        let architecture: String
+        let expected: Bool
+    }
+
+    private static let cases: [Case] = [
+        // Embedders — must be TRUE.
+        Case(fileName: "nomic-embed-text-v1.5.Q5_K_M.gguf", architecture: "nomic-bert", expected: true),
+        Case(fileName: "bge-large-en-v1.5.gguf",            architecture: "bert",       expected: true),
+        Case(fileName: "jina-embeddings-v2.gguf",           architecture: "jina-bert",  expected: true),
+        // Architecture-only signal (file name gives nothing away).
+        Case(fileName: "mystery-model-q4.gguf",             architecture: "mpnet-bert", expected: true),
+        // File-name-only signal (architecture lies / is unknown).
+        Case(fileName: "e5-large-v2.embed.gguf",            architecture: "unknown",    expected: true),
+
+        // Generators — must be FALSE.
+        Case(fileName: "Llama-3.2-3B-Instruct-Q4_K_M.gguf", architecture: "llama",      expected: false),
+        Case(fileName: "Jan-v1-4B-Q4_K_M.gguf",             architecture: "qwen2",      expected: false),
+        Case(fileName: "gpt-oss-20b-F16.gguf",              architecture: "gptoss",     expected: false),
+        // Edge: empty inputs default to generator (do not over-block).
+        Case(fileName: "",                                  architecture: "",           expected: false),
+        // Edge: "bert" only as a substring of the architecture is the intended trigger,
+        // but a generator whose name merely contains "ember" must NOT match "embed".
+        Case(fileName: "ember-7b.gguf",                     architecture: "llama",      expected: false),
+    ]
+
+    /// Run every case, print a result table, return true iff all pass.
+    @discardableResult
+    static func runAllTests() -> Bool {
+        print("🧪 ModelRegistry.looksLikeEmbedder")
+        print(String(repeating: "=", count: 64))
+        print("result  actual  expected  [fileName | architecture]")
+
+        var allPassed = true
+        for c in cases {
+            let metadata = GGUFMetadata(architecture: c.architecture)
+            let actual = ModelRegistry.looksLikeEmbedder(fileName: c.fileName, metadata: metadata)
+            let pass = actual == c.expected
+            allPassed = allPassed && pass
+            let mark = pass ? "✅" : "❌"
+            let shown = c.fileName.isEmpty ? "(empty)" : c.fileName
+            print("\(mark) \(actual)  exp=\(c.expected)  [\(shown) | \(c.architecture)]")
+        }
+
+        print(String(repeating: "-", count: 64))
+        print(allPassed
+              ? "✅ looksLikeEmbedder: all \(cases.count) cases passed"
+              : "❌ looksLikeEmbedder: FAILURES present")
+        return allPassed
+    }
+}
+#endif

--- a/Shared/ModelManager.swift
+++ b/Shared/ModelManager.swift
@@ -59,6 +59,15 @@ class ModelManager: ObservableObject {
         // Try to restore last selection from UserDefaults
         // SAFE: Small string ID (< 100 bytes)
         if let lastModelIDString = UserDefaults.standard.string(forKey: "lastSelectedModelID"),
+           !availableModels.contains(where: { $0.id == lastModelIDString }) {
+            // Saved ID is stale — e.g. the embedder GGUF that Layer 1 now excludes
+            // from availableModels. Clear it so the warning does not re-fire on every
+            // launch, then fall through to the configured-default path below.
+            UserDefaults.standard.removeObject(forKey: "lastSelectedModelID")
+            SystemLog().logEvent(event: "[ModelManager] Cleared stale lastSelectedModelID: \(lastModelIDString)")
+        }
+
+        if let lastModelIDString = UserDefaults.standard.string(forKey: "lastSelectedModelID"),
            availableModels.contains(where: { $0.id == lastModelIDString }) {
             selectedModelID = ModelID(lastModelIDString)
             currentModelID = lastModelIDString
@@ -366,6 +375,14 @@ class ModelManager: ObservableObject {
         print("🧠 [ModelManager] Prompt: \(question.prefix(80))...")
         print("🧠 [ModelManager] Context: \(context.isEmpty ? "none" : "\(context.count) chars")")
         #endif
+
+        // Belt-and-braces (Layer 3): even after the registry-scan exclusion (Layer 1)
+        // and the stale-UserDefaults cleanup (Layer 2), warn if the model we are about
+        // to drive looks like an embedder — catches future surprise paths (e.g. a direct
+        // switchLLMModel("nomic-embed-text-…") call) without altering control flow.
+        if currentModel.modelFile.lowercased().contains("embed") {
+            _log.logEvent(event: "[ModelManager] WARN: currentLLMModel.modelFile looks like an embedder: \(currentModel.modelFile)")
+        }
 
         let answer: String
         do {


### PR DESCRIPTION
## Symptom (UAT blocker)

After PR #99 + #100 unblocked RAGpack import, **Spinoza chat returned the same `[unusedN]` reserved-vocab token sequence to all 5 questions** — different prompts, byte-identical garbage. Settings revealed `Current Model: Nomic Embed Text V1.5.Q5 K M`: the embedder was being driven as the chat LLM. `nomic-embed-text-v1.5` is embedding-only — it has no generation head, so asked to *generate* it emits the BERT-family `[unused1]…[unused99]` tokens.

## Root cause (2 lines)

`ModelRegistry.scanDirectory` registers **any** `.gguf` indiscriminately:

```swift
let ggufFiles = contents.filter { $0.lowercased().hasSuffix(".gguf") }   // ModelRegistry.swift:116
for fileName in ggufFiles { await registerGGUFFile(at: fullPath) }       // ModelRegistry.swift:118-121
```

Fine when only the generator lived in `Resources/Models/`, but ADR-0011 PR-A (#97) placed `nomic-embed-text-v1.5.Q5_K_M.gguf` in the same dir. The scan picked it up → `availableModels` exposed it → the picker (or a stale `lastSelectedModelID`) drove every chat through it. Same prompt-contract-gap shape as #99/#100: the registry-cleanup scrubbed `predefinedSpecs` but never added a scan-time embedder exclusion.

## Fix — defense in depth (three layers)

- **Layer 1 — `ModelRegistry`**: new pure `static looksLikeEmbedder(fileName:metadata:)` + an early `return` in `registerGGUFFile` right after `readMetadata`. Embedders never reach `modelSpecs` / `availableModels` / the picker. Detection (any one): file base name contains `embed` / `-bert` / `jina-`, **or** GGUF `architecture` contains `bert`. A `#if DEBUG` startup smoke in `scanForModels()` asserts `availableModels` contains no embedder after the scan.
- **Layer 2 — `ModelManager.setDefaultModel`**: when the saved `lastSelectedModelID` is no longer in `availableModels` (e.g. the now-excluded embedder), **remove the UserDefaults entry** and log, then fall through to the configured default — so the warning does not re-fire every launch.
- **Layer 3 — `ModelManager.generateAsyncAnswer`**: belt-and-braces log-only warning before `generateAsync` if `currentLLMModel.modelFile` looks like an embedder. No control-flow change — catches future surprise paths (e.g. a direct `switchLLMModel("nomic-embed-text-…")`).

## `looksLikeEmbedder` — test cases + results (10/10 pass)

| fileName | architecture | expected | actual |
|---|---|---|---|
| `nomic-embed-text-v1.5.Q5_K_M.gguf` | `nomic-bert` | true | ✅ true |
| `bge-large-en-v1.5.gguf` | `bert` | true | ✅ true |
| `jina-embeddings-v2.gguf` | `jina-bert` | true | ✅ true |
| `mystery-model-q4.gguf` | `mpnet-bert` | true | ✅ true (arch-only signal) |
| `e5-large-v2.embed.gguf` | `unknown` | true | ✅ true (name-only signal) |
| `Llama-3.2-3B-Instruct-Q4_K_M.gguf` | `llama` | false | ✅ false |
| `Jan-v1-4B-Q4_K_M.gguf` | `qwen2` | false | ✅ false |
| `gpt-oss-20b-F16.gguf` | `gptoss` | false | ✅ false |
| `` (empty) | `` (empty) | false | ✅ false |
| `ember-7b.gguf` | `llama` | false | ✅ false (no false-positive on `ember`) |

Cover lives in `Apps/macOS/NoesisNoema/ModelRegistry/Tests/EmbedderExclusionTests.swift`, guarded with `#if !BRIDGE_TEST` (matching `TestRunner.swift`) so it stays out of the `LlamaBridgeTest` target. The `NoesisNoemaTests` Xcode target is unwired, so it is a self-contained checker like `TestRunner`.

## Startup smoke output (live, Debug macOS app)

Captured from the running Debug build with both GGUFs present in `Resources/Models/`:

```
[ModelRegistry] Registered model: llama_3_2_3b_instruct_q4_k_m at …/llama-3.2-3b-instruct-q4_k_m.gguf
[ModelRegistry] Skipping embedder GGUF (not a generator): nomic-embed-text-v1.5.Q5_K_M.gguf
[ModelRegistry] embedder-exclusion smoke PASSED — 1 available model(s), none look like embedders.
```

`availableModels` now contains only the Llama generator; the embedder is dropped at scan time.

## Build matrix (all green)

| # | Target | Config | Arch | Result |
|---|---|---|---|---|
| 1 | NoesisNoema (macOS) | Debug | active | ✅ BUILD SUCCEEDED |
| 2 | NoesisNoema (macOS) | Release | `arm64` (`ONLY_ACTIVE_ARCH=NO`) | ✅ BUILD SUCCEEDED |
| 3 | NoesisNoemaMobile (iOS Sim, iPhone 17 Pro) | Debug | `arm64` | ✅ BUILD SUCCEEDED |
| 4 | NoesisNoemaMobile (iOS Sim, iPhone 17 Pro) | Release | `arm64` (`ONLY_ACTIVE_ARCH=NO`) | ✅ BUILD SUCCEEDED |

## Diff (3 files, in-scope only)

- `Apps/macOS/NoesisNoema/ModelRegistry/Core/ModelRegistry.swift` — +61 (helper + early-return + DEBUG smoke)
- `Shared/ModelManager.swift` — +17 (Layer 2 UserDefaults cleanup + Layer 3 dispatch warning)
- `Apps/macOS/NoesisNoema/ModelRegistry/Tests/EmbedderExclusionTests.swift` — new, 74 lines

`NoesisNoema.xcodeproj/project.pbxproj` was already modified before this work (package-resolution noise) and is intentionally **not** part of this PR. The new test file needs no pbxproj edit — the `Apps/macOS/NoesisNoema` folder is an Xcode 16 file-system-synchronized group, so the file is auto-included in the app targets.

## Orthogonal findings (reported, NOT fixed)

1. **`GGUFMetadata` does not surface a pooling-type field.** The Spinoza embedder's GGUF metadata explicitly sets `nomic-bert.pooling_type = 1` (confirmed in the live load dump) — a definitive embedding-model marker that generators never set. Surfacing it in `GGUFReader` would give Layer 1 a third, content-based signal that catches future embedders dodging the file-name / architecture heuristics. Out of scope here.
2. **iOS shares the same `ModelRegistry.swift`** (synchronized group → both app targets). Layer 1 applies identically on iOS; the iOS scan path goes through `registerGGUFFile`, so no platform-specific bypass was found. If the iOS bundle ships the embedder GGUF, it is excluded the same way.

## Do NOT merge

Taka merges, relaunches (UserDefaults cleanup runs once), re-imports the existing Spinoza zip if needed (should already be loaded), and continues UAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)