### PR TITLE
fix(llm): set n_batch=n_ctx and add context length guard to prevent llama_decode overflow

### DIFF
--- a/Shared/Llama/LibLlama.swift
+++ b/Shared/Llama/LibLlama.swift
@@ -132,6 +132,13 @@ actor LlamaContext {
         #else
         ctx_params.n_ctx = 4096 // macOS: room for Deep Search + history + retrieved chunks
         #endif
+        // A single llama_decode batch may contain up to n_ctx tokens once RAG
+        // context + history are injected. The llama.cpp default n_batch (2048) is
+        // smaller than n_ctx, so a large prompt trips
+        // GGML_ASSERT(n_tokens_all <= cparams.n_batch). Size the logical batch to
+        // n_ctx so the whole prompt fits in one decode; n_ubatch stays at its
+        // default (512).
+        ctx_params.n_batch = ctx_params.n_ctx
         ctx_params.n_threads       = Int32(n_threads)
         ctx_params.n_threads_batch = Int32(n_threads)
 

--- a/Shared/Runtime/Executors/LocalExecutor.swift
+++ b/Shared/Runtime/Executors/LocalExecutor.swift
@@ -109,7 +109,27 @@ final class LocalExecutor: Executor {
         }
 
         // Stage 2: Build context from retrieved chunks (current query only).
-        let context = chunks.map { $0.content }.joined(separator: "\n\n")
+        let joinedContext = chunks.map { $0.content }.joined(separator: "\n\n")
+
+        // Guard against llama_decode overflow: the whole prompt
+        // (system + context + question) must decode within the model's context
+        // window, leaving room for the generated answer. Cap the joined context
+        // by a char-based estimate (~3 chars/token for English) so it cannot push
+        // the prompt past n_ctx. Mirrors the per-platform n_ctx/n_len set in
+        // LibLlama.create_context (macOS 4096/1024, iOS 1024/256).
+        #if os(iOS)
+        let nCtx = 1024, nLen = 256
+        #else
+        let nCtx = 4096, nLen = 1024
+        #endif
+        let contextCharCap = max(0, (nCtx - nLen - 200)) * 3
+        let context: String
+        if joinedContext.count > contextCharCap {
+            context = String(joinedContext.prefix(contextCharCap))
+            print("✂️ [LocalExecutor/RAG] context truncated \(joinedContext.count)→\(context.count) chars (cap=\(contextCharCap)) to avoid llama_decode overflow")
+        } else {
+            context = joinedContext
+        }
 
         print("🔎 [LocalExecutor/RAG] context length=\(context.count) chars (chunks joined)")
 


### PR DESCRIPTION
## Problem

`GGML_ASSERT(n_tokens_all <= cparams.n_batch)` failed at `llama-context.cpp:1692` (SIGABRT).

The prompt was ~2433 tokens (7277 chars) once RAG context (6964 chars) was injected, but `create_context` never set `n_batch` — it stayed at the llama.cpp default of **2048**, smaller than `n_ctx` (**4096**). A single `llama_decode` of the full prompt therefore overflowed the logical batch.

## Fix (two changes, both required)

1. **`Shared/Llama/LibLlama.swift:140`** — in `create_context`, set `ctx_params.n_batch = ctx_params.n_ctx` so a full prompt decodes in one batch. `n_ubatch` is left at its default (512). Applies to both platforms (macOS n_ctx=4096, iOS n_ctx=1024).

2. **`Shared/Runtime/Executors/LocalExecutor.swift:112`** — cap the joined RAG context to a char-based estimate `(n_ctx - n_len - 200) * 3` before generation, sized per-platform to mirror `LibLlama.create_context` (macOS 4096/1024, iOS 1024/256). Today's 6964-char context is under the cap so nothing truncates now; this prevents future overflow and logs when it trims.

## Not changed
`n_ctx` (4096), `n_len`, retrieval logic, UI, and `project.pbxproj`.

## Build verification
| Target | Debug | Release |
|---|---|---|
| macOS | ✅ | ✅ |
| iOS Simulator (arm64) | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)