### PR TITLE
fix(rag): populate VectorStore.shared from persisted chunks on launch

### DIFF
--- a/Shared/DocumentManager.swift
+++ b/Shared/DocumentManager.swift
@@ -84,6 +84,11 @@ class DocumentManager: ObservableObject {
         // Load from file storage
         loadHistory()
         loadRAGpackChunks()
+        // Re-hydrate the in-memory retrieval corpus from persisted chunks. Without
+        // this hop, packs imported in a prior session sit in `ragpackChunks` (disk)
+        // but never reach `VectorStore.shared`, so the retriever sees an empty store
+        // on every cold launch (P0: RAG only worked in the same session as import).
+        populateVectorStoreFromPersistedChunks()
         loadQAHistory()
     }
 
@@ -105,6 +110,19 @@ class DocumentManager: ObservableObject {
 
     func loadRAGpackChunks() {
         ragpackChunks = PersistenceStore.shared.loadRAGpackChunks()
+    }
+
+    /// Copies all persisted RAGpack chunks into `VectorStore.shared` so the retriever
+    /// sees prior-session packs on a cold launch. Call once, after `loadRAGpackChunks()`.
+    ///
+    /// - Uses `addChunks(_:deduplicate:)` — NOT `addTexts` — because persisted chunks
+    ///   already carry their embeddings; `addTexts` would re-embed and waste a model pass.
+    /// - Guarded on an empty store (and `deduplicate: true`) so repeated `DocumentManager()`
+    ///   construction (e.g. `#Preview` sites, tests) cannot stack duplicate corpus data.
+    private func populateVectorStoreFromPersistedChunks() {
+        let allChunks = ragpackChunks.values.flatMap { $0 }
+        guard !allChunks.isEmpty, VectorStore.shared.chunks.isEmpty else { return }
+        VectorStore.shared.addChunks(allChunks, deduplicate: true)
     }
     func deleteRAGpack(named name: String) {
         let chunksToDelete = ragpackChunks[name] ?? []


### PR DESCRIPTION
## Root cause
The disk → in-memory re-hydration hop was missing. `PersistenceStore.loadRAGpackChunks()` loads persisted chunks into `DocumentManager.ragpackChunks` at launch, but nothing copied them into `VectorStore.shared`. The retriever saw `chunks.count == 0` on every cold launch — RAG only worked in the same session as a fresh import.

## Fix
**File:line:** `Shared/DocumentManager.swift:115-121` (new `populateVectorStoreFromPersistedChunks()`), called from `init()` at `Shared/DocumentManager.swift:91`.

```swift
private func populateVectorStoreFromPersistedChunks() {
    let allChunks = ragpackChunks.values.flatMap { $0 }
    guard !allChunks.isEmpty, VectorStore.shared.chunks.isEmpty else { return }
    VectorStore.shared.addChunks(allChunks, deduplicate: true)
}
```

### `addChunks` vs `addTexts` rationale
Uses **`addChunks(_:deduplicate:)`**, NOT `addTexts`. Persisted chunks already carry their embeddings; `addTexts` would re-embed every chunk and waste a full model pass. Embeddings are preserved as-is.

### Live-import path unchanged
The live-import append at `DocumentManager.swift:216` (`VectorStore.shared.chunks.append(contentsOf:)`) is untouched. A fresh import in the same session still works exactly as before.

### `#Preview` guard
Guarded on `VectorStore.shared.chunks.isEmpty` **and** `deduplicate: true`, so repeated `DocumentManager()` construction from `#Preview` sites or tests cannot stack duplicate corpus data.

## Build matrix (all green)
| Build | Result |
|---|---|
| macOS Debug | ✅ BUILD SUCCEEDED |
| macOS Release | ✅ BUILD SUCCEEDED |
| iOS Simulator arm64 Debug (`ARCHS=arm64 ONLY_ACTIVE_ARCH=NO`) | ✅ BUILD SUCCEEDED |
| iOS Simulator arm64 Release (`ARCHS=arm64 ONLY_ACTIVE_ARCH=NO`) | ✅ BUILD SUCCEEDED |

## UAT instruction
Launch the app **without** importing anything this session (a Spinoza pack must exist from a prior session), ask Q3 ("Quote a passage from Spinoza's Ethics about substance."), and confirm the diagnostic print shows `🔎 [LocalExecutor/RAG] store-state: ...chunks.count > 0` and a non-zero `retrieved chunks.count` with a populated `Context:`.

## Orthogonal findings (noted, not fixed)
- The redundant second `EmbeddingModel` load at query time lives in `LocalExecutor.swift`, which this PR is scoped not to touch — left for a follow-up.
- `VectorStore.findRelevant` silently skips dimension-mismatched chunks (VectorStore.swift:110-115) — flagged for Taka's runtime dimension verification after this lands.

⚠️ **Do NOT merge — Taka runs UAT first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)