### PR TITLE
chore(diag): trace retrieval state at the LocalExecutor boundary (UAT diagnostic)

### DIFF
--- a/Shared/Runtime/Executors/LocalExecutor.swift
+++ b/Shared/Runtime/Executors/LocalExecutor.swift
@@ -78,6 +78,10 @@ final class LocalExecutor: Executor {
 
         let traceId = UUID()
 
+        print("🔎 [LocalExecutor/RAG] store-state: VectorStore.shared.chunks.count=\(VectorStore.shared.chunks.count)")
+        print("🔎 [LocalExecutor/RAG] query: \"\(query.prefix(120))\"")
+        print("🔎 [LocalExecutor/RAG] topK=\(defaultTopK), useDeepSearch=\(UserDefaults.standard.bool(forKey: Self.deepSearchDefaultsKey))")
+
         // Stage 1: Retrieve relevant chunks (local, off main thread).
         // Both retrieval paths are local-only; DeepSearch is opt-in (heavier).
         // ADR-0009 §4: history is NOT a retrieval input — retrieve on the
@@ -96,8 +100,18 @@ final class LocalExecutor: Executor {
             }
         }.value
 
+        print("🔎 [LocalExecutor/RAG] retrieved chunks.count=\(chunks.count)")
+        if let first = chunks.first {
+            let preview = first.content.prefix(120).replacingOccurrences(of: "\n", with: " ")
+            print("🔎 [LocalExecutor/RAG] chunk[0] preview: \"\(preview)\"")
+        } else {
+            print("🔎 [LocalExecutor/RAG] no chunks retrieved — context will be empty")
+        }
+
         // Stage 2: Build context from retrieved chunks (current query only).
         let context = chunks.map { $0.content }.joined(separator: "\n\n")
+
+        print("🔎 [LocalExecutor/RAG] context length=\(context.count) chars (chunks joined)")
 
         // Stage 3: Generate with the local model.
         // currentLLMModel is MainActor-isolated; hop to read it, then call the


### PR DESCRIPTION
## Temporary diagnostic patch — NOT a fix

This PR adds **diagnostic print statements only**. It is intended to be reverted or absorbed into a real fix once the failure mode is identified. It changes no behavior whatsoever: no control flow, no threading, no error throwing, no return values, no new types/imports/signatures.

## Why

The Spinoza UAT post-PR#102 shows Q3 on the LocalExecutor path hitting `Context: none` / `[RAG] context length: 0` — the LLM is being asked the question with **zero retrieved chunks**. We cannot yet distinguish between:
- (a) `VectorStore.shared.chunks` empty in this process (import/persistence broken)
- (b) `LocalRetriever.retrieve(...)` returns empty for this query
- (c) DeepSearch enabled in UserDefaults, silently filtering everything out
- (d) retrieval succeeds but the join into `context` yields an empty string

The dispatched LocalExecutor path prints no retrieval breadcrumbs (unlike the `ModelManager.generateAsyncAnswer` path), so we are flying blind. These prints make the next UAT run tell us which of (a)–(d) is happening. Tags are greppable: `🔎 [LocalExecutor/RAG]`.

Prints are intentionally **not** `#if DEBUG` gated so they appear in whatever build configuration the UAT runs.

## The three blocks (verbatim)

**Block 1 — after `let traceId = UUID()`, before Stage 1:**
```swift
print("🔎 [LocalExecutor/RAG] store-state: VectorStore.shared.chunks.count=\(VectorStore.shared.chunks.count)")
print("🔎 [LocalExecutor/RAG] query: \"\(query.prefix(120))\"")
print("🔎 [LocalExecutor/RAG] topK=\(defaultTopK), useDeepSearch=\(UserDefaults.standard.bool(forKey: Self.deepSearchDefaultsKey))")
```

**Block 2 — after the retrieval `Task.detached(...).value`:**
```swift
print("🔎 [LocalExecutor/RAG] retrieved chunks.count=\(chunks.count)")
if let first = chunks.first {
    let preview = first.content.prefix(120).replacingOccurrences(of: "\n", with: " ")
    print("🔎 [LocalExecutor/RAG] chunk[0] preview: \"\(preview)\"")
} else {
    print("🔎 [LocalExecutor/RAG] no chunks retrieved — context will be empty")
}
```

**Block 3 — after `let context = chunks.map { $0.content }.joined(separator: "\n\n")`:**
```swift
print("🔎 [LocalExecutor/RAG] context length=\(context.count) chars (chunks joined)")
```

## Scope

Diff strictly limited to `Shared/Runtime/Executors/LocalExecutor.swift` (1 file, +14 lines). No RAG/registry/embedder/llama/ModelManager/pipeline changes — PR #99/100/101/102 unaffected. `VectorStore` untouched (reads existing public `chunks` count).

## 4-build matrix

| # | Scheme | Config | Destination | Flags | Result |
|---|--------|--------|-------------|-------|--------|
| 1 | NoesisNoema | Debug | macOS | — | ✅ BUILD SUCCEEDED |
| 2 | NoesisNoema | Release | macOS | `ARCHS=arm64 ONLY_ACTIVE_ARCH=NO` | ✅ BUILD SUCCEEDED |
| 3 | NoesisNoemaMobile | Debug | iOS Simulator (iPhone 17 Pro) | `ARCHS=arm64 ONLY_ACTIVE_ARCH=NO` | ✅ BUILD SUCCEEDED |
| 4 | NoesisNoemaMobile | Release | iOS Simulator (iPhone 17 Pro) | `ARCHS=arm64 ONLY_ACTIVE_ARCH=NO` | ✅ BUILD SUCCEEDED |

## Next steps

This PR is intentionally **NOT a fix**. Merge → re-run Spinoza UAT (Q1–Q5) with the UAT chat → share the new console output containing the `🔎 [LocalExecutor/RAG]` lines → real fix lands in a subsequent PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)