### PR TITLE
fix(llm): use n_decode not n_cur for generation length guard in completion_loop

### DIFF
--- a/Shared/Llama/LibLlama.swift
+++ b/Shared/Llama/LibLlama.swift
@@ -296,9 +296,14 @@ actor LlamaContext {
         dprint("[DEBUG] new_token_id:", new_token_id)
         dprint("[DEBUG] is_eog:", llama_vocab_is_eog(vocab, new_token_id), "n_cur:", n_cur, "n_len:", n_len)
 
-        // Fix B3: `>=` (not `==`) so the loop still terminates if n_cur ever
+        // Fix B3: `>=` (not `==`) so the loop still terminates if the counter ever
         // drifts past n_len; equality alone leaves EOG as the only exit.
-        if llama_vocab_is_eog(vocab, new_token_id) || n_cur >= n_len {
+        // n_len bounds GENERATED tokens, so compare against n_decode (starts at 0,
+        // incremented per generated token) — NOT n_cur, which is seeded with the
+        // prompt token count in completion_init and would trip this guard on the
+        // first call for any prompt longer than n_len (e.g. a ~2000-token RAG
+        // prompt with n_len=1024), yielding a single-token/empty completion.
+        if llama_vocab_is_eog(vocab, new_token_id) || n_decode >= n_len {
             dprint("[DEBUG] EOG or max length reached. Returning:", String(cString: temporary_invalid_cchars + [0]))
             is_done = true
             // 直前のトークンがflushされていない場合は返す


### PR DESCRIPTION
## Root cause

`completion_init()` seeds `n_cur` with the prompt token count:

```swift
n_cur = batch.n_tokens   // LibLlama.swift:285
```

`completion_loop()` then used `n_cur >= n_len` as the max-length stop condition:

```swift
if llama_vocab_is_eog(vocab, new_token_id) || n_cur >= n_len {   // before
```

For a RAG prompt (~2000 tokens) with `n_len = 1024` (macOS default), `n_cur ≈ 2000` on entry, so `2000 >= 1024` is **true on the first call**. `is_done` flips immediately and the loop returns a single token (the lone `"`) or an empty string. That `"` was then saved to QA history and replayed as a prior assistant turn, feeding the EOG loops.

## Fix

`n_len` bounds **generated** tokens, so compare against `n_decode` — which starts at 0 and increments once per generated token (`LibLlama.swift:336`) — not `n_cur`, which tracks total KV position (prompt + generated):

```swift
if llama_vocab_is_eog(vocab, new_token_id) || n_decode >= n_len {   // after
```

`kvBudgetExceeds` is **unaffected** — it correctly checks `nPrompt + nLen > nCtx` against the full context window and was not touched.

## Builds (4/4 green)

| Target | Config | Result |
|---|---|---|
| macOS | Debug | ✅ BUILD SUCCEEDED |
| macOS | Release | ✅ BUILD SUCCEEDED |
| iOS Simulator (arm64) | Debug | ✅ BUILD SUCCEEDED |
| iOS Simulator (arm64) | Release | ✅ BUILD SUCCEEDED |

iOS Release required `ARCHS=arm64 EXCLUDED_ARCHS=x86_64` (llama.xcframework has no x86_64 slice).

**Do not merge** — pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)