### PR TITLE
fix(retrieval): manifest-gated mean-centering to recover collapsed embedding space

### DIFF
--- a/Shared/DocumentManager.swift
+++ b/Shared/DocumentManager.swift
@@ -44,6 +44,12 @@ class DocumentManager: ObservableObject {
     /// POTENTIAL LARGE PAYLOAD: RAGpack chunks with embeddings (can be MBs per pack)
     @Published var ragpackChunks: [String: [Chunk]] = [:]
 
+    /// Per-pack mean-centering correction directions, keyed by pack doc name
+    /// (== `Chunk.correctionId`). Mirrors `VectorStore.shared.correctionMeans`;
+    /// owned here for persistence. Only corrected packs (legacy, non-`mean_centered`)
+    /// have an entry.
+    @Published var correctionMeans: [String: [Float]] = [:]
+
     /// ADR-0011 §4 (no silent fallback): the last RAGpack import failure, surfaced
     /// to the user via a SwiftUI alert in the Settings views. Set on a failed
     /// import; cleared on a successful one (and when the user dismisses the alert).
@@ -84,6 +90,9 @@ class DocumentManager: ObservableObject {
         // Load from file storage
         loadHistory()
         loadRAGpackChunks()
+        // Restore per-pack mean-centering directions BEFORE rehydrating the corpus so
+        // the retriever can correct queries for prior-session packs on a cold launch.
+        loadCorrectionMeans()
         // Re-hydrate the in-memory retrieval corpus from persisted chunks. Without
         // this hop, packs imported in a prior session sit in `ragpackChunks` (disk)
         // but never reach `VectorStore.shared`, so the retriever sees an empty store
@@ -112,6 +121,19 @@ class DocumentManager: ObservableObject {
         ragpackChunks = PersistenceStore.shared.loadRAGpackChunks()
     }
 
+    // MARK: - Correction Means (mean-centering recovery)
+
+    func saveCorrectionMeans() {
+        PersistenceStore.shared.saveCorrectionMeans(correctionMeans)
+    }
+
+    /// Loads persisted correction directions and publishes them to the shared
+    /// VectorStore so query-time correction works on a cold launch.
+    func loadCorrectionMeans() {
+        correctionMeans = PersistenceStore.shared.loadCorrectionMeans()
+        VectorStore.shared.correctionMeans = correctionMeans
+    }
+
     /// Copies all persisted RAGpack chunks into `VectorStore.shared` so the retriever
     /// sees prior-session packs on a cold launch. Call once, after `loadRAGpackChunks()`.
     ///
@@ -130,6 +152,11 @@ class DocumentManager: ObservableObject {
         uploadHistory.removeAll { $0.filename == name }
         VectorStore.shared.chunks.removeAll { chunk in
             chunksToDelete.contains(where: { $0.content == chunk.content && $0.embedding == chunk.embedding })
+        }
+        // Drop this pack's correction direction (keep registry/disk in lockstep).
+        if correctionMeans.removeValue(forKey: name) != nil {
+            VectorStore.shared.correctionMeans.removeValue(forKey: name)
+            saveCorrectionMeans()
         }
         saveHistory()
         saveRAGpackChunks()
@@ -208,15 +235,20 @@ class DocumentManager: ObservableObject {
         }
 
         // 2. Read + validate the v1.2 pack. Throws RAGpackImportError; let it propagate.
-        let (chunks, _) = try RAGpackReader.readPack(at: tempDir, embedder: self.embedder)
+        //    `correctionMean` is the mean-centering direction removed from this pack's
+        //    document vectors (nil when the pack is already `mean_centered`).
+        let (chunks, _, correctionMean) = try RAGpackReader.readPack(at: tempDir, embedder: self.embedder)
 
-        // 3. Title the chunks and add the unique ones to the VectorStore.
+        // 3. Title the chunks and add the unique ones to the VectorStore. Tag each
+        //    chunk with the pack's correctionId so the query is corrected with this
+        //    pack's mean direction at search time (only when a correction was applied).
         let baseName = fileURL.deletingPathExtension().lastPathComponent
         let timestamp = Date()
         let docName = "\(baseName)_\(Int(timestamp.timeIntervalSince1970))"
         let titledChunks = chunks.map { ch -> Chunk in
             var c = ch
             if c.sourceTitle == nil { c.sourceTitle = docName }
+            if correctionMean != nil { c.correctionId = docName }
             return c
         }
         let metadata: [String: Any] = [
@@ -233,6 +265,13 @@ class DocumentManager: ObservableObject {
             self.llmragFiles.append(ragFile)
             VectorStore.shared.chunks.append(contentsOf: uniqueChunks)
             self.ragpackChunks[docName] = uniqueChunks
+            // Register + persist this pack's correction direction so query-time
+            // correction works now and after a cold launch.
+            if let correctionMean = correctionMean {
+                self.correctionMeans[docName] = correctionMean
+                VectorStore.shared.correctionMeans[docName] = correctionMean
+                self.saveCorrectionMeans()
+            }
             self.uploadHistory.append(UploadHistory(filename: docName, timestamp: timestamp, chunkCount: uniqueChunks.count))
             self.saveHistory()
             self.saveRAGpackChunks()

--- a/Shared/PersistenceStore.swift
+++ b/Shared/PersistenceStore.swift
@@ -41,6 +41,7 @@ final class PersistenceStore {
     private var qaHistoryFileURL: URL { baseDirectory.appendingPathComponent("qaHistory.json") }
     private var ragpackChunksFileURL: URL { baseDirectory.appendingPathComponent("ragpackChunks.json") }
     private var uploadHistoryFileURL: URL { baseDirectory.appendingPathComponent("uploadHistory.json") }
+    private var correctionMeansFileURL: URL { baseDirectory.appendingPathComponent("correctionMeans.json") }
 
     init(fileManager: FileManager = .default) {
         self.fileManager = fileManager
@@ -140,6 +141,38 @@ final class PersistenceStore {
             return chunks
         } catch {
             NSLog("[PersistenceStore] ❌ Failed to load RAGpack Chunks: %@", error.localizedDescription)
+            return [:]
+        }
+    }
+
+    // MARK: - Correction Means (SMALL - one 768-float direction per corrected pack)
+
+    /// Persists the per-pack mean-centering correction directions
+    /// (`[Chunk.correctionId: meanDirection]`) so the query can be corrected with the
+    /// same direction the document vectors were corrected by, across cold launches.
+    func saveCorrectionMeans(_ means: [String: [Float]]) {
+        let encoder = JSONEncoder()
+        do {
+            let data = try encoder.encode(means)
+            try data.write(to: correctionMeansFileURL, options: [.atomic])
+            NSLog("[PersistenceStore] ✅ Saved Correction Means: %d packs", means.count)
+        } catch {
+            NSLog("[PersistenceStore] ❌ Failed to save Correction Means: %@", error.localizedDescription)
+        }
+    }
+
+    func loadCorrectionMeans() -> [String: [Float]] {
+        guard fileManager.fileExists(atPath: correctionMeansFileURL.path) else {
+            NSLog("[PersistenceStore] ℹ️ No Correction Means file found (first launch)")
+            return [:]
+        }
+        do {
+            let data = try Data(contentsOf: correctionMeansFileURL)
+            let means = try JSONDecoder().decode([String: [Float]].self, from: data)
+            NSLog("[PersistenceStore] ✅ Loaded Correction Means: %d packs", means.count)
+            return means
+        } catch {
+            NSLog("[PersistenceStore] ❌ Failed to load Correction Means: %@", error.localizedDescription)
             return [:]
         }
     }

--- a/Shared/RAG/BanditRetriever.swift
+++ b/Shared/RAG/BanditRetriever.swift
@@ -26,12 +26,15 @@ struct BanditRetriever {
         let ps = choice.arm.params
         let results = base.retrieve(query: query, k: ps.topK, lambda: ps.mmrLambda, trace: trace)
         if ps.minScore <= 0 { return results }
-        // Filter by minScore using cosine similarity to the original query
+        // Filter by minScore using cosine similarity to the original query. Apply the
+        // same per-pack mean-centering correction as retrieval so the threshold is
+        // compared against meaningful (corrected-space) cosines.
         let q = store.embeddingModel.embed(text: query)
+        let corrector = QueryCorrector(rawQuery: q, means: store.correctionMeans)
         var filtered: [Chunk] = []
         filtered.reserveCapacity(results.count)
         for c in results {
-            let sim = cosine(q, c.embedding)
+            let sim = cosine(corrector.query(for: c.correctionId), c.embedding)
             if sim >= ps.minScore { filtered.append(c) }
         }
         return filtered

--- a/Shared/RAG/Chunk.swift
+++ b/Shared/RAG/Chunk.swift
@@ -28,9 +28,17 @@ struct Chunk: Codable, Equatable {
     var charEnd: Int?
     var paragraphBoundaries: [Int]?
 
+    // Mean-centering recovery (EmbeddingCorrection): identifies which pack this
+    // chunk belongs to so the query can be corrected with that pack's stored mean
+    // direction at search time. nil when the chunk's pack was not corrected (e.g. a
+    // healthy `mean_centered` pack, or a legacy chunk imported before this feature).
+    // Optional + defaulted → purely additive; existing encoded chunks keep decoding.
+    var correctionId: String?
+
     enum CodingKeys: String, CodingKey {
         case content, embedding, sourceTitle, sourcePath, page
         case docId, charStart, charEnd, paragraphBoundaries
+        case correctionId
     }
 
     init(content: String,
@@ -41,7 +49,8 @@ struct Chunk: Codable, Equatable {
          docId: String? = nil,
          charStart: Int? = nil,
          charEnd: Int? = nil,
-         paragraphBoundaries: [Int]? = nil) {
+         paragraphBoundaries: [Int]? = nil,
+         correctionId: String? = nil) {
         self.content = content
         self.embedding = embedding
         self.sourceTitle = sourceTitle
@@ -51,6 +60,7 @@ struct Chunk: Codable, Equatable {
         self.charStart = charStart
         self.charEnd = charEnd
         self.paragraphBoundaries = paragraphBoundaries
+        self.correctionId = correctionId
     }
 
     // Custom decoder so a v1.2 chunks.json that carries content (+ optional
@@ -68,5 +78,6 @@ struct Chunk: Codable, Equatable {
         self.charStart = try c.decodeIfPresent(Int.self, forKey: .charStart)
         self.charEnd = try c.decodeIfPresent(Int.self, forKey: .charEnd)
         self.paragraphBoundaries = try c.decodeIfPresent([Int].self, forKey: .paragraphBoundaries)
+        self.correctionId = try c.decodeIfPresent(String.self, forKey: .correctionId)
     }
 }

--- a/Shared/RAG/DeepSearch.swift
+++ b/Shared/RAG/DeepSearch.swift
@@ -71,9 +71,12 @@ struct DeepSearch {
             }
         }
         if pool.isEmpty { return [] }
-        // Final rerank with MMR using original query as anchor
+        // Final rerank with MMR using original query as anchor. Correct the query
+        // per-pack (mean-centering recovery) so relevance is computed in the same
+        // space as the already-corrected document vectors.
         let qEmb = store.embeddingModel.embed(text: query)
-        let ranked = MMR.rerank(queryEmbedding: qEmb, candidates: pool, k: config.topK, lambda: config.mmrLambda, trace: config.trace)
+        let corrector = QueryCorrector(rawQuery: qEmb, means: store.correctionMeans)
+        let ranked = MMR.rerank(queryEmbedding: qEmb, candidates: pool, k: config.topK, lambda: config.mmrLambda, corrector: corrector, trace: config.trace)
         return ranked
     }
 

--- a/Shared/RAG/EmbeddingCorrection.swift
+++ b/Shared/RAG/EmbeddingCorrection.swift
@@ -1,0 +1,244 @@
+// Project: NoesisNoema
+// File: EmbeddingCorrection.swift
+// Description: Mean-centering recovery layer for collapsed embedding spaces.
+//
+//   Document vectors in some shipped RAGpacks are collapsed onto a common
+//   direction (a shared document-side embedding bias baked in by the external
+//   pipeline — prefix/pooling). Symptoms measured on a real pack:
+//     - mean-vector norm ≈ 0.893 (near-total alignment; 0 = healthy)
+//     - every chunk has cos ≥ 0.744 to the global mean direction
+//     - effective dimensionality ≈ 71.9 / 768 (~90% of the space dead)
+//     - intra-pack off-diagonal cos mean ≈ 0.79 (healthy is ~0.3–0.5)
+//   Removing the common direction restores health (off-diagonal cos → ~0,
+//   top1-vs-top10 score gap widens 2–18×). The semantic information is intact;
+//   only a shared bias is the problem.
+//
+//   This is a RECOVERY layer for legacy packs. The permanent fix is pipeline-side
+//   re-generation (which would set `embedder.mean_centered = true` in the manifest,
+//   gating this correction OFF so healthy packs are never double-corrected).
+//
+//   ALL math lives here (pure, testable) — it is NOT inlined across call sites.
+//   The transform follows the design exactly:
+//     mean_dir = normalize(mean(doc_vectors))           // 768-d unit vector
+//     doc:   d' = normalize(d - mean_dir)
+//     query: q' = normalize(q - mean_dir)               // SAME pack mean_dir
+// License: MIT License
+
+import Foundation
+
+enum EmbeddingCorrection {
+
+    // MARK: - Primitives
+
+    /// Arithmetic mean of a set of equal-length vectors. Empty input → [].
+    static func mean(of vectors: [[Float]]) -> [Float] {
+        guard let first = vectors.first, !first.isEmpty else { return [] }
+        let dim = first.count
+        var acc = [Float](repeating: 0, count: dim)
+        var n = 0
+        for v in vectors where v.count == dim {
+            for i in 0..<dim { acc[i] += v[i] }
+            n += 1
+        }
+        guard n > 0 else { return [] }
+        let inv = 1 / Float(n)
+        for i in 0..<dim { acc[i] *= inv }
+        return acc
+    }
+
+    /// L2 norm of a vector.
+    static func l2Norm(_ v: [Float]) -> Float {
+        var s: Float = 0
+        for x in v { s += x * x }
+        return s.squareRoot()
+    }
+
+    /// L2-normalized copy. A zero/non-finite-norm vector is returned unchanged
+    /// (no NaN); callers treat that as "no usable direction".
+    static func l2Normalized(_ v: [Float]) -> [Float] {
+        let n = l2Norm(v)
+        guard n > 0, n.isFinite else { return v }
+        return v.map { $0 / n }
+    }
+
+    /// The pack's common direction: `normalize(mean(vectors))`. Returns nil when
+    /// there is no usable direction (empty input or a degenerate zero mean).
+    static func meanDirection(of vectors: [[Float]]) -> [Float]? {
+        let m = mean(of: vectors)
+        guard !m.isEmpty else { return nil }
+        let norm = l2Norm(m)
+        guard norm > 0, norm.isFinite else { return nil }
+        return m.map { $0 / norm }
+    }
+
+    /// Apply the correction to a single vector: `normalize(v - meanDir)`.
+    /// If subtraction yields a degenerate (zero-norm) residual, the original
+    /// vector is returned unchanged so similarity never sees a NaN.
+    static func center(_ v: [Float], around meanDir: [Float]) -> [Float] {
+        guard !v.isEmpty, v.count == meanDir.count else { return v }
+        var residual = [Float](repeating: 0, count: v.count)
+        for i in 0..<v.count { residual[i] = v[i] - meanDir[i] }
+        let norm = l2Norm(residual)
+        guard norm > 0, norm.isFinite else { return v }
+        for i in 0..<residual.count { residual[i] /= norm }
+        return residual
+    }
+
+    // MARK: - Batch correction (document side, import-time)
+
+    /// Remove the common direction from a whole matrix of document vectors.
+    /// Returns the corrected matrix and the `meanDirection` used (to be stored so
+    /// the query can later be corrected with the SAME direction). When there is no
+    /// usable direction, this is the identity (and meanDirection is nil).
+    static func removeCommonDirection(from vectors: [[Float]]) -> (corrected: [[Float]], meanDirection: [Float]?) {
+        guard let meanDir = meanDirection(of: vectors) else { return (vectors, nil) }
+        let corrected = vectors.map { center($0, around: meanDir) }
+        return (corrected, meanDir)
+    }
+
+    /// Manifest-gated entry point. When the pack is already mean-centered (a healthy,
+    /// pipeline-corrected pack) this is a strict no-op so it is never double-corrected.
+    /// Otherwise it removes the common direction.
+    static func apply(to vectors: [[Float]],
+                      alreadyMeanCentered: Bool) -> (corrected: [[Float]], meanDirection: [Float]?) {
+        guard !alreadyMeanCentered else { return (vectors, nil) }
+        return removeCommonDirection(from: vectors)
+    }
+
+    // MARK: - Diagnostics (logging + tests)
+
+    /// Norm of the arithmetic mean of (assumed L2-normalized) vectors. This is the
+    /// alignment/collapse score: ~0 is healthy, →1 means the vectors point the same
+    /// way. Cheap: O(N·d).
+    static func meanVectorNorm(of vectors: [[Float]]) -> Float {
+        l2Norm(mean(of: vectors))
+    }
+
+    /// Effective dimensionality = participation ratio of the (UNCENTERED) Gram
+    /// eigenvalues, computed WITHOUT an eigendecomposition via
+    ///   PR = (Σ λ)² / Σ λ²  =  trace(G)² / ‖G‖_F²
+    /// where, with rows xₙ (NOT mean-subtracted — the collapse is a shared MEAN
+    /// direction, so centering would hide it),
+    ///   trace(G) = Σₙ ‖xₙ‖²   and   ‖G‖_F² = Σₙ,ₘ (xₙ·xₘ)².
+    /// For unit vectors: collapsed (all aligned) → PR ≈ 1; orthogonal/spread → PR ≈ N.
+    /// Cost is O(N²·d); intended for modest N (tests / import-time on small packs).
+    static func effectiveDimension(of vectors: [[Float]]) -> Float {
+        guard let first = vectors.first, !first.isEmpty else { return 0 }
+        let dim = first.count
+        let rows = vectors.filter { $0.count == dim }
+        guard !rows.isEmpty else { return 0 }
+        var traceTerm: Double = 0   // Σₙ ‖xₙ‖²
+        for x in rows {
+            var s: Double = 0
+            for v in x { s += Double(v) * Double(v) }
+            traceTerm += s
+        }
+        var frob: Double = 0        // Σₙ,ₘ (xₙ·xₘ)²
+        for n in 0..<rows.count {
+            let a = rows[n]
+            for m in 0..<rows.count {
+                let b = rows[m]
+                var dot: Double = 0
+                for i in 0..<dim { dot += Double(a[i]) * Double(b[i]) }
+                frob += dot * dot
+            }
+        }
+        guard frob > 0 else { return 0 }
+        return Float((traceTerm * traceTerm) / frob)
+    }
+
+    /// Mean of the off-diagonal pairwise cosine similarities. Healthy corpora sit
+    /// around ~0.3–0.5; a collapsed pack runs ~0.79. O(N²·d).
+    static func averageOffDiagonalCosine(of vectors: [[Float]]) -> Float {
+        let normed = vectors.map { l2Normalized($0) }
+        guard normed.count > 1 else { return 0 }
+        var sum: Double = 0
+        var pairs: Int = 0
+        for i in 0..<normed.count {
+            for j in (i + 1)..<normed.count {
+                let a = normed[i], b = normed[j]
+                guard a.count == b.count else { continue }
+                var dot: Double = 0
+                for k in 0..<a.count { dot += Double(a[k]) * Double(b[k]) }
+                sum += dot
+                pairs += 1
+            }
+        }
+        guard pairs > 0 else { return 0 }
+        return Float(sum / Double(pairs))
+    }
+}
+
+/// Resolves the per-pack–corrected query vector at search time. Document vectors
+/// are corrected once at import (baked into their stored embedding); the query must
+/// be corrected with the SAME `meanDirection` as the pack it is being compared
+/// against. Because the VectorStore is a single flat corpus mixing packs, the
+/// correction is resolved per chunk via the chunk's `correctionId`, memoized per id.
+///
+/// An empty `means` registry makes this a pass-through (raw query for every chunk),
+/// so existing/uncorrected packs and call sites behave exactly as before.
+final class QueryCorrector {
+    private let rawQuery: [Float]
+    private let means: [String: [Float]]
+    private var cache: [String: [Float]] = [:]
+
+    init(rawQuery: [Float], means: [String: [Float]]) {
+        self.rawQuery = rawQuery
+        self.means = means
+    }
+
+    /// True when no correction would ever be applied (registry empty).
+    var isIdentity: Bool { means.isEmpty }
+
+    /// The query vector to compare against a chunk carrying `correctionId`.
+    /// Falls back to the raw query when the chunk has no id or no registered mean.
+    func query(for correctionId: String?) -> [Float] {
+        guard !rawQuery.isEmpty,
+              let id = correctionId,
+              let meanDir = means[id] else { return rawQuery }
+        if let cached = cache[id] { return cached }
+        let corrected = EmbeddingCorrection.center(rawQuery, around: meanDir)
+        cache[id] = corrected
+        return corrected
+    }
+}
+
+#if DEBUG
+extension EmbeddingCorrection {
+    /// Runnable smoke for the mean-centering recovery, callable from a debugger or a
+    /// scratch call site while the NoesisNoemaTests Xcode target is unwired (mirrors
+    /// `RAGpackManifest.runDecodeSmoke()` / `RAGpackReader.runChunksSmoke()`). Builds a
+    /// synthetic collapsed corpus and asserts the common direction is removed, the
+    /// effective dimensionality rises, and a query for its own chunk gains a decisive
+    /// rank-1 margin.
+    static func runCorrectionSmoke() {
+        // collapsed corpus: each vector = normalize(3·axis0 + axis_{i+1})
+        let dim = 16, n = 12
+        var raw: [[Float]] = []
+        for i in 0..<n {
+            var v = [Float](repeating: 0, count: dim)
+            v[0] = 3; v[i + 1] = 1
+            raw.append(l2Normalized(v))
+        }
+        let rawOff = averageOffDiagonalCosine(of: raw)
+        let rawDim = effectiveDimension(of: raw)
+
+        let (corrected, meanDir) = removeCommonDirection(from: raw)
+        assert(meanDir != nil, "a common direction must be found")
+        let corrOff = averageOffDiagonalCosine(of: corrected)
+        let corrDim = effectiveDimension(of: corrected)
+        assert(rawOff > 0.6, "synthetic corpus must start collapsed")
+        assert(abs(corrOff) < 0.25, "off-diagonal cosine must drop toward 0")
+        assert(corrDim > rawDim * 2, "effective dimensionality must rise")
+
+        // mean_centered gate is a strict no-op.
+        let (identity, none) = apply(to: raw, alreadyMeanCentered: true)
+        assert(none == nil && identity == raw, "mean_centered=true must be identity")
+
+        print(String(format: "[EmbeddingCorrection] smoke PASSED — offDiag %.3f→%.3f, "
+                     + "effDim %.2f→%.2f, meanNorm %.3f→%.3f",
+                     rawOff, corrOff, rawDim, corrDim,
+                     meanVectorNorm(of: raw), meanVectorNorm(of: corrected)))
+    }
+}
+#endif

--- a/Shared/RAG/LocalRetriever.swift
+++ b/Shared/RAG/LocalRetriever.swift
@@ -73,9 +73,13 @@ final class LocalRetriever {
         if trace { print("[Retriever] Candidates after hybrid+dedupe: \(candidateList.count) (from \(N) docs)") }
         if candidateList.isEmpty { return [] }
 
-        // Final rerank with MMR
+        // Final rerank with MMR. Build a per-pack query corrector so the relevance
+        // term compares each candidate against the query corrected with that pack's
+        // mean direction (mean-centering recovery); pass-through when no packs were
+        // corrected.
         let qEmb = embedder.embed(text: query)
-        let ranked = MMR.rerank(queryEmbedding: qEmb, candidates: candidateList, k: effectiveK, lambda: L, trace: trace)
+        let corrector = QueryCorrector(rawQuery: qEmb, means: store.correctionMeans)
+        let ranked = MMR.rerank(queryEmbedding: qEmb, candidates: candidateList, k: effectiveK, lambda: L, corrector: corrector, trace: trace)
         return ranked
     }
 

--- a/Shared/RAG/MMR.swift
+++ b/Shared/RAG/MMR.swift
@@ -13,9 +13,14 @@ struct MMR {
     ///   - candidates: candidate chunks
     ///   - k: number of results to select
     ///   - lambda: trade-off between relevance (to query) and diversity (away from selected)
+    ///   - corrector: optional per-pack query corrector (mean-centering recovery). When
+    ///     provided, the relevance term compares each candidate against the query
+    ///     corrected with that candidate's pack mean direction. Diversity (chunk↔chunk)
+    ///     is unaffected — document vectors are already corrected at import. nil ⇒ the
+    ///     raw query is used for every candidate (pre-feature behavior).
     ///   - trace: print decision logs
     /// - Returns: top-k chunks in selected order
-    static func rerank(queryEmbedding: [Float], candidates: [Chunk], k: Int, lambda: Float = 0.7, trace: Bool = false) -> [Chunk] {
+    static func rerank(queryEmbedding: [Float], candidates: [Chunk], k: Int, lambda: Float = 0.7, corrector: QueryCorrector? = nil, trace: Bool = false) -> [Chunk] {
         guard !candidates.isEmpty else { return [] }
         let k = min(max(k, 1), candidates.count)
         var selected: [Chunk] = []
@@ -25,7 +30,8 @@ struct MMR {
             var bestIdx = 0
             var bestScore: Float = -Float.greatestFiniteMagnitude
             for (i, cand) in remaining.enumerated() {
-                let relevance = cosine(queryEmbedding, cand.embedding)
+                let q = corrector?.query(for: cand.correctionId) ?? queryEmbedding
+                let relevance = cosine(q, cand.embedding)
                 var diversity: Float = 0
                 if !selected.isEmpty {
                     var maxSim: Float = -Float.greatestFiniteMagnitude

--- a/Shared/RAG/RAGpackManifest.swift
+++ b/Shared/RAG/RAGpackManifest.swift
@@ -60,6 +60,13 @@ struct RAGpackManifest: Codable {
         let l2Normalized: Bool
         let runtime: String?
 
+        // Mean-centering gate (EmbeddingCorrection). Optional; absent/false means the
+        // pack carries the legacy document-side embedding bias and the app should
+        // recover it at import by removing the common direction. A pipeline that has
+        // already mean-centered its document vectors sets this true so the app does
+        // NOT double-correct a healthy pack. Informational — never fails validation.
+        let meanCentered: Bool?
+
         enum CodingKeys: String, CodingKey {
             case embeddingModel = "embedding_model"
             case embeddingDimension = "embedding_dimension"
@@ -68,6 +75,7 @@ struct RAGpackManifest: Codable {
             case pooling
             case l2Normalized = "l2_normalized"
             case runtime
+            case meanCentered = "mean_centered"
         }
     }
 

--- a/Shared/RAG/RAGpackReader.swift
+++ b/Shared/RAG/RAGpackReader.swift
@@ -25,11 +25,16 @@ struct RAGpackReader {
     ///     embeddings.npy, and optionally citations.jsonl.
     ///   - embedder: the app's current `EmbeddingModel` — used to validate the
     ///     embedder fingerprint and dimension (ADR-0011 §3).
-    /// - Returns: `chunks` (each carrying its embedding and any citation metadata)
-    ///   and the parallel `embeddings` matrix.
+    /// - Returns: `chunks` (each carrying its embedding and any citation metadata),
+    ///   the parallel `embeddings` matrix, and `correctionMean` — the L2-normalized
+    ///   common direction removed from the document vectors (nil when no correction
+    ///   was applied, i.e. the pack is already `mean_centered`). The caller stores
+    ///   `correctionMean` per pack so the query can be corrected with the SAME
+    ///   direction at search time (EmbeddingCorrection / mean-centering recovery).
     static func readPack(at unzippedDir: URL,
                          embedder: EmbeddingModel) throws -> (chunks: [Chunk],
-                                                              embeddings: [[Float]]) {
+                                                              embeddings: [[Float]],
+                                                              correctionMean: [Float]?) {
         let fm = FileManager.default
 
         // 1. manifest.json → RAGpackManifest
@@ -77,6 +82,30 @@ struct RAGpackReader {
             embeddings.append(Array(flat[start..<(start + dim)]))
         }
 
+        // 4b. Mean-centering recovery (EmbeddingCorrection). Legacy packs ship
+        //     document vectors collapsed onto a shared direction (a pipeline-side
+        //     embedding bias) that destroys retrieval discrimination. Unless the pack
+        //     declares itself already `mean_centered`, remove that common direction
+        //     from every document vector here and return the direction so the query
+        //     can be corrected identically at search time. No-op for healthy packs.
+        let alreadyCentered = manifest.embedder.meanCentered ?? false
+        let preNorm = EmbeddingCorrection.meanVectorNorm(of: embeddings)
+        let correctionMean: [Float]?
+        if alreadyCentered {
+            correctionMean = nil
+            SystemLog().logEvent(event: String(
+                format: "[RAGpackReader] mean-centering SKIPPED (manifest mean_centered=true); rows=%d dim=%d preMeanNorm=%.3f",
+                rowCount, dim, preNorm))
+        } else {
+            let (corrected, meanDir) = EmbeddingCorrection.apply(to: embeddings, alreadyMeanCentered: false)
+            embeddings = corrected
+            correctionMean = meanDir
+            let postNorm = EmbeddingCorrection.meanVectorNorm(of: embeddings)
+            SystemLog().logEvent(event: String(
+                format: "[RAGpackReader] mean-centering APPLIED=%@ rows=%d dim=%d preMeanNorm=%.3f postMeanNorm=%.3f",
+                meanDir == nil ? "false(no-direction)" : "true", rowCount, dim, preNorm, postNorm))
+        }
+
         // 5. chunks.json → [String] (flat array of chunk TEXT, NOT objects), then
         //    join with embeddings + optional citations.jsonl to build [Chunk].
         let chunksURL = unzippedDir.appendingPathComponent(manifest.files.chunks)
@@ -108,8 +137,9 @@ struct RAGpackReader {
                                      embeddings: embeddings,
                                      citationsJSONL: citationsData)
 
-        // 6. Done.
-        return (chunks, embeddings)
+        // 6. Done. `embeddings` (and the chunk embeddings built from them) are
+        //    already mean-centered when `correctionMean != nil`.
+        return (chunks, embeddings, correctionMean)
     }
 
     /// Assembles the in-memory `[Chunk]` from the v1.2 two-file split (ADR-0011 §5).

--- a/Shared/RAG/VectorStore.swift
+++ b/Shared/RAG/VectorStore.swift
@@ -18,6 +18,14 @@ class VectorStore {
     var embeddingModel: EmbeddingModel
     var isEmbedded: Bool
 
+    /// Per-pack mean-centering correction directions, keyed by `Chunk.correctionId`
+    /// (the pack's doc name). Populated at import and rehydrated on cold launch. Each
+    /// value is the L2-normalized common direction removed from that pack's document
+    /// vectors; the query is corrected with the SAME direction before similarity so
+    /// query and (already-corrected) document vectors live in the same space.
+    /// Empty registry → retrieval behaves exactly as before this feature.
+    var correctionMeans: [String: [Float]] = [:]
+
     // PERFORMANCE: Cache for chunk lookup by hash
     private var chunkCache: [String: [Chunk]] = [:]
     private let cacheQueue = DispatchQueue(label: "com.noesis.vectorstore.cache", attributes: .concurrent)
@@ -105,11 +113,15 @@ class VectorStore {
         // 長さが一致しない場合は安全フォールバックとして先頭から返す
         let dim = queryEmbedding.count
         guard dim > 0 else { return [] }
+        // Mean-centering recovery: correct the query with each chunk's pack mean
+        // direction before similarity. With an empty registry this is a pass-through.
+        let corrector = QueryCorrector(rawQuery: queryEmbedding, means: correctionMeans)
         var scored: [(Chunk, Float)] = []
         scored.reserveCapacity(chunks.count)
         for c in chunks {
             if c.embedding.count == dim {
-                let s = cosineSimilarity(a: queryEmbedding, b: c.embedding)
+                let q = corrector.query(for: c.correctionId)
+                let s = cosineSimilarity(a: q, b: c.embedding)
                 scored.append((c, s))
             }
         }

--- a/Tests/RAG/EmbeddingCorrectionTests.swift
+++ b/Tests/RAG/EmbeddingCorrectionTests.swift
@@ -1,0 +1,175 @@
+// Project: NoesisNoema
+// File: EmbeddingCorrectionTests.swift
+// Description: Unit + regression tests for the mean-centering recovery layer
+//   (EmbeddingCorrection / QueryCorrector). Document vectors in legacy RAGpacks
+//   collapse onto a shared direction; removing it restores retrieval discrimination.
+//
+//   These tests are pure and deterministic (no GGUF / no model load): a synthetic
+//   "collapsed" corpus reproduces the measured pathology exactly (high off-diagonal
+//   cosine, low effective dimensionality, negligible top1-vs-top10 gap), and the
+//   tests assert the helper recovers it. The transform under test is the design's:
+//     mean_dir = normalize(mean(docs)); d' = normalize(d - mean_dir); same for q.
+//
+//   NOTE: like the sibling RAG tests, the NoesisNoemaTests Xcode target is currently
+//   unwired, so these are committed for when it is wired and are NOT run by
+//   `xcodebuild test` today.
+// License: MIT License
+
+import XCTest
+@testable import NoesisNoema
+
+final class EmbeddingCorrectionTests: XCTestCase {
+
+    // MARK: - Synthetic collapsed corpus
+
+    /// Builds `n` unit vectors of the form `normalize(alpha·sharedAxis + uniqueAxis_i)`.
+    /// They all share a dominant common direction (axis 0) — exactly the collapse this
+    /// feature recovers from. Each chunk's unique semantic axis is distinct.
+    private func collapsedCorpus(n: Int, dim: Int, alpha: Float) -> [[Float]] {
+        precondition(dim >= n + 1, "need one shared axis + one unique axis per chunk")
+        var out: [[Float]] = []
+        out.reserveCapacity(n)
+        for i in 0..<n {
+            var v = [Float](repeating: 0, count: dim)
+            v[0] = alpha        // shared (collapse) direction
+            v[i + 1] = 1        // unique semantic direction
+            out.append(EmbeddingCorrection.l2Normalized(v))
+        }
+        return out
+    }
+
+    /// Full cosine, mirroring the retriever's similarity (defensive — divides by norms).
+    private func cosine(_ a: [Float], _ b: [Float]) -> Float {
+        var dot: Float = 0, na: Float = 0, nb: Float = 0
+        for i in 0..<min(a.count, b.count) { dot += a[i]*b[i]; na += a[i]*a[i]; nb += b[i]*b[i] }
+        let d = na.squareRoot() * nb.squareRoot()
+        return d == 0 ? 0 : dot / d
+    }
+
+    // MARK: - 1. Injected common bias is removed
+
+    func testRemovesInjectedCommonBias() {
+        let raw = collapsedCorpus(n: 12, dim: 16, alpha: 3)
+        let rawOff = EmbeddingCorrection.averageOffDiagonalCosine(of: raw)
+        XCTAssertGreaterThan(rawOff, 0.6, "synthetic corpus must start collapsed (high off-diagonal cosine)")
+
+        let (corrected, meanDir) = EmbeddingCorrection.removeCommonDirection(from: raw)
+        XCTAssertNotNil(meanDir, "a usable common direction must be found")
+
+        let corrOff = EmbeddingCorrection.averageOffDiagonalCosine(of: corrected)
+        XCTAssertLessThan(abs(corrOff), 0.25, "after removing the common direction the corpus is ~orthogonal")
+        XCTAssertLessThan(abs(corrOff), abs(rawOff) / 2, "off-diagonal cosine at least halved")
+
+        // Correction must preserve unit length (renormalized residuals).
+        for v in corrected {
+            XCTAssertEqual(EmbeddingCorrection.l2Norm(v), 1.0, accuracy: 1e-4)
+        }
+        // And it must collapse the mean-vector norm (alignment) toward 0.
+        XCTAssertGreaterThan(EmbeddingCorrection.meanVectorNorm(of: raw), 0.8)
+        XCTAssertLessThan(EmbeddingCorrection.meanVectorNorm(of: corrected),
+                          EmbeddingCorrection.meanVectorNorm(of: raw))
+    }
+
+    // MARK: - 2. mean_centered == true → strict no-op
+
+    func testMeanCenteredManifestIsNoOp() {
+        let raw = collapsedCorpus(n: 8, dim: 16, alpha: 3)
+
+        let (identity, meanDir) = EmbeddingCorrection.apply(to: raw, alreadyMeanCentered: true)
+        XCTAssertNil(meanDir, "no correction direction when the pack is already mean-centered")
+        XCTAssertEqual(identity.count, raw.count)
+        for (a, b) in zip(identity, raw) {
+            XCTAssertEqual(a, b, "mean_centered pack must pass through bit-identical (no double-correction)")
+        }
+
+        // Sanity: the gate matters — with the flag off, the same input IS corrected.
+        let (corrected, meanDir2) = EmbeddingCorrection.apply(to: raw, alreadyMeanCentered: false)
+        XCTAssertNotNil(meanDir2)
+        XCTAssertNotEqual(corrected.first!, raw.first!)
+    }
+
+    // MARK: - 3. Recovery widens discrimination and effective dimensionality
+
+    func testRecoveryWidensDiscriminationAndDimensionality() throws {
+        let raw = collapsedCorpus(n: 12, dim: 16, alpha: 4)
+        let (corrected, meanDir) = EmbeddingCorrection.removeCommonDirection(from: raw)
+        let md = try XCTUnwrap(meanDir)
+
+        // Effective dimensionality increases — dead space is recovered.
+        let rawDim = EmbeddingCorrection.effectiveDimension(of: raw)
+        let corrDim = EmbeddingCorrection.effectiveDimension(of: corrected)
+        XCTAssertLessThan(rawDim, 2.0, "collapsed corpus has near-1 effective dimensionality")
+        XCTAssertGreaterThan(corrDim, rawDim * 2, "corrected space uses many more dimensions")
+
+        // top1-vs-top10 gap: query == a chunk's own source text (use its vector). The
+        // raw gap is tiny (matches the measured 0.018–0.059); after correction (query
+        // corrected with the SAME mean) the gap widens dramatically (the measured 2–18×).
+        let targetIdx = 3
+        let rawQuery = raw[targetIdx]
+        let rawScores = raw.map { cosine($0, rawQuery) }.sorted(by: >)
+        let rawGap = rawScores[0] - rawScores[min(9, rawScores.count - 1)]
+
+        let correctedQuery = EmbeddingCorrection.center(rawQuery, around: md)
+        let corrScores = corrected.map { cosine($0, correctedQuery) }.sorted(by: >)
+        let corrGap = corrScores[0] - corrScores[min(9, corrScores.count - 1)]
+
+        XCTAssertLessThan(rawGap, 0.1, "pre-correction: scores are bunched (cannot discriminate)")
+        XCTAssertGreaterThan(corrGap, rawGap * 2, "post-correction: discrimination gap widens")
+    }
+
+    // MARK: - 4. Query symmetry — own chunk ranks #1 after correction
+
+    func testQueryMatchesItsOwnChunkAtRank1AfterCorrection() throws {
+        let raw = collapsedCorpus(n: 12, dim: 16, alpha: 5)
+        let (corrected, meanDir) = EmbeddingCorrection.removeCommonDirection(from: raw)
+        let md = try XCTUnwrap(meanDir)
+
+        let targetIdx = 7
+        let rawQuery = raw[targetIdx]   // query == the chunk's own source text
+
+        // BEFORE: collapsed — the top-1 margin is negligible, so the ranking is not
+        // robust (in real embeddings, finite-precision noise within this band reorders
+        // results, so the correct chunk is "not retrieved" / ranks low).
+        let rawRanking = raw.enumerated()
+            .map { ($0.offset, cosine($0.element, rawQuery)) }
+            .sorted { $0.1 > $1.1 }
+        XCTAssertLessThan(rawRanking[0].1 - rawRanking[1].1, 0.05,
+                          "pre-correction: top-1 barely beats top-2 — no real discrimination")
+
+        // AFTER: corrected query (same mean direction) ⇒ the own chunk is rank #1 by a
+        // decisive margin — the ranking is now robust.
+        let correctedQuery = EmbeddingCorrection.center(rawQuery, around: md)
+        let corrRanking = corrected.enumerated()
+            .map { ($0.offset, cosine($0.element, correctedQuery)) }
+            .sorted { $0.1 > $1.1 }
+        XCTAssertEqual(corrRanking[0].0, targetIdx, "post-correction: the own chunk ranks #1")
+        XCTAssertGreaterThan(corrRanking[0].1 - corrRanking[1].1, 0.2,
+                             "post-correction: rank-1 wins by a clear margin")
+    }
+
+    // MARK: - 5. QueryCorrector keeps per-pack means independent (never mixed)
+
+    func testQueryCorrectorIsPerPackAndIndependent() {
+        let packA = collapsedCorpus(n: 6, dim: 16, alpha: 3)
+        let packB = collapsedCorpus(n: 6, dim: 16, alpha: 3).map { v -> [Float] in
+            // Rotate pack B onto a different shared axis so its mean direction differs.
+            var r = v; r.swapAt(0, 8); return EmbeddingCorrection.l2Normalized(r)
+        }
+        let meanA = EmbeddingCorrection.meanDirection(of: packA)!
+        let meanB = EmbeddingCorrection.meanDirection(of: packB)!
+        XCTAssertLessThan(abs(cosine(meanA, meanB)), 0.2, "the two packs have distinct collapse directions")
+
+        let rawQuery = packA[0]
+        let corrector = QueryCorrector(rawQuery: rawQuery, means: ["A": meanA, "B": meanB])
+
+        // The query corrected for pack A must equal center(query, meanA), and for B meanB.
+        XCTAssertEqual(corrector.query(for: "A"), EmbeddingCorrection.center(rawQuery, around: meanA))
+        XCTAssertEqual(corrector.query(for: "B"), EmbeddingCorrection.center(rawQuery, around: meanB))
+        XCTAssertNotEqual(corrector.query(for: "A"), corrector.query(for: "B"), "means must never be mixed")
+
+        // Unknown / nil id ⇒ pass-through (raw query); empty registry ⇒ identity.
+        XCTAssertEqual(corrector.query(for: nil), rawQuery)
+        XCTAssertEqual(corrector.query(for: "missing"), rawQuery)
+        XCTAssertTrue(QueryCorrector(rawQuery: rawQuery, means: [:]).isIdentity)
+    }
+}


### PR DESCRIPTION
## Summary

Document vectors in shipped (legacy) RAGpacks are **collapsed onto a common direction** — a document-side embedding bias baked in by the external pipeline (prefix/pooling). The retrieval space is ~90% dead, so the retriever cannot discriminate. This PR adds a **manifest-gated mean-centering recovery layer**: at import it removes the pack's common direction from every document vector, and at search time it removes the **same** direction from the query before computing similarity.

This is a **recovery layer for existing/legacy packs**. The permanent fix is **pipeline-side re-generation** (which sets `embedder.mean_centered: true`, gating this correction OFF so healthy packs are never double-corrected).

### Measured collapse (raw pack) → after removing the common direction
| Metric | Before | After |
|---|---|---|
| mean-vector norm (0 = healthy) | **0.893** | → ~0 |
| every chunk cos to global mean | **≥ 0.744** | — |
| effective dimensionality | **71.9 / 768** (~90% dead) | recovered |
| intra-pack off-diagonal cos (healthy ~0.3–0.5) | **0.79** | **−0.002** |
| top1-vs-top10 score gap | **0.018–0.059** | widens **2–18×** (e.g. 0.059 → 0.347) |

The semantic information is intact — only a shared bias is the problem.

A deterministic synthetic corpus in the tests reproduces the pathology exactly and is verified empirically: off-diagonal `0.90 → −0.065`, effective-dim `1.12 → 11.28`, top1–top10 gap `0.059 → 1.08`, and a query for its own chunk goes from a negligible top-1 margin (`0.038`) to a decisive one (`1.08`).

## Design (as specified)

1. **Manifest gate** — `RAGpackManifest.EmbedderInfo.meanCentered: Bool?` (`mean_centered`). Optional/informational; never fails validation.
2. **Math in one testable helper** — `Shared/RAG/EmbeddingCorrection.swift` (pure): `meanDirection`, `center`, `removeCommonDirection`, `apply(to:alreadyMeanCentered:)`, plus diagnostics (`meanVectorNorm`, `effectiveDimension`, `averageOffDiagonalCosine`) and `QueryCorrector`. The transform is exactly `mean_dir = normalize(mean(docs))`, `d' = normalize(d − mean_dir)`, `q' = normalize(q − mean_dir)`.
3. **Import-time** (`RAGpackReader.readPack`): if `mean_centered == true` → no-op; else compute the mean direction, subtract it from every doc vector, renormalize, and return the direction. One `SystemLog` line records applied/skipped + pre/post mean-vector norm. `DocumentManager` tags each chunk with a per-pack `correctionId`, registers the mean in `VectorStore.correctionMeans`, and persists it (`PersistenceStore`) so cold launches still correct queries.
4. **Query-time**: the query is corrected with the **same per-pack mean** before similarity, in `VectorStore.findRelevant`, `MMR.rerank` (relevance term only — diversity is chunk↔chunk and already corrected), and the `BanditRetriever` min-score filter. **Multi-pack is per-pack and independent — means are never mixed** (each chunk resolves its own pack's mean via `correctionId`; empty registry ⇒ exact pre-feature behavior).
5. **minScore / MMR defaults unchanged.** Post-correction cosines are lower in absolute terms but now meaningful; ParamBandit adapts. *(Note: `minScore` 0.10–0.20 may want retuning later — not changed here.)*

## Guardrails honored
- Pure Swift, no Python/subprocess; vendored llama.cpp frameworks untouched.
- All mean-centering math lives in `EmbeddingCorrection.swift`, not inlined across call sites.
- Per-pack means are independent; never mixed.
- **Does not touch chunk text / extraction** (separate, pipeline-side issue).

## Tests
`Tests/RAG/EmbeddingCorrectionTests.swift` (5 XCTest cases): bias removal → off-diagonal ~0; `mean_centered` no-op; effective-dim + discrimination-gap widening; query→own-chunk rank-1 after correction; and `QueryCorrector` per-pack independence. Like the sibling RAG tests, the `NoesisNoemaTests` Xcode target is currently **unwired**, so a runnable `EmbeddingCorrection.runCorrectionSmoke()` `#if DEBUG` smoke is included (mirrors `RAGpackManifest.runDecodeSmoke()`). The macOS app target **builds clean** with these changes.

## Notes / follow-ups
- **Already-imported packs**: correction is applied at import, so packs imported *before* this change keep their raw vectors and are unaffected until **re-imported** (re-import recovers them). A future migration could re-correct in place, but that's out of scope and riskier (the raw manifest flag isn't persisted).
- The dev-only `RagCLI` deep-search path keeps the default (no corrector); all product retrieval paths are corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
