### PR TITLE
Diagnostics: expose per-pack chunk counts and imported-pack visibility

### DIFF
--- a/Apps/iOS/NoesisNoemaMobile/Views/SettingsView.swift
+++ b/Apps/iOS/NoesisNoemaMobile/Views/SettingsView.swift
@@ -61,6 +61,7 @@ struct SettingsView: View {
                 presetSection
                 runtimeSection
                 ragDocumentSection
+                ragpackListSection
                 retrievalSection
                 dataSection
                 advancedSection
@@ -283,6 +284,65 @@ struct SettingsView: View {
         }
     }
 
+    // MARK: - RAGpack List Section
+
+    /// Diagnostics: lists every imported pack with its persisted chunk count and
+    /// the aggregate VectorStore total. Supports individual pack deletion.
+    @ViewBuilder
+    private var ragpackListSection: some View {
+        let summary = documentManager.packChunkSummary
+        let totalChunks = VectorStore.shared.chunks.count
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Imported RAGpacks")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.secondary)
+                Spacer()
+                Text("\(totalChunks) chunks total")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if summary.isEmpty {
+                Text("No RAGpacks imported yet.")
+                    .font(.system(size: 14))
+                    .foregroundColor(.secondary)
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(summary, id: \.name) { entry in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(entry.name)
+                                    .font(.system(size: 13))
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                                Text("\(entry.count) chunks")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            Spacer()
+                            Button(role: .destructive) {
+                                documentManager.deleteRAGpack(named: entry.name)
+                            } label: {
+                                Image(systemName: "trash")
+                                    .foregroundColor(.red)
+                                    .font(.system(size: 14))
+                            }
+                            .buttonStyle(.borderless)
+                        }
+                        .padding(.vertical, 8)
+                        Divider()
+                    }
+                }
+                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 10))
+            }
+
+            Text("Total reflects all chunks loaded from all packs into the retrieval corpus.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+
     // MARK: - Advanced Section
     @ViewBuilder
     private var advancedSection: some View {
@@ -350,7 +410,7 @@ struct SettingsView: View {
                 .foregroundColor(.secondary)
 
             Button {
-                nctxHarness.run()
+                nctxHarness.run(packSummary: documentManager.packChunkSummary)
             } label: {
                 HStack(spacing: 8) {
                     if nctxHarness.isRunning {

--- a/Apps/macOS/NoesisNoema/Views/DesktopSettingsView.swift
+++ b/Apps/macOS/NoesisNoema/Views/DesktopSettingsView.swift
@@ -230,6 +230,19 @@ struct DesktopSettingsView: View {
                 Label("Manage RAGpacks", systemImage: "shippingbox")
             }
 
+            // Corpus diagnostics: always-visible summary so the total chunk count
+            // is readable without opening the manager sheet.
+            let packCount = documentManager.packChunkSummary.count
+            let totalChunks = VectorStore.shared.chunks.count
+            HStack {
+                Text("Corpus")
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("\(packCount) pack\(packCount == 1 ? "" : "s") · \(totalChunks) chunks total")
+                    .foregroundStyle(.secondary)
+                    .font(.system(.body, design: .monospaced))
+            }
+
             Button(role: .destructive) {
                 showClearConfirm = true
             } label: {

--- a/Shared/Debug/NctxHarnessReport.swift
+++ b/Shared/Debug/NctxHarnessReport.swift
@@ -21,7 +21,12 @@ struct NctxHarnessReport {
     let modelFile: String
     let preset: String
     let embedderName: String
+    /// Total chunks in VectorStore at harness start (aggregate across all packs).
     let chunkCount: Int
+    /// Per-pack breakdown: (name, chunkCount) pairs, sorted by name.
+    /// Populated by the SettingsView caller from DocumentManager.packChunkSummary.
+    /// Empty when the harness is invoked without a DocumentManager reference.
+    let packSummary: [(name: String, count: Int)]
 
     let baselineBytes: UInt64
     let loadedPeakBytes: UInt64
@@ -59,7 +64,15 @@ struct NctxHarnessReport {
         out += " n_ctx FOOTPRINT + LATENCY HARNESS\n"
         out += "════════════════════════════════════════════════════════════\n"
         out += " model:    \(modelName)  [\(modelFile)]\n"
-        out += " embedder: \(embedderName)   chunks: \(chunkCount)   preset: \(preset)\n"
+        out += " embedder: \(embedderName)   preset: \(preset)\n"
+        out += " corpus:   \(chunkCount) total chunks across \(packSummary.count) pack(s)\n"
+        if !packSummary.isEmpty {
+            for entry in packSummary {
+                out += "   \(entry.name)  \(entry.count) chunks\n"
+            }
+        } else {
+            out += "   (pack breakdown not available — pass documentManager.packChunkSummary to run())\n"
+        }
         out += " n_ctx requested: \(selectedNCtx)   effective: \(effectiveNCtx)\n"
         out += " questions: \(samples.count)   answered: \(answered.count)   bailed(over-budget): \(bailedCount)\n"
         out += "────────────────────────────────────────────────────────────\n"
@@ -99,6 +112,10 @@ struct NctxHarnessReport {
             let tokensPerSecond: Double
             let bailed: Bool
         }
+        struct PackEntry: Encodable {
+            let name: String
+            let chunkCount: Int
+        }
         let schema = "nctx-harness/v1"
         let selectedNCtx: Int
         let effectiveNCtx: Int
@@ -106,7 +123,10 @@ struct NctxHarnessReport {
         let modelFile: String
         let preset: String
         let embedderName: String
+        /// Aggregate chunk count across all imported packs.
         let chunkCount: Int
+        /// Per-pack breakdown. Empty when the harness ran without a DocumentManager reference.
+        let packBreakdown: [PackEntry]
         let baselineMB: Double
         let loadedMB: Double
         let peakGenMB: Double
@@ -132,6 +152,7 @@ struct NctxHarnessReport {
                 bailed: s.bailed
             )
         }
+        let breakdown = packSummary.map { DTO.PackEntry(name: $0.name, chunkCount: $0.count) }
         return DTO(
             selectedNCtx: selectedNCtx,
             effectiveNCtx: effectiveNCtx,
@@ -140,6 +161,7 @@ struct NctxHarnessReport {
             preset: preset,
             embedderName: embedderName,
             chunkCount: chunkCount,
+            packBreakdown: breakdown,
             baselineMB: baselineMB,
             loadedMB: loadedMB,
             peakGenMB: peakGenMB,

--- a/Shared/Debug/NctxHarnessRunner.swift
+++ b/Shared/Debug/NctxHarnessRunner.swift
@@ -50,7 +50,12 @@ final class NctxHarnessRunner: ObservableObject {
 
     // MARK: - Run
 
-    func run() {
+    /// Run the harness with the current `NctxConfig` selection.
+    /// - Parameter packSummary: per-pack chunk breakdown from the owning
+    ///   `DocumentManager`. Pass `documentManager.packChunkSummary` from the
+    ///   SettingsView so the JSON artifact records the full corpus breakdown
+    ///   alongside the latency data. Defaults to empty when not provided.
+    func run(packSummary: [(name: String, count: Int)] = []) {
         guard !isRunning else { return }
         isRunning = true
         resultText = nil
@@ -60,7 +65,7 @@ final class NctxHarnessRunner: ObservableObject {
         let selectedNCtx = NctxConfig.deviceNCtx
 
         Task { @MainActor in
-            let report = await self.execute(selectedNCtx: selectedNCtx)
+            let report = await self.execute(selectedNCtx: selectedNCtx, packSummary: packSummary)
             self.resultText = report.renderTable()
             self.lastArtifactPath = report.writeJSON()
             SystemLog().logEvent(event: "[NctxHarness] RUN COMPLETE\n" + report.renderTable())
@@ -69,7 +74,7 @@ final class NctxHarnessRunner: ObservableObject {
         }
     }
 
-    private func execute(selectedNCtx: Int32) async -> NctxHarnessReport {
+    private func execute(selectedNCtx: Int32, packSummary: [(name: String, count: Int)]) async -> NctxHarnessReport {
         let sampler = MemorySampler()
         let probe = NctxHarnessProbe.shared
 
@@ -122,6 +127,7 @@ final class NctxHarnessRunner: ObservableObject {
             preset: preset,
             embedderName: embedderName,
             chunkCount: chunkCount,
+            packSummary: packSummary,
             baselineBytes: baselineBytes,
             loadedPeakBytes: loadedPeakBytes,
             peakGenBytes: sampler.peakBytes,

--- a/Shared/DocumentManager.swift
+++ b/Shared/DocumentManager.swift
@@ -99,6 +99,9 @@ class DocumentManager: ObservableObject {
         // on every cold launch (P0: RAG only worked in the same session as import).
         populateVectorStoreFromPersistedChunks()
         loadQAHistory()
+        #if DEBUG
+        logCorpusDiagnostics(context: "cold-launch")
+        #endif
     }
 
     // MARK: - Upload History (SMALL - moved to file for consistency)
@@ -160,6 +163,36 @@ class DocumentManager: ObservableObject {
         }
         saveHistory()
         saveRAGpackChunks()
+    }
+
+    // MARK: - Corpus Diagnostics
+
+    /// Per-pack chunk summary, sorted by pack name. Suitable for display and
+    /// for passing to the n_ctx harness report without touching the VectorStore.
+    /// Returns an empty array when no packs have been imported.
+    var packChunkSummary: [(name: String, count: Int)] {
+        ragpackChunks.map { (name: $0.key, count: $0.value.count) }
+            .sorted { $0.name < $1.name }
+    }
+
+    /// Emits a concise corpus breakdown to SystemLog (one line per pack + one
+    /// summary line). Call after cold-launch rehydration and after each import
+    /// so that logs always reflect the current state.
+    ///
+    /// Example output (SystemLog):
+    ///   [Corpus] packs=3 total=1251
+    ///   [Corpus]   spinoza_ethics_1749000001  417 chunks
+    ///   [Corpus]   kant_critique_1748000002   417 chunks
+    ///   [Corpus]   test_pack_1747000003       417 chunks
+    func logCorpusDiagnostics(context: String = "") {
+        let summary = packChunkSummary
+        let total = VectorStore.shared.chunks.count
+        let tag = context.isEmpty ? "" : " [\(context)]"
+        let log = SystemLog()
+        log.logEvent(event: "[Corpus]\(tag) packs=\(summary.count) total=\(total)")
+        for entry in summary {
+            log.logEvent(event: "[Corpus]   \(entry.name)  \(entry.count) chunks")
+        }
     }
 
     /// Imports a document from a .zip RAGpack file.
@@ -276,6 +309,7 @@ class DocumentManager: ObservableObject {
             self.saveHistory()
             self.saveRAGpackChunks()
             print("Imported RAGpack v1.2 document: \(docName) (\(uniqueChunks.count) unique chunks)")
+            self.logCorpusDiagnostics(context: "post-import")
         }
     }
 

--- a/Shared/Llama/LibLlama.swift
+++ b/Shared/Llama/LibLlama.swift
@@ -128,10 +128,11 @@ actor LlamaContext {
 
         var ctx_params = llama_context_default_params()
         #if os(iOS)
-        // Lightweight for iOS. DEBUG: the n_ctx footprint+latency harness can
-        // sweep this across {1024,2048,4096,8192} via NctxConfig; Release is the
-        // unchanged 1024 default. Each generation builds a fresh context (see
-        // runNoesisCompletion), so the new KV cache is allocated on next load.
+        // iOS: DEBUG allows the n_ctx harness to sweep {1024,2048,4096,8192} via
+        // NctxConfig (UserDefaults override). Release always returns
+        // NctxConfig.deviceDefault (currently 4096, raised from 1024 in PR #116).
+        // Each generation builds a fresh LlamaContext (see runNoesisCompletion),
+        // so the new KV cache is allocated on the next generation automatically.
         ctx_params.n_ctx = UInt32(NctxConfig.deviceNCtx)
         #else
         ctx_params.n_ctx = 4096 // macOS: room for Deep Search + history + retrieved chunks

--- a/Shared/Runtime/Executors/LocalExecutor.swift
+++ b/Shared/Runtime/Executors/LocalExecutor.swift
@@ -115,13 +115,13 @@ final class LocalExecutor: Executor {
         // (system + context + question) must decode within the model's context
         // window, leaving room for the generated answer. Cap the joined context
         // by a char-based estimate (~3 chars/token for English) so it cannot push
-        // the prompt past n_ctx. Mirrors the per-platform n_ctx/n_len set in
-        // LibLlama.create_context (macOS 4096/1024, iOS 1024/256).
-        // Derive the prompt budget at runtime from the effective n_ctx instead
-        // of a hardcoded ceiling. On iOS n_ctx is DEBUG-switchable via the n_ctx
-        // harness (NctxConfig); Release stays at the 1024 default. The budget is
-        // n_ctx − n_len − headroom, so a larger n_ctx admits proportionally more
-        // retrieved context rather than truncating to the old 1024-based cap.
+        // the prompt past n_ctx. Per-platform n_ctx/n_len:
+        //   macOS: 4096/1024 (hardcoded literal in LibLlama.create_context)
+        //   iOS:   NctxConfig.deviceNCtx / 256
+        //          Release = NctxConfig.deviceDefault (currently 4096, PR #116)
+        //          Debug   = UserDefaults override, else deviceDefault
+        // The budget is n_ctx − n_len − headroom, so a larger n_ctx admits
+        // proportionally more retrieved context.
         #if os(iOS)
         let nCtx = Int(NctxConfig.deviceNCtx), nLen = 256
         #else


### PR DESCRIPTION
## Where chunk counts originate

`VectorStore.shared.chunks.count` is the aggregate count of **all chunks from all packs ever imported**, not just the active one. It is produced by:

1. `DocumentManager.populateVectorStoreFromPersistedChunks()` at cold launch — flattens all values from `ragpackChunks` (a `[String: [Chunk]]` dict keyed by a timestamp-suffixed docName) and loads them into `VectorStore.shared` via `addChunks(deduplicate: true)`.
2. `DocumentManager.processRAGpackImport()` during live imports — appends `uniqueChunks` (filtered by `content == && embedding ==`) to `VectorStore.shared.chunks` and stores them under a new timestamped docName key.

**No per-pack scoping exists.** Retrieval is global across all packs simultaneously. The corpus can accumulate unboundedly if packs are imported repeatedly with different embedding vectors (dedup fails when embeddings differ even for identical text).

## What this PR adds

- **`DocumentManager.packChunkSummary`** — computed property returning `[(name: String, count: Int)]` sorted by name, one entry per persisted pack key.
- **`DocumentManager.logCorpusDiagnostics(context:)`** — emits to SystemLog: one `[Corpus] packs=N total=M` summary line followed by one line per pack. Called at cold-launch (`#if DEBUG`) and after every successful import.
- **iOS `SettingsView` — `ragpackListSection`** — lists every imported pack with its chunk count and the corpus total. Supports per-pack delete via existing `deleteRAGpack` path.
- **macOS `DesktopSettingsView`** — corpus summary line (`N packs · M chunks total`) inline in the Data section, visible without opening the manager sheet.
- **`NctxHarnessReport` + `NctxHarnessRunner`** — `packSummary: [(name: String, count: Int)]` field added to the report; SettingsView passes `documentManager.packChunkSummary` to `run()` so harness JSON artifacts now include a `packBreakdown` array alongside latency data.
- **Stale comment fixes** — `LibLlama.swift` and `LocalExecutor.swift` both said "Release stays at the 1024 default"; the actual Release iOS n_ctx is 4096 (set by `NctxConfig.deviceDefault` in PR #116). Comments corrected; no behavior change.

## Sample diagnostics output

```
[Corpus] [cold-launch] packs=3 total=1251
[Corpus]   kant_critique_1748000002   417 chunks
[Corpus]   spinoza_ethics_1749000001  417 chunks
[Corpus]   test_pack_1747000003       417 chunks
```

Harness table header (extended):
```
════════════════════════════════════════════════════════════
 n_ctx FOOTPRINT + LATENCY HARNESS
════════════════════════════════════════════════════════════
 model:    Llama-3.2-3B-Instruct  [Llama-3.2-3B-Instruct-Q4_K_M.gguf]
 embedder: nomic-embed-text-v1.5   preset: balanced
 corpus:   1251 total chunks across 3 pack(s)
   kant_critique_1748000002   417 chunks
   spinoza_ethics_1749000001  417 chunks
   test_pack_1747000003       417 chunks
 n_ctx requested: 4096   effective: 4096
```

## Whether 6649 is confirmed aggregate or still inconclusive

**Inconclusive until the diagnostics are run on the device that reported 6649.**

The code analysis confirms the mechanism: `VectorStore.shared.chunks.count` is an aggregate across all persisted packs. The deduplication check (`content == && embedding ==`) fails silently when the same text was imported under different embedder versions, producing duplicate content with distinct embedding vectors that both survive. 6649 ÷ 417 ≈ 15.94, consistent with ~16 non-deduplicated import events, but this could also be multiple distinct documents.

**To confirm**: run this build on the device, open Settings, and read the ragpackListSection (iOS) or the corpus summary line (macOS). The per-pack names will immediately show whether 6649 comes from many copies of one pack or from many different documents.

## Recommended next task after merge

Run the app on the device that reported 6649, read `logCorpusDiagnostics` from the cold-launch log and the Settings screen. Then:

- **If the list shows N copies of the same pack** (same base name, many timestamps) → implement a pack deduplication pass at import time (match by embedder fingerprint + base filename, reject if already present).
- **If the list shows many different documents** → retrieval corpus is intentionally broad; decide whether to scope retrieval to a user-selected "active pack" or keep global retrieval.
- **Either way**: min-spec n_ctx validation on a 6 GB device remains an open item before broad release.

## Build verification

| Build | Result |
|---|---|
| macOS Debug | ✅ BUILD SUCCEEDED |
| macOS Release | ✅ BUILD SUCCEEDED |
| iOS Simulator arm64 Debug | ✅ BUILD SUCCEEDED |
| iOS Simulator arm64 Release (`ARCHS=arm64 ONLY_ACTIVE_ARCH=NO`) | ✅ BUILD SUCCEEDED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)