### PR TITLE
fix(llama): bail on KV-cache overflow + propagate decode failure (UAT blocker)

### DIFF
--- a/Apps/macOS/NoesisNoema/Tests/LibLlamaCompletionBailTests.swift
+++ b/Apps/macOS/NoesisNoema/Tests/LibLlamaCompletionBailTests.swift
@@ -1,0 +1,78 @@
+#if DEBUG
+// Project: NoesisNoema
+// File: LibLlamaCompletionBailTests.swift
+// Description: Unit smoke for the KV-cache-overflow bail-out (hotfix #4, Fix B1).
+//   Regression cover for the UAT blocker where Spinoza chat Q5 hung the runtime:
+//   the rendered ChatML prompt (system + 3 prior Q/A turns + ~2,500-token RAG
+//   context) reached ~12–13k tokens, far past macOS n_ctx=4096. completion_init
+//   only PRINTED the overflow and decoded anyway; llama.cpp then capped its KV
+//   cache at n_ctx-1 (X=4095) while the Swift loop ran n_cur away into the
+//   hundreds of thousands (Y=910640+), emitting "inconsistent sequence positions"
+//   on every one of ~910k iterations and never terminating.
+//
+//   `LlamaContext.kvBudgetExceeds(nPrompt:nLen:nCtx:)` is the pure decision seam
+//   completion_init now consults BEFORE decode (returning false + setting
+//   last_error + is_done on overflow). Exercising it directly needs no model
+//   GGUF — the failure is in the arithmetic, not the C bindings.
+// License: MIT License
+//
+// The NoesisNoemaTests Xcode target is unwired (see auto-memory), so — like
+// EmbedderExclusionTests / TestRunner — this is a self-contained, dependency-free
+// checker runnable from a scratch call site or the debugger. `runAllTests()`
+// returns true iff every case passes; it does not depend on XCTest.
+
+import Foundation
+
+/// Pure unit cover for `LlamaContext.kvBudgetExceeds`.
+enum LibLlamaCompletionBailTests {
+
+    /// One row: (nPrompt, nLen, nCtx) → expected `kvBudgetExceeds`.
+    private struct Case {
+        let nPrompt: Int
+        let nLen: Int
+        let nCtx: Int
+        let expected: Bool
+        let note: String
+    }
+
+    private static let cases: [Case] = [
+        // The UAT Q5 shape: ~13k-token prompt + 512 generate, macOS n_ctx=4096.
+        // MUST overflow (true) so completion_init bails instead of looping.
+        Case(nPrompt: 13_000, nLen: 512, nCtx: 4096, expected: true,  note: "Q5 over-budget multi-turn"),
+        // A healthy Q1-style single-turn prompt comfortably fits.
+        Case(nPrompt: 1_200,  nLen: 512, nCtx: 4096, expected: false, note: "Q1 single-turn fits"),
+        // Exact-fit boundary: prompt + n_len == n_ctx is NOT an overflow.
+        Case(nPrompt: 3_584,  nLen: 512, nCtx: 4096, expected: false, note: "exact fit (== n_ctx)"),
+        // One token over the boundary IS an overflow.
+        Case(nPrompt: 3_585,  nLen: 512, nCtx: 4096, expected: true,  note: "one token over"),
+        // iOS lightweight context (n_ctx=1024) is far easier to overflow.
+        Case(nPrompt: 800,    nLen: 256, nCtx: 1024, expected: true,  note: "iOS n_ctx=1024 overflow"),
+        Case(nPrompt: 700,    nLen: 256, nCtx: 1024, expected: false, note: "iOS n_ctx=1024 fits"),
+        // Degenerate: empty prompt, generate within budget.
+        Case(nPrompt: 0,      nLen: 512, nCtx: 4096, expected: false, note: "empty prompt fits"),
+    ]
+
+    /// Run every case, print a result table, return true iff all pass.
+    @discardableResult
+    static func runAllTests() -> Bool {
+        print("🧪 LlamaContext.kvBudgetExceeds")
+        print(String(repeating: "=", count: 64))
+        print("result  actual  expected  [nPrompt + nLen vs nCtx | note]")
+
+        var allPassed = true
+        for c in cases {
+            let actual = LlamaContext.kvBudgetExceeds(nPrompt: c.nPrompt, nLen: c.nLen, nCtx: c.nCtx)
+            let pass = actual == c.expected
+            allPassed = allPassed && pass
+            let mark = pass ? "✅" : "❌"
+            print("\(mark) \(actual)  exp=\(c.expected)  [\(c.nPrompt) + \(c.nLen) vs \(c.nCtx) | \(c.note)]")
+        }
+
+        print(String(repeating: "-", count: 64))
+        print(allPassed
+              ? "✅ kvBudgetExceeds: all \(cases.count) cases passed"
+              : "❌ kvBudgetExceeds: FAILURES present")
+        return allPassed
+    }
+}
+#endif

