### PR TITLE
fix(llm): enable parse_special=true for generator prompt tokenization

### DIFF
--- a/Shared/Llama/LibLlama.swift
+++ b/Shared/Llama/LibLlama.swift
@@ -459,7 +459,12 @@ actor LlamaContext {
         let utf8Count = text.utf8.count
         let n_tokens = utf8Count + (add_bos ? 1 : 0) + 1
         let tokens = UnsafeMutablePointer<llama_token>.allocate(capacity: n_tokens)
-        let tokenCount = llama_tokenize(vocab, text, Int32(utf8Count), tokens, Int32(n_tokens), add_bos, false)
+        // parse_special=true: the generator prompt carries Llama-3 control tokens
+        // (<|begin_of_text|>, <|start_header_id|>, <|eot_id|>, …) that MUST map to
+        // single control-token IDs. With false they tokenize as literal text, the
+        // instruct model sees no valid chat structure, and emits EOG after 1 token.
+        // (The embedding path has its own tokenize() and stays parse_special=false.)
+        let tokenCount = llama_tokenize(vocab, text, Int32(utf8Count), tokens, Int32(n_tokens), add_bos, true)
 
         var swiftTokens: [llama_token] = []
         for i in 0..<tokenCount {


### PR DESCRIPTION
## Problem

The model generated **one token then emitted EOG**. Confirmed root cause: the generator's `tokenize()` called `llama_tokenize` with `parse_special=false`, so the Llama-3 control tokens in the prompt (`<|begin_of_text|>`, `<|start_header_id|>`, `<|end_header_id|>`, `<|eot_id|>`) were tokenized as **literal text** instead of their single control-token IDs. The instruct model saw no valid chat structure and immediately sampled an EOG token.

## Fix — one line

`Shared/Llama/LibLlama.swift:467` — change the final `llama_tokenize` argument (`parse_special`) from `false` to `true` in the generator's `tokenize()`.

## Generator vs. embedder — verified separate
- Generator: `LibLlama.swift` `tokenize()` is `private`, called only from `completion_init` (line 236). ✅ changed to `parse_special=true`.
- Embedder: `LlamaEmbeddingContext.swift` has its **own** `private func tokenize()` (line 188) with an independent `llama_tokenize(..., true, false)` call (line 194). ✅ left untouched at `parse_special=false` — nomic-bert does not use special tokens.

No global/shared change was needed.

## Build verification
| Target | Debug | Release |
|---|---|---|
| macOS | ✅ | ✅ |
| iOS Simulator (arm64) | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)