### PR TITLE
fix(llm): set add_bos=false in completion_init to prevent double BOS token

### DIFF
--- a/Shared/Llama/LibLlama.swift
+++ b/Shared/Llama/LibLlama.swift
@@ -233,7 +233,11 @@ actor LlamaContext {
         dprint("attempting to complete \"\(text)\"")
 
         last_error = nil
-        tokens_list = tokenize(text: text, add_bos: true)
+        // add_bos=false: the prompt already begins with the literal
+        // <|begin_of_text|>, which parse_special=true tokenizes to the BOS id
+        // (128000). Adding another BOS here yields two BOS tokens, which makes the
+        // instruct model emit EOG after a single token.
+        tokens_list = tokenize(text: text, add_bos: false)
         temporary_invalid_cchars = []
 
         // Ensure batch capacity >= prompt token length


### PR DESCRIPTION
## Problem

The model emitted EOG after a single token. Log evidence:

```
check_double_bos_eos: Added a BOS token to the prompt as specified by the model
but the prompt also starts with a BOS token.
```

`buildPrompt` (PR #108) embeds the literal `<|begin_of_text|>` at the start of the prompt, and with `parse_special=true` (PR #109) that literal tokenizes to the BOS id (128000). But `completion_init` also passed `add_bos=true` to `tokenize()`, so the prompt got **two** BOS tokens — which makes the instruct model emit EOG immediately.

## Fix — one line

`Shared/Llama/LibLlama.swift:236` — change `tokenize(text: text, add_bos: true)` to `add_bos: false`. The only BOS now comes from the `<|begin_of_text|>` already in the prompt string.

## Not changed
Everything else, including the embedding path and `project.pbxproj`.

## Build verification
| Target | Debug | Release |
|---|---|---|
| macOS | ✅ | ✅ |
| iOS Simulator (arm64) | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)