--- a/Shared/Llama/LibLlama.swift
+++ b/Shared/Llama/LibLlama.swift
@@ -49,6 +49,11 @@ actor LlamaContext {
     private var tokens_list: [llama_token]
     var is_done: Bool = false
 
+    /// Last fatal reason completion_init/completion_loop bailed out, if any.
+    /// Surfaced to the pipeline via `get_last_error()` so the UI can show a
+    /// human-readable message instead of hanging on an out-of-sync KV cache.
+    var last_error: String? = nil
+
     // verbose logging switch
     private var verbose: Bool = false
     private func dprint(_ items: Any...) {
@@ -196,9 +201,31 @@ actor LlamaContext {
         return batch.n_tokens;
     }
 
-    func completion_init(text: String) {
+    /// Reason the last completion_init/completion_loop bailed out, or nil.
+    func get_last_error() -> String? {
+        return last_error
+    }
+
+    /// Pure KV-budget check, extracted as a static seam so the bail-out branch
+    /// (Fix B1) is unit-testable without loading a model. Returns true when the
+    /// prompt tokens plus the tokens we intend to generate would not fit in the
+    /// context's KV cache (n_ctx). When true, decode would silently stall the KV
+    /// cache at n_ctx-1 while the Swift loop runs away — see hotfix #4.
+    static func kvBudgetExceeds(nPrompt: Int, nLen: Int, nCtx: Int) -> Bool {
+        return nPrompt + nLen > nCtx
+    }
+
+    /// Tokenize `text` and prime the KV cache for generation.
+    ///
+    /// Returns `true` on success, `false` on a fatal bail-out (over-budget
+    /// prompt or decode failure). On bail-out `is_done` is set so the caller's
+    /// `while !ctx.is_done` loop exits immediately, and `last_error` carries the
+    /// reason for `get_last_error()`. See hotfix #4 (Fix B1).
+    @discardableResult
+    func completion_init(text: String) -> Bool {
         dprint("attempting to complete \"\(text)\"")
 
+        last_error = nil
         tokens_list = tokenize(text: text, add_bos: true)
         temporary_invalid_cchars = []
 
@@ -208,13 +235,21 @@ actor LlamaContext {
         llama_batch_free(batch)
         batch = llama_batch_init(Int32(needed), 0, 1)
 
-        let n_ctx = llama_n_ctx(context)
-        let n_kv_req = tokens_list.count + (Int(n_len) - tokens_list.count)
+        let n_ctx = Int(llama_n_ctx(context))
+        let n_prompt = tokens_list.count
+        // KV cache must hold the prompt plus every token we intend to generate.
+        let n_kv_req = n_prompt + Int(n_len)
 
         dprint("\n n_len = \(n_len), n_ctx = \(n_ctx), n_kv_req = \(n_kv_req)")
 
-        if n_kv_req > n_ctx {
-            print("error: n_kv_req > n_ctx, the required KV cache size is not big enough")
+        // Fix B1: bail BEFORE decode when the prompt + n_len won't fit. Otherwise
+        // llama.cpp silently caps the KV cache at n_ctx-1 while n_cur runs away,
+        // producing the "inconsistent sequence positions" runaway from UAT Q5.
+        if LlamaContext.kvBudgetExceeds(nPrompt: n_prompt, nLen: Int(n_len), nCtx: n_ctx) {
+            last_error = "prompt + n_len (\(n_kv_req)) exceeds n_ctx (\(n_ctx))"
+            print("⚠️ [LlamaContext] \(last_error!) — aborting completion_init")
+            is_done = true
+            return false
         }
 
         for id in tokens_list {
@@ -230,11 +265,15 @@ actor LlamaContext {
         batch.logits[Int(batch.n_tokens) - 1] = 1 // true
 
         if llama_decode(context, batch) != 0 {
-            print("llama_decode() failed")
+            last_error = "llama_decode failed during completion_init"
+            print("❌ [LlamaContext] \(last_error!)")
+            is_done = true
+            return false
         }
 
         n_cur = batch.n_tokens
         is_done = false // 追加: 推論開始時にis_doneをリセット
+        return true
     }
 
     func completion_loop() -> String {
@@ -246,7 +285,9 @@ actor LlamaContext {
         dprint("[DEBUG] new_token_id:", new_token_id)
         dprint("[DEBUG] is_eog:", llama_vocab_is_eog(vocab, new_token_id), "n_cur:", n_cur, "n_len:", n_len)
 
-        if llama_vocab_is_eog(vocab, new_token_id) || n_cur == n_len {
+        // Fix B3: `>=` (not `==`) so the loop still terminates if n_cur ever
+        // drifts past n_len; equality alone leaves EOG as the only exit.
+        if llama_vocab_is_eog(vocab, new_token_id) || n_cur >= n_len {
             dprint("[DEBUG] EOG or max length reached. Returning:", String(cString: temporary_invalid_cchars + [0]))
             is_done = true
             // 直前のトークンがflushされていない場合は返す
@@ -284,8 +325,15 @@ actor LlamaContext {
         n_decode += 1
         n_cur    += 1
 
+        // Fix B2: a decode failure must STOP the loop. Previously this only
+        // printed, so the caller never observed the failure and kept calling
+        // completion_loop() with an ever-incrementing n_cur out of sync with the
+        // KV cache — the ~910k-iteration runaway from UAT Q5.
         if llama_decode(context, batch) != 0 {
-            print("failed to evaluate llama!")
+            last_error = "llama_decode failed in completion_loop at n_cur=\(n_cur)"
+            print("❌ [LlamaContext] \(last_error!)")
+            is_done = true
+            return ""
         }
 
         return new_token_str

--- a/Shared/Llama/NoesisCompletionPipeline.swift
+++ b/Shared/Llama/NoesisCompletionPipeline.swift
@@ -88,7 +88,15 @@ public func runNoesisCompletion(
     print("   Prompt length: \(prompt.count)")
     print("   Prompt preview: \(prompt.prefix(200))...")
     let tokenizeStart = Date()
-    await ctx.completion_init(text: prompt)
+    let initOK = await ctx.completion_init(text: prompt)
+    if !initOK {
+        let err = await ctx.get_last_error() ?? "unknown init error"
+        print("⚠️ [NoesisCompletion] completion_init bailed: \(err)")
+        // Over-budget prompt (or decode failure) — skip the generation loop
+        // entirely and return a user-visible message instead of hanging.
+        return "The question exceeded the model's context window. " +
+               "Try a shorter question or clear chat history."
+    }
     let tokenizeTime = Date().timeIntervalSince(tokenizeStart)
     print("✅ [NoesisCompletion] AFTER completion_init() - Prompt tokenized in \(String(format: "%.2f", tokenizeTime*1000))ms")
     SystemLog().logEvent(event: String(format: "[PERF] Tokenization: %.2f ms", tokenizeTime*1000))


### PR DESCRIPTION
## Bug (release blocker, surfaced after PR #101)

After #101 made LLM dispatch correct (Llama 3.2 3B), the **5th question** in Taka's Spinoza UAT hung the runtime. Xcode console:

```
init: the tokens of sequence 0 in the input batch have inconsistent sequence positions:
  - the last position stored in the memory module of the context (i.e. the KV cache) for sequence 0 is X = 4095
  - the tokens for sequence 0 in the input batch have a starting position of Y = 910640
  it is required that the sequence positions remain consecutive: Y = X + 1
decode: failed to initialize batch
llama_decode: failed to decode, ret = -1
failed to evaluate llama!
[909790 tokens...]
```

Y kept incrementing one at a time (910640 → 910641 → 910642 → …). The `[909790 tokens...]` line is `NoesisCompletionPipeline.swift`'s 10-token progress print — the generation loop iterated ~910k times after the decode error, never stopping. KV cache stuck at X = 4095 (= n_ctx 4096 − 1) while Swift-side `n_cur` ran away into the hundreds of thousands.

### The rest of the stack is correct (Q1 evidence)

Q1–Q4 all returned answers, including Q1's clean verbatim Spinoza quote:

> "Substance, or God, or Nature, is that which is conceived through itself, and is conceived through itself alone." — Part I, Definition 3

That proves the embedder / registry / RAG path (#97–#101) is correct end-to-end. Q5 is purely a runtime-loop hazard.

## Root cause: three composing bugs in `Shared/Llama/LibLlama.swift`

Multi-turn (ADR-0009) accumulates 3 prior Q/A turns; each retrieved RAG context is ~2,500 tokens (5 chunks × 512). By Q5 the rendered ChatML prompt easily reaches 12–13k tokens — well past macOS n_ctx=4096. Q1–Q4 individually stayed under n_ctx, so the chain didn't trip until Q5.

- **B1** — `completion_init` did NOT bail when `n_kv_req > n_ctx` (old line ~216): it only printed, then ran `llama_decode` regardless and set `n_cur = batch.n_tokens`. llama.cpp capped the KV cache at n_ctx-1 while Swift believed `n_cur` ≈ 13k.
- **B2** — `completion_loop` swallowed decode failure (old line ~287): `llama_decode != 0` only printed; no `is_done`, no return. Every iteration called `llama_batch_add(&batch, …, n_cur, …)` with an ever-increasing `n_cur` already out of sync with the KV cache, so llama.cpp re-emitted "inconsistent sequence positions" forever.
- **B3** — `n_cur == n_len` equality cutoff (old line ~249): if `n_cur` ever drifts past `n_len`, equality is never true and only EOG can stop the loop — and with B2 swallowing decode failures, EOG sampling is unreliable too.

The three only compose into a runaway under the specific combination (over-budget prompt + decode error not propagated + equality cutoff).

## Fixes (surgical; `LibLlama.swift` + one call site)

- **B1** — `completion_init` now returns `Bool`. It bails **before** decode when `prompt + n_len > n_ctx` (via pure seam `LlamaContext.kvBudgetExceeds(nPrompt:nLen:nCtx:)`), and on `llama_decode` failure — setting `last_error` and `is_done = true` and returning `false`.
- **B2** — decode failure in `completion_loop` sets `last_error` + `is_done = true` and returns `""`; the caller exits on the next `while !ctx.is_done`.
- **B3** — cutoff is now `n_cur >= n_len`.
- Added `var last_error: String?` + `func get_last_error()`. `completion_init` is `@discardableResult`, so the other two call sites (`LlamaState.swift`, CLI `main.swift`) compile unchanged and stay out of scope.

`NoesisCompletionPipeline.swift` checks the new return value:

```swift
let initOK = await ctx.completion_init(text: prompt)
if !initOK {
    let err = await ctx.get_last_error() ?? "unknown init error"
    print("⚠️ [NoesisCompletion] completion_init bailed: \(err)")
    return "The question exceeded the model's context window. " +
           "Try a shorter question or clear chat history."
}
```

### Behavioural change

Over-budget Q5 now returns **"The question exceeded the model's context window. Try a shorter question or clear chat history."** instead of looping forever emitting `[N tokens...]` past `n_len`.

## Test

`Apps/macOS/NoesisNoema/Tests/LibLlamaCompletionBailTests.swift` — self-contained `#if DEBUG` smoke (matching #99/#100/#101; the NoesisNoemaTests target is unwired) over the pure `kvBudgetExceeds` seam, incl. the Q5 over-budget shape (13000 + 512 vs 4096 → bail), the exact-fit boundary (== n_ctx → no bail), one-token-over, and iOS n_ctx=1024. All 7 cases pass:

```
✅ true  exp=true  [13000 + 512 vs 4096 | Q5 over-budget multi-turn]
✅ false exp=false [1200 + 512 vs 4096  | Q1 single-turn fits]
✅ false exp=false [3584 + 512 vs 4096  | exact fit (== n_ctx)]
✅ true  exp=true  [3585 + 512 vs 4096  | one token over]
✅ true  exp=true  [800 + 256 vs 1024   | iOS n_ctx=1024 overflow]
✅ false exp=false [700 + 256 vs 1024   | iOS n_ctx=1024 fits]
✅ false exp=false [0 + 512 vs 4096     | empty prompt fits]
```

## Build matrix

| Build | Result |
|---|---|
| macOS `NoesisNoema` Debug (arm64) | ✅ |
| macOS `NoesisNoema` Release (`ARCHS=arm64 ONLY_ACTIVE_ARCH=NO`) | ✅ |
| iOS `NoesisNoemaMobile` Debug (Simulator, arm64) | ✅ |
| iOS `NoesisNoemaMobile` Release (Simulator, arm64) | ✅ |

(The `LlamaBridgeTest` CLI scheme fails to resolve the `llama` module on clean `main` too — a pre-existing scheme-config issue under `-DBRIDGE_TEST`, unrelated to this change.)

## Scope / follow-ups

- **Does NOT change history budgeting.** The underlying issue is 3 turns × ~2,500-token RAG context blowing past n_ctx=4096. The right long-term fix is to cap history by token budget (e.g. ≤ 30% of n_ctx), not by turn count (**ADR-0009 follow-up PR**). This PR makes the failure graceful; the follow-up makes it rare.
- Deferred: bumping n_ctx beyond 4096 (memory + latency cost); prompt truncation / sliding window (needs an ADR on what to drop).

### Orthogonal findings (reported, not fixed)
- `n_kv_req` was `tokens_list.count + (Int(n_len) - tokens_list.count)`, which simplifies to `Int(n_len)` — copy-paste leftover. This PR computes `n_prompt + Int(n_len)` directly (the intended budget). The dead `(… - tokens_list.count)` form is gone.
- The `n_decode` counter is incremented but never read — dead instrumentation; flag for cleanup.

⚠️ **Do NOT merge** — Taka merges, then re-runs Spinoza Q1–Q5 UAT to confirm graceful termination (Q5 must answer briefly or print the context-window message — never hang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